### PR TITLE
Merge service internal methods

### DIFF
--- a/src/hrtree.rs
+++ b/src/hrtree.rs
@@ -954,11 +954,6 @@ mod tests {
         assert_eq!(tree1.insertion_position(&0), 0);
         assert_eq!(tree1.insertion_position(&u64::MAX), tree1.len());
 
-        // test iteration
-        let items: Vec<(u64, u64)> = tree1.iter().map(|(&k, &v)| (k, v)).collect();
-        assert_eq!(items.len(), key_values.len());
-        assert_eq!(items, key_values);
-
         // test get_range
         let from_index = rng.gen_range(0..key_values.len());
         let to_index = rng.gen_range(from_index..key_values.len());

--- a/src/internal_service.rs
+++ b/src/internal_service.rs
@@ -48,7 +48,7 @@ pub(crate) struct InternalService<M: Map> {
     socket: Arc<UdpSocket>,
     peer_net: IpNet,
     rng: Arc<RwLock<StdRng>>,
-    peers: Arc<RwLock<HashMap<IpAddr, Instant>>>,
+    pub(crate) peers: Arc<RwLock<HashMap<IpAddr, Instant>>>,
     pre_insert: Arc<RwLock<PreInsertCallback<M::Key, M::Value>>>,
 }
 
@@ -100,12 +100,6 @@ impl<
             peers: Arc::new(RwLock::new(HashMap::new())),
             pre_insert: Arc::new(RwLock::new(Box::new(|_, _| {}))),
         }
-    }
-
-    pub fn with_seed(self, addr: IpAddr) -> Self {
-        let now = Instant::now();
-        self.peers.write().insert(addr, now);
-        self
     }
 
     pub fn with_pre_insert<F: Send + Sync + Fn(&M::Key, &M::Value) + 'static>(

--- a/src/internal_service.rs
+++ b/src/internal_service.rs
@@ -18,7 +18,7 @@ use std::time::{Duration, Instant};
 
 use bincode::{DefaultOptions, Deserializer, Serializer};
 use ipnet::IpNet;
-use parking_lot::{RwLock, RwLockReadGuard};
+use parking_lot::RwLock;
 use rand::rngs::StdRng;
 use rand::SeedableRng;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
@@ -114,10 +114,6 @@ impl<
     ) -> Self {
         *self.pre_insert.write() = Box::new(pre_insert);
         self
-    }
-
-    pub fn read(&self) -> RwLockReadGuard<'_, M> {
-        self.map.read()
     }
 
     fn get_peers(&self) -> Vec<IpAddr> {

--- a/src/internal_service.rs
+++ b/src/internal_service.rs
@@ -49,7 +49,7 @@ pub(crate) struct InternalService<M: Map> {
     peer_net: IpNet,
     rng: Arc<RwLock<StdRng>>,
     pub(crate) peers: Arc<RwLock<HashMap<IpAddr, Instant>>>,
-    pre_insert: Arc<RwLock<PreInsertCallback<M::Key, M::Value>>>,
+    pub(crate) pre_insert: Arc<RwLock<PreInsertCallback<M::Key, M::Value>>>,
 }
 
 impl<M: Map> Clone for InternalService<M> {
@@ -100,14 +100,6 @@ impl<
             peers: Arc::new(RwLock::new(HashMap::new())),
             pre_insert: Arc::new(RwLock::new(Box::new(|_, _| {}))),
         }
-    }
-
-    pub fn with_pre_insert<F: Send + Sync + Fn(&M::Key, &M::Value) + 'static>(
-        self,
-        pre_insert: F,
-    ) -> Self {
-        *self.pre_insert.write() = Box::new(pre_insert);
-        self
     }
 
     fn get_peers(&self) -> Vec<IpAddr> {

--- a/src/service.rs
+++ b/src/service.rs
@@ -99,7 +99,7 @@ impl<
     }
 
     pub fn with_pre_insert<F: Send + Sync + Fn(&M::Key, &M::Value) + 'static>(
-        mut self,
+        self,
         pre_insert: F,
     ) -> Self {
         let tombstones = self.tombstones.clone();
@@ -111,7 +111,7 @@ impl<
                 tombstones.insert(k.clone(), v.0);
             }
         };
-        self.service = self.service.with_pre_insert(wrapped_pre_insert);
+        *self.service.pre_insert.write() = Box::new(wrapped_pre_insert);
         self
     }
 

--- a/src/service.rs
+++ b/src/service.rs
@@ -12,7 +12,7 @@
 use std::fmt::Debug;
 use std::hash::Hash;
 use std::net::IpAddr;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use chrono::{DateTime, Utc};
 use ipnet::IpNet;
@@ -85,8 +85,9 @@ impl<
     /// Provides the address of a known peer to the service
     ///
     /// This is optional, but reduces the time to connect to existing peers
-    pub fn with_seed(mut self, peer: IpAddr) -> Self {
-        self.service = self.service.with_seed(peer);
+    pub fn with_seed(self, peer: IpAddr) -> Self {
+        let now = Instant::now();
+        self.service.peers.write().insert(peer, now);
         self
     }
 

--- a/src/service.rs
+++ b/src/service.rs
@@ -116,7 +116,7 @@ impl<
 
     /// Direct read access to the underlying map.
     pub fn read(&self) -> RwLockReadGuard<'_, M> {
-        self.service.read()
+        self.service.map.read()
     }
 
     pub fn get(&self, k: &K) -> Option<MappedRwLockReadGuard<'_, V>> {


### PR DESCRIPTION
In the context of #77, we are about to add various iteration methods to `Service`, mapping to iteration methods of `HRTree`. In an effort to keep code complexity in check, I think we should skip the `InternalService` and directly access the `map` from `Service`. As long as `Service` does not modify the keys in the map, everything should be fine.