### PR TITLE
Implement read-only iterators on HRTree

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -35,6 +35,8 @@ jobs:
       run: cargo build --all --verbose
     - name: Run tests
       run: cargo test --all --verbose
+    - name: Check that the benchmarks can still compile
+      run: cargo bench --no-run
     - name: Generate the documentation
       run: cargo doc --all --verbose
     - name: Check that the crate is publishable

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,6 +88,7 @@ Choose the one that fits your tooling.
    ```bash
    make build
    ```
+
 3. **Run the container interactively**
 
    ```bash
@@ -157,13 +158,13 @@ ln -sf ./.devcontainer/../pre-commit .git/hooks/pre-commit
 This will run the [`./pre-commit`](./pre-commit) before letting you create any
 commit. The goal is to detect linting errors as early as possible.
 
-# Code Coverage
+## Code Coverage
 
 To get the code coverage, run:
 
 ```bash
-$ cargo install cargo-llvm-cov
-$ cargo llvm-cov
+cargo install cargo-llvm-cov
+cargo llvm-cov
 ```
 
 For a detailed report of missed lines, use:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,8 +154,29 @@ We use a Git pre-commit hook to catch linting errors early. The hook is automati
 ln -sf ./.devcontainer/../pre-commit .git/hooks/pre-commit
 ```
 
-This ensures the `./pre-commit` script runs before each commit.
+This will run the [`./pre-commit`](./pre-commit) before letting you create any
+commit. The goal is to detect linting errors as early as possible.
 
----
+# Code Coverage
 
-If you encounter any issues, please open an issue or submit a pull request. Happy coding!
+To get the code coverage, run:
+
+```bash
+$ cargo install cargo-llvm-cov
+$ cargo llvm-cov
+```
+
+For a detailed report of missed lines, use:
+
+```bash
+cargo llvm-cov --hide-instantiations --text
+```
+
+You can also generate an HTML version with:
+
+```bash
+cargo llvm-cov --hide-instantiations --html
+```
+
+Use the `report` sub-command to reuse the results of the previous run instead
+of running the tests again.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -694,6 +694,7 @@ dependencies = [
  "clap",
  "criterion",
  "ipnet",
+ "once_cell",
  "parking_lot",
  "rand",
  "range-cmp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ arrayvec = "0.7.4"
 bincode = "1.3.3"
 chrono = { version = "0.4.31", features = ["serde"] }
 ipnet = "2.9.0"
+once_cell = "1.21.3"
 parking_lot = "0.12.1"
 rand = "0.8.5"
 range-cmp = "0.1.1"

--- a/src/hrtree.rs
+++ b/src/hrtree.rs
@@ -46,11 +46,11 @@ const MAX_CAPACITY: usize = 2 * B - 1;
 type InsertionTuple<K, V> = Option<(K, V, u64, Box<Node<K, V>>)>;
 
 #[derive(Debug, Default)]
-struct Node<K, V> {
-    keys: ArrayVec<K, MAX_CAPACITY>,
-    values: ArrayVec<V, MAX_CAPACITY>,
+pub(crate) struct Node<K, V> {
+    pub(crate) keys: ArrayVec<K, MAX_CAPACITY>,
+    pub(crate) values: ArrayVec<V, MAX_CAPACITY>,
     hashes: ArrayVec<u64, MAX_CAPACITY>,
-    children: Option<ArrayVec<Box<Node<K, V>>, { MAX_CAPACITY + 1 }>>,
+    pub(crate) children: Option<ArrayVec<Box<Node<K, V>>, { MAX_CAPACITY + 1 }>>,
     tree_hash: u64,
     tree_size: usize,
 }
@@ -263,7 +263,7 @@ impl<K, V> Node<K, V> {
 }
 
 pub struct HRTree<K, V> {
-    root: Box<Node<K, V>>,
+    pub(crate) root: Box<Node<K, V>>,
 }
 
 impl<K, V> Default for HRTree<K, V> {
@@ -566,115 +566,6 @@ impl<K, V> PartialEq for HRTree<K, V> {
 }
 
 impl<K, V> Eq for HRTree<K, V> {}
-
-impl<K: Hash + Ord, V: Hash> FromIterator<(K, V)> for HRTree<K, V> {
-    fn from_iter<T>(iter: T) -> Self
-    where
-        T: IntoIterator<Item = (K, V)>,
-    {
-        let mut tree = HRTree::new();
-        let mut items: Vec<_> = iter.into_iter().collect();
-        items.sort_by(|a, b| a.0.cmp(&b.0));
-        for (k, v) in items {
-            tree.insert(k, v);
-        }
-        tree
-    }
-}
-
-enum IntoIterItem<K, V> {
-    Node(Box<Node<K, V>>),
-    Element(K, V),
-}
-
-pub struct IntoIter<K, V> {
-    stack: Vec<IntoIterItem<K, V>>,
-}
-
-impl<K, V> Iterator for IntoIter<K, V> {
-    type Item = (K, V);
-    fn next(&mut self) -> Option<Self::Item> {
-        match self.stack.pop() {
-            Some(IntoIterItem::Node(mut node)) => {
-                if let Some(mut children) = node.children {
-                    self.stack.push(IntoIterItem::Node(children.pop().unwrap()));
-                    while !node.keys.is_empty() {
-                        let k = node.keys.pop().unwrap();
-                        let v = node.values.pop().unwrap();
-                        self.stack.push(IntoIterItem::Element(k, v));
-                        let c = children.pop().unwrap();
-                        self.stack.push(IntoIterItem::Node(c));
-                    }
-                } else {
-                    while !node.keys.is_empty() {
-                        let k = node.keys.pop().unwrap();
-                        let v = node.values.pop().unwrap();
-                        self.stack.push(IntoIterItem::Element(k, v));
-                    }
-                }
-                self.next()
-            }
-            Some(IntoIterItem::Element(k, v)) => Some((k, v)),
-            None => None,
-        }
-    }
-}
-
-impl<K, V> IntoIterator for HRTree<K, V> {
-    type Item = (K, V);
-    type IntoIter = IntoIter<K, V>;
-    fn into_iter(self) -> Self::IntoIter {
-        IntoIter {
-            stack: vec![IntoIterItem::Node(self.root)],
-        }
-    }
-}
-
-pub struct Iter<'a, K, V> {
-    stack: Vec<(&'a Node<K, V>, usize)>,
-}
-
-impl<'a, K, V> Iterator for Iter<'a, K, V> {
-    type Item = (&'a K, &'a V);
-    fn next(&mut self) -> Option<Self::Item> {
-        if let Some((node, children_passed)) = self.stack.pop() {
-            if children_passed < node.keys.len() {
-                self.stack.push((node, children_passed + 1));
-            }
-            if children_passed <= node.keys.len() {
-                if let Some(children) = node.children.as_ref() {
-                    self.stack.push((&children[children_passed], 0));
-                }
-            }
-            if 0 < children_passed && children_passed <= node.keys.len() {
-                Some((
-                    &node.keys[children_passed - 1],
-                    &node.values[children_passed - 1],
-                ))
-            } else {
-                self.next()
-            }
-        } else {
-            None
-        }
-    }
-}
-
-impl<'a, K, V> IntoIterator for &'a HRTree<K, V> {
-    type Item = (&'a K, &'a V);
-    type IntoIter = Iter<'a, K, V>;
-    fn into_iter(self) -> Self::IntoIter {
-        Iter {
-            stack: vec![(&self.root, 0)],
-        }
-    }
-}
-
-impl<K, V> HRTree<K, V> {
-    pub fn iter(&self) -> Iter<K, V> {
-        self.into_iter()
-    }
-}
 
 impl<K: std::fmt::Debug, V: std::fmt::Debug> std::fmt::Debug for HRTree<K, V> {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
@@ -1055,25 +946,5 @@ mod tests {
             expected_hash ^= super::hash(&key, &value);
             assert_eq!(tree1.hash(&..), expected_hash);
         }
-    }
-
-    #[test]
-    fn test_iter() {
-        let mut rng = rand::rngs::StdRng::seed_from_u64(42);
-        let mut key_values = Vec::new();
-
-        // add some
-        for _ in 0..1000 {
-            let key: u64 = rng.gen::<u64>();
-            let value: u64 = rng.gen();
-            key_values.push((key, value));
-        }
-        let tree = HRTree::from_iter(key_values.clone());
-        key_values.sort();
-        assert_eq!(
-            tree.iter().map(|(&k, &v)| (k, v)).collect::<Vec<_>>(),
-            key_values
-        );
-        assert_eq!(tree.into_iter().collect::<Vec<_>>(), key_values);
     }
 }

--- a/src/hrtree.rs
+++ b/src/hrtree.rs
@@ -45,7 +45,7 @@ const MAX_CAPACITY: usize = 2 * B - 1;
 
 type InsertionTuple<K, V> = Option<(K, V, u64, Box<Node<K, V>>)>;
 
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub(crate) struct Node<K, V> {
     pub(crate) keys: ArrayVec<K, MAX_CAPACITY>,
     pub(crate) values: ArrayVec<V, MAX_CAPACITY>,
@@ -262,6 +262,7 @@ impl<K, V> Node<K, V> {
     }
 }
 
+#[derive(Clone)]
 pub struct HRTree<K, V> {
     pub(crate) root: Box<Node<K, V>>,
 }

--- a/src/hrtree_iter.rs
+++ b/src/hrtree_iter.rs
@@ -1,0 +1,139 @@
+use std::hash::Hash;
+
+use crate::hrtree::{HRTree, Node};
+
+impl<K: Hash + Ord, V: Hash> FromIterator<(K, V)> for HRTree<K, V> {
+    fn from_iter<T>(iter: T) -> Self
+    where
+        T: IntoIterator<Item = (K, V)>,
+    {
+        let mut tree = HRTree::new();
+        let mut items: Vec<_> = iter.into_iter().collect();
+        items.sort_by(|a, b| a.0.cmp(&b.0));
+        for (k, v) in items {
+            tree.insert(k, v);
+        }
+        tree
+    }
+}
+
+enum IntoIterItem<K, V> {
+    Node(Box<Node<K, V>>),
+    Element(K, V),
+}
+
+pub struct IntoIter<K, V> {
+    stack: Vec<IntoIterItem<K, V>>,
+}
+
+impl<K, V> Iterator for IntoIter<K, V> {
+    type Item = (K, V);
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.stack.pop() {
+            Some(IntoIterItem::Node(mut node)) => {
+                if let Some(mut children) = node.children {
+                    self.stack.push(IntoIterItem::Node(children.pop().unwrap()));
+                    while !node.keys.is_empty() {
+                        let k = node.keys.pop().unwrap();
+                        let v = node.values.pop().unwrap();
+                        self.stack.push(IntoIterItem::Element(k, v));
+                        let c = children.pop().unwrap();
+                        self.stack.push(IntoIterItem::Node(c));
+                    }
+                } else {
+                    while !node.keys.is_empty() {
+                        let k = node.keys.pop().unwrap();
+                        let v = node.values.pop().unwrap();
+                        self.stack.push(IntoIterItem::Element(k, v));
+                    }
+                }
+                self.next()
+            }
+            Some(IntoIterItem::Element(k, v)) => Some((k, v)),
+            None => None,
+        }
+    }
+}
+
+impl<K, V> IntoIterator for HRTree<K, V> {
+    type Item = (K, V);
+    type IntoIter = IntoIter<K, V>;
+    fn into_iter(self) -> Self::IntoIter {
+        IntoIter {
+            stack: vec![IntoIterItem::Node(self.root)],
+        }
+    }
+}
+
+pub struct Iter<'a, K, V> {
+    stack: Vec<(&'a Node<K, V>, usize)>,
+}
+
+impl<'a, K, V> Iterator for Iter<'a, K, V> {
+    type Item = (&'a K, &'a V);
+    fn next(&mut self) -> Option<Self::Item> {
+        if let Some((node, children_passed)) = self.stack.pop() {
+            if children_passed < node.keys.len() {
+                self.stack.push((node, children_passed + 1));
+            }
+            if children_passed <= node.keys.len() {
+                if let Some(children) = node.children.as_ref() {
+                    self.stack.push((&children[children_passed], 0));
+                }
+            }
+            if 0 < children_passed && children_passed <= node.keys.len() {
+                Some((
+                    &node.keys[children_passed - 1],
+                    &node.values[children_passed - 1],
+                ))
+            } else {
+                self.next()
+            }
+        } else {
+            None
+        }
+    }
+}
+
+impl<'a, K, V> IntoIterator for &'a HRTree<K, V> {
+    type Item = (&'a K, &'a V);
+    type IntoIter = Iter<'a, K, V>;
+    fn into_iter(self) -> Self::IntoIter {
+        Iter {
+            stack: vec![(&self.root, 0)],
+        }
+    }
+}
+
+impl<K, V> HRTree<K, V> {
+    pub fn iter(&self) -> Iter<K, V> {
+        self.into_iter()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rand::{Rng, SeedableRng};
+
+    use super::HRTree;
+
+    #[test]
+    fn test_iter() {
+        let mut rng = rand::rngs::StdRng::seed_from_u64(42);
+        let mut key_values = Vec::new();
+
+        // add some
+        for _ in 0..1000 {
+            let key: u64 = rng.gen::<u64>();
+            let value: u64 = rng.gen();
+            key_values.push((key, value));
+        }
+        let tree = HRTree::from_iter(key_values.clone());
+        key_values.sort();
+        assert_eq!(
+            tree.iter().map(|(&k, &v)| (k, v)).collect::<Vec<_>>(),
+            key_values
+        );
+        assert_eq!(tree.into_iter().collect::<Vec<_>>(), key_values);
+    }
+}

--- a/src/hrtree_iter.rs
+++ b/src/hrtree_iter.rs
@@ -17,39 +17,40 @@ impl<K: Hash + Ord, V: Hash> FromIterator<(K, V)> for HRTree<K, V> {
     }
 }
 
-enum IntoIterItem<K, V> {
+enum IntoIterLayer<K, V> {
     Node(Box<Node<K, V>>),
     Element(K, V),
 }
 
 pub struct IntoIter<K, V> {
-    stack: Vec<IntoIterItem<K, V>>,
+    stack: Vec<IntoIterLayer<K, V>>,
 }
 
 impl<K, V> Iterator for IntoIter<K, V> {
     type Item = (K, V);
     fn next(&mut self) -> Option<Self::Item> {
         match self.stack.pop() {
-            Some(IntoIterItem::Node(mut node)) => {
+            Some(IntoIterLayer::Node(mut node)) => {
                 if let Some(mut children) = node.children {
-                    self.stack.push(IntoIterItem::Node(children.pop().unwrap()));
+                    self.stack
+                        .push(IntoIterLayer::Node(children.pop().unwrap()));
                     while !node.keys.is_empty() {
                         let k = node.keys.pop().unwrap();
                         let v = node.values.pop().unwrap();
-                        self.stack.push(IntoIterItem::Element(k, v));
+                        self.stack.push(IntoIterLayer::Element(k, v));
                         let c = children.pop().unwrap();
-                        self.stack.push(IntoIterItem::Node(c));
+                        self.stack.push(IntoIterLayer::Node(c));
                     }
                 } else {
                     while !node.keys.is_empty() {
                         let k = node.keys.pop().unwrap();
                         let v = node.values.pop().unwrap();
-                        self.stack.push(IntoIterItem::Element(k, v));
+                        self.stack.push(IntoIterLayer::Element(k, v));
                     }
                 }
                 self.next()
             }
-            Some(IntoIterItem::Element(k, v)) => Some((k, v)),
+            Some(IntoIterLayer::Element(k, v)) => Some((k, v)),
             None => None,
         }
     }
@@ -60,7 +61,7 @@ impl<K, V> IntoIterator for HRTree<K, V> {
     type IntoIter = IntoIter<K, V>;
     fn into_iter(self) -> Self::IntoIter {
         IntoIter {
-            stack: vec![IntoIterItem::Node(self.root)],
+            stack: vec![IntoIterLayer::Node(self.root)],
         }
     }
 }
@@ -109,38 +110,38 @@ impl<K, V> HRTree<K, V> {
     }
 }
 
-enum IntoValuesItem<K, V> {
+enum IntoValuesLayer<K, V> {
     Node(Box<Node<K, V>>),
     Element(V),
 }
 
 pub struct IntoValues<K, V> {
-    stack: Vec<IntoValuesItem<K, V>>,
+    stack: Vec<IntoValuesLayer<K, V>>,
 }
 
 impl<K, V> Iterator for IntoValues<K, V> {
     type Item = V;
     fn next(&mut self) -> Option<Self::Item> {
         match self.stack.pop() {
-            Some(IntoValuesItem::Node(mut node)) => {
+            Some(IntoValuesLayer::Node(mut node)) => {
                 if let Some(mut children) = node.children {
                     self.stack
-                        .push(IntoValuesItem::Node(children.pop().unwrap()));
+                        .push(IntoValuesLayer::Node(children.pop().unwrap()));
                     while !node.values.is_empty() {
                         let v = node.values.pop().unwrap();
-                        self.stack.push(IntoValuesItem::Element(v));
+                        self.stack.push(IntoValuesLayer::Element(v));
                         let c = children.pop().unwrap();
-                        self.stack.push(IntoValuesItem::Node(c));
+                        self.stack.push(IntoValuesLayer::Node(c));
                     }
                 } else {
                     while !node.values.is_empty() {
                         let v = node.values.pop().unwrap();
-                        self.stack.push(IntoValuesItem::Element(v));
+                        self.stack.push(IntoValuesLayer::Element(v));
                     }
                 }
                 self.next()
             }
-            Some(IntoValuesItem::Element(v)) => Some(v),
+            Some(IntoValuesLayer::Element(v)) => Some(v),
             None => None,
         }
     }
@@ -149,7 +150,7 @@ impl<K, V> Iterator for IntoValues<K, V> {
 impl<K, V> HRTree<K, V> {
     pub fn into_values(self) -> IntoValues<K, V> {
         IntoValues {
-            stack: vec![IntoValuesItem::Node(self.root)],
+            stack: vec![IntoValuesLayer::Node(self.root)],
         }
     }
 }
@@ -187,37 +188,38 @@ impl<K, V> HRTree<K, V> {
     }
 }
 
-enum IntoKeysItem<K, V> {
+enum IntoKeysLayer<K, V> {
     Node(Box<Node<K, V>>),
     Element(K),
 }
 
 pub struct IntoKeys<K, V> {
-    stack: Vec<IntoKeysItem<K, V>>,
+    stack: Vec<IntoKeysLayer<K, V>>,
 }
 
 impl<K, V> Iterator for IntoKeys<K, V> {
     type Item = K;
     fn next(&mut self) -> Option<Self::Item> {
         match self.stack.pop() {
-            Some(IntoKeysItem::Node(mut node)) => {
+            Some(IntoKeysLayer::Node(mut node)) => {
                 if let Some(mut children) = node.children {
-                    self.stack.push(IntoKeysItem::Node(children.pop().unwrap()));
+                    self.stack
+                        .push(IntoKeysLayer::Node(children.pop().unwrap()));
                     while !node.keys.is_empty() {
                         let k = node.keys.pop().unwrap();
-                        self.stack.push(IntoKeysItem::Element(k));
+                        self.stack.push(IntoKeysLayer::Element(k));
                         let c = children.pop().unwrap();
-                        self.stack.push(IntoKeysItem::Node(c));
+                        self.stack.push(IntoKeysLayer::Node(c));
                     }
                 } else {
                     while !node.keys.is_empty() {
                         let k = node.keys.pop().unwrap();
-                        self.stack.push(IntoKeysItem::Element(k));
+                        self.stack.push(IntoKeysLayer::Element(k));
                     }
                 }
                 self.next()
             }
-            Some(IntoKeysItem::Element(k)) => Some(k),
+            Some(IntoKeysLayer::Element(k)) => Some(k),
             None => None,
         }
     }
@@ -226,7 +228,7 @@ impl<K, V> Iterator for IntoKeys<K, V> {
 impl<K, V> HRTree<K, V> {
     pub fn into_keys(self) -> IntoKeys<K, V> {
         IntoKeys {
-            stack: vec![IntoKeysItem::Node(self.root)],
+            stack: vec![IntoKeysLayer::Node(self.root)],
         }
     }
 }

--- a/src/hrtree_iter.rs
+++ b/src/hrtree_iter.rs
@@ -235,6 +235,41 @@ impl<K, V> HRTree<K, V> {
     }
 }
 
+pub struct Keys<'a, K, V> {
+    stack: Vec<(&'a Node<K, V>, usize)>,
+}
+
+impl<'a, K, V> Iterator for Keys<'a, K, V> {
+    type Item = &'a K;
+    fn next(&mut self) -> Option<Self::Item> {
+        if let Some((node, children_passed)) = self.stack.pop() {
+            if children_passed < node.keys.len() {
+                self.stack.push((node, children_passed + 1));
+            }
+            if children_passed <= node.keys.len() {
+                if let Some(children) = node.children.as_ref() {
+                    self.stack.push((&children[children_passed], 0));
+                }
+            }
+            if 0 < children_passed && children_passed <= node.keys.len() {
+                Some(&node.keys[children_passed - 1])
+            } else {
+                self.next()
+            }
+        } else {
+            None
+        }
+    }
+}
+
+impl<K, V> HRTree<K, V> {
+    pub fn keys(&self) -> Keys<'_, K, V> {
+        Keys {
+            stack: vec![(&self.root, 0)],
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use rand::{Rng, SeedableRng};
@@ -274,5 +309,8 @@ mod tests {
 
         // test into_keys()
         assert_eq!(tree.clone().into_keys().collect::<Vec<_>>(), keys);
+
+        // test keys()
+        assert_eq!(tree.keys().copied().collect::<Vec<_>>(), keys);
     }
 }

--- a/src/hrtree_iter.rs
+++ b/src/hrtree_iter.rs
@@ -76,12 +76,10 @@ impl<'a, K, V> Iterator for Iter<'a, K, V> {
             if children_passed < node.keys.len() {
                 self.stack.push((node, children_passed + 1));
             }
-            if children_passed <= node.keys.len() {
-                if let Some(children) = node.children.as_ref() {
-                    self.stack.push((&children[children_passed], 0));
-                }
+            if let Some(children) = node.children.as_ref() {
+                self.stack.push((&children[children_passed], 0));
             }
-            if 0 < children_passed && children_passed <= node.keys.len() {
+            if children_passed > 0 {
                 Some((
                     &node.keys[children_passed - 1],
                     &node.values[children_passed - 1],
@@ -167,12 +165,10 @@ impl<'a, K, V> Iterator for Values<'a, K, V> {
             if children_passed < node.keys.len() {
                 self.stack.push((node, children_passed + 1));
             }
-            if children_passed <= node.keys.len() {
-                if let Some(children) = node.children.as_ref() {
-                    self.stack.push((&children[children_passed], 0));
-                }
+            if let Some(children) = node.children.as_ref() {
+                self.stack.push((&children[children_passed], 0));
             }
-            if 0 < children_passed && children_passed <= node.keys.len() {
+            if children_passed > 0 {
                 Some(&node.values[children_passed - 1])
             } else {
                 self.next()
@@ -246,12 +242,10 @@ impl<'a, K, V> Iterator for Keys<'a, K, V> {
             if children_passed < node.keys.len() {
                 self.stack.push((node, children_passed + 1));
             }
-            if children_passed <= node.keys.len() {
-                if let Some(children) = node.children.as_ref() {
-                    self.stack.push((&children[children_passed], 0));
-                }
+            if let Some(children) = node.children.as_ref() {
+                self.stack.push((&children[children_passed], 0));
             }
-            if 0 < children_passed && children_passed <= node.keys.len() {
+            if children_passed > 0 {
                 Some(&node.keys[children_passed - 1])
             } else {
                 self.next()

--- a/src/hrtree_iter.rs
+++ b/src/hrtree_iter.rs
@@ -624,15 +624,47 @@ mod tests {
     }
 
     #[test]
-    fn test_empty_tree_iterators() {
-        let tree: HRTree<u64, u64> = HRTree::new();
-        assert!(tree.clone().into_iter().next().is_none());
-        assert!(tree.iter().next().is_none());
-        assert!(tree.clone().iter_mut().next().is_none());
-        assert!(tree.clone().into_values().next().is_none());
-        assert!(tree.values().next().is_none());
-        assert!(tree.clone().values_mut().next().is_none());
-        assert!(tree.clone().into_keys().next().is_none());
-        assert!(tree.keys().next().is_none());
+    fn test_all_iterators_empty() {
+        let empty: HRTree<i32, i32> = HRTree::new();
+        // immutable
+        assert_eq!(empty.iter().next(), None);
+        // consuming
+        assert!(empty.clone().into_iter().next().is_none());
+        assert!(empty.clone().into_keys().next().is_none());
+        assert!(empty.clone().into_values().next().is_none());
+        // shared
+        assert!(empty.keys().next().is_none());
+        assert!(empty.values().next().is_none());
+        // mutable
+        let mut empty_mut = empty.clone();
+        assert!(empty_mut.iter_mut().next().is_none());
+        assert!(empty_mut.values_mut().next().is_none());
+    }
+
+    #[test]
+    fn test_all_iterators_single_leaf() {
+        let mut single = HRTree::new();
+        single.insert(42, 99);
+        // immutable
+        assert_eq!(single.iter().collect::<Vec<_>>(), vec![(&42, &99)]);
+        // consuming
+        assert_eq!(
+            single.clone().into_iter().collect::<Vec<_>>(),
+            vec![(42, 99)]
+        );
+        assert_eq!(single.clone().into_keys().collect::<Vec<_>>(), vec![42]);
+        assert_eq!(single.clone().into_values().collect::<Vec<_>>(), vec![99]);
+        // shared
+        assert_eq!(single.keys().copied().collect::<Vec<_>>(), vec![42]);
+        assert_eq!(single.values().copied().collect::<Vec<_>>(), vec![99]);
+        // mutable
+        for (_k, v) in single.iter_mut() {
+            *v += 1;
+        }
+        assert_eq!(single.iter().collect::<Vec<_>>(), vec![(&42, &100)]);
+        for val in single.values_mut() {
+            *val *= 2;
+        }
+        assert_eq!(single.values().copied().collect::<Vec<_>>(), vec![200]);
     }
 }

--- a/src/hrtree_iter.rs
+++ b/src/hrtree_iter.rs
@@ -325,9 +325,13 @@ mod tests {
     use super::HRTree;
     use once_cell::sync::Lazy;
 
+    const TREE_SIZE: usize = 1000;
+
     static BASE_ITEMS: Lazy<Vec<(u64, u64)>> = Lazy::new(|| {
         let mut rng = rand::rngs::StdRng::seed_from_u64(42);
-        (0..1000).map(|i| (i, rng.gen::<u64>())).collect()
+        (0..TREE_SIZE)
+            .map(|i| (i as u64, rng.gen::<u64>()))
+            .collect()
     });
 
     fn make_tree() -> HRTree<u64, u64> {
@@ -364,7 +368,7 @@ mod tests {
     fn test_iter_mut_1_modification() {
         let mut tree = make_tree();
 
-        let num = rand::random::<usize>().rem_euclid(1000);
+        let num = rand::random::<usize>().rem_euclid(TREE_SIZE);
         let (key, value) = BASE_ITEMS[num];
         let mut expected: Vec<_> = BASE_ITEMS.iter().map(|&(_, v)| v).collect();
         expected[num] = value;

--- a/src/hrtree_iter.rs
+++ b/src/hrtree_iter.rs
@@ -1,3 +1,22 @@
+// Copyright 2025 Developers of the reconcile-rs project.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Module `hrtree_iter` provides iteration utilities for `HRTree<K, V>`,
+//! including:
+//! - `IntoIter`: immutable in-order traversal consuming the tree and returning `(K, V)`;
+//! - `Iter`: immutable in-order traversal returning `(&K, &V)`;
+//! - `IterMut`: mutable in-order traversal returning `(&K, &mut V)`;
+//! - `IntoValues`: immutable in-order traversal consuming the tree and yielding `V`;
+//! - `Values`: immutable in-order traversal yielding `&V`;
+//! - `ValuesMut`: mutable in-order traversal yielding `&mut V`;
+//! - `IntoKeys`: immutable in-order traversal consuming the tree and yielding `K`;
+//! - `Keys`: immutable in-order traversal yielding `&K`;
+
 use std::{hash::Hash, marker::PhantomData};
 
 use crate::hrtree::{HRTree, Node};
@@ -22,6 +41,9 @@ enum IntoIterLayer<K, V> {
     Element(K, V),
 }
 
+/// An in-order immutable iterator over a `HRTree`.
+///
+/// Consumes the tree and yields keys and values in ascending key order.
 pub struct IntoIter<K, V> {
     stack: Vec<IntoIterLayer<K, V>>,
 }
@@ -59,6 +81,16 @@ impl<K, V> Iterator for IntoIter<K, V> {
 impl<K, V> IntoIterator for HRTree<K, V> {
     type Item = (K, V);
     type IntoIter = IntoIter<K, V>;
+    /// Consumes the `HRTree` and returns `(K, V)` pairs in-order.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use reconcile::HRTree;
+    /// let tree = HRTree::from_iter(vec![(1, "a"), (2, "b")]);
+    /// let pairs: Vec<_> = tree.into_iter().collect();
+    /// assert_eq!(pairs, vec![(1, "a"), (2, "b")]);
+    /// ```
     fn into_iter(self) -> Self::IntoIter {
         IntoIter {
             stack: vec![IntoIterLayer::Node(self.root)],
@@ -66,6 +98,9 @@ impl<K, V> IntoIterator for HRTree<K, V> {
     }
 }
 
+/// An in-order immutable iterator over a `HRTree`.
+///
+/// Yields references to keys and values in ascending key order.
 pub struct Iter<'a, K, V> {
     stack: Vec<(&'a Node<K, V>, usize)>,
 }
@@ -105,11 +140,24 @@ impl<'a, K, V> IntoIterator for &'a HRTree<K, V> {
 }
 
 impl<K, V> HRTree<K, V> {
+    /// Returns an in-order iterator over `(&K, &V)` pairs.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use reconcile::HRTree;
+    /// let tree = HRTree::from_iter(vec![(1, "a"), (2, "b")]);
+    /// let pairs: Vec<_> = tree.iter().collect();
+    /// assert_eq!(pairs, vec![(&1, &"a"), (&2, &"b")]);
+    /// ```
     pub fn iter(&self) -> Iter<K, V> {
         self.into_iter()
     }
 }
 
+/// An in-order mutable iterator over a `HRTree`.
+///
+/// Yields each key and a mutable reference to its associated value in ascending key order.
 pub struct IterMut<'a, K, V> {
     stack: Vec<(*mut Node<K, V>, usize)>,
     _marker: PhantomData<&'a mut V>,
@@ -143,6 +191,21 @@ impl<'a, K: 'a + Hash + Ord, V: Hash> Iterator for IterMut<'a, K, V> {
 }
 
 impl<'a, K: Hash + Ord, V: Hash> HRTree<K, V> {
+    /// Returns an in-order iterator over `(&K, &mut V)` pairs.
+    ///
+    /// # Safety
+    ///
+    /// Uses raw pointers internally to allow multiple mutable borrows,
+    /// but ensures safety by strictly controlling traversal and lifetime.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use reconcile::HRTree;
+    /// let mut tree = HRTree::from_iter(vec![(1, "a"), (2, "b")]);
+    /// let pairs: Vec<_> = tree.iter_mut().collect();
+    /// assert_eq!(pairs, vec![(&1, &mut "a"), (&2, &mut "b")]);
+    /// ```
     pub fn iter_mut(&'a mut self) -> IterMut<'a, K, V> {
         let mut stack = Vec::new();
         // Unsafe pointer to root
@@ -167,6 +230,9 @@ enum IntoValuesLayer<K, V> {
     Element(V),
 }
 
+/// An in-order mutable iterator over a `HRTree`.
+///
+/// Consumes the tree and yields its values in ascending key order.
 pub struct IntoValues<K, V> {
     stack: Vec<IntoValuesLayer<K, V>>,
 }
@@ -200,6 +266,16 @@ impl<K, V> Iterator for IntoValues<K, V> {
 }
 
 impl<K, V> HRTree<K, V> {
+    /// Consumes the tree and returns an in-order iterator over `V` values.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use reconcile::HRTree;
+    /// let tree = HRTree::from_iter(vec![(1, "a"), (2, "b")]);
+    /// let pairs: Vec<_> = tree.into_values().collect();
+    /// assert_eq!(pairs, vec![("a"), ("b")]);
+    /// ```
     pub fn into_values(self) -> IntoValues<K, V> {
         IntoValues {
             stack: vec![IntoValuesLayer::Node(self.root)],
@@ -207,6 +283,11 @@ impl<K, V> HRTree<K, V> {
     }
 }
 
+/// An iterator over shared references to values in ascending key order.
+///
+/// Yields references to values in ascending key order.
+///
+/// Does not consume the `HRTree`.
 pub struct Values<'a, K, V> {
     stack: Vec<(&'a Node<K, V>, usize)>,
 }
@@ -233,6 +314,16 @@ impl<'a, K, V> Iterator for Values<'a, K, V> {
 }
 
 impl<K, V> HRTree<K, V> {
+    /// Returns an in-order iterator over `&V` values.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use reconcile::HRTree;
+    /// let tree = HRTree::from_iter(vec![(1, "a"), (2, "b")]);
+    /// let pairs: Vec<_> = tree.values().collect();
+    /// assert_eq!(pairs, vec![(&"a"), (&"b")]);
+    /// ```
     pub fn values(&self) -> Values<'_, K, V> {
         Values {
             stack: vec![(&self.root, 0)],
@@ -240,13 +331,34 @@ impl<K, V> HRTree<K, V> {
     }
 }
 
+// === Values-only mutable iterator ===
+
+/// A mutable in-order iterator yielding references to values only.
+///
+/// Useful when only the values need to be updated or inspected in sequence.
 pub struct ValuesMut<'a, K, V> {
     stack: Vec<(*mut Node<K, V>, usize)>,
     _marker: PhantomData<&'a mut V>,
 }
 
 impl<'a, K: Hash + Ord, V: Hash> HRTree<K, V> {
-    /// Returns a mutable iterator over values in-order.
+    /// Returns an in-order iterator over `&mut V` values.
+    ///
+    /// # Safety
+    ///
+    /// Uses raw pointers internally to allow multiple mutable borrows,
+    /// but ensures safety by strictly controlling traversal and lifetime.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use reconcile::HRTree;
+    /// let mut tree = HRTree::from_iter(vec![(1, 10), (2, 20)]);
+    /// for val in tree.values_mut() {
+    ///     *val += 1;
+    /// }
+    /// assert_eq!(tree.values().copied().collect::<Vec<_>>(), vec![11, 21]);
+    /// ```
     pub fn values_mut(&'a mut self) -> ValuesMut<'a, K, V> {
         let mut stack = Vec::new();
         let mut cur_ptr: *mut Node<K, V> = &mut *self.root;
@@ -294,6 +406,9 @@ enum IntoKeysLayer<K, V> {
     Element(K),
 }
 
+/// An iterator that consumes the tree and yields its keys in ascending key order.
+///
+/// Useful when keys only need to be inspected in sequence.
 pub struct IntoKeys<K, V> {
     stack: Vec<IntoKeysLayer<K, V>>,
 }
@@ -327,6 +442,16 @@ impl<K, V> Iterator for IntoKeys<K, V> {
 }
 
 impl<K, V> HRTree<K, V> {
+    /// Consumes the `HRTree` and returns `K` keys in-order.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use reconcile::HRTree;
+    /// let tree = HRTree::from_iter(vec![(1, 'a'), (2, 'b')]);
+    /// let ks: Vec<_> = tree.clone().into_keys().collect();
+    /// assert_eq!(ks, vec![1, 2]);
+    /// ```
     pub fn into_keys(self) -> IntoKeys<K, V> {
         IntoKeys {
             stack: vec![IntoKeysLayer::Node(self.root)],
@@ -334,6 +459,9 @@ impl<K, V> HRTree<K, V> {
     }
 }
 
+/// An iterator over shared references to keys in ascending key order.
+///
+/// Does not consume the `HRTree`.
 pub struct Keys<'a, K, V> {
     stack: Vec<(&'a Node<K, V>, usize)>,
 }
@@ -360,6 +488,16 @@ impl<'a, K, V> Iterator for Keys<'a, K, V> {
 }
 
 impl<K, V> HRTree<K, V> {
+    /// Returns an iterator over references to keys in ascending order.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use reconcile::HRTree;
+    /// let tree = HRTree::from_iter(vec![(1, 'a'), (2, 'b')]);
+    /// let ks: Vec<_> = tree.keys().copied().collect();
+    /// assert_eq!(ks, vec![1, 2]);
+    /// ```
     pub fn keys(&self) -> Keys<'_, K, V> {
         Keys {
             stack: vec![(&self.root, 0)],

--- a/src/hrtree_iter.rs
+++ b/src/hrtree_iter.rs
@@ -240,6 +240,55 @@ impl<K, V> HRTree<K, V> {
     }
 }
 
+pub struct ValuesMut<'a, K, V> {
+    stack: Vec<(*mut Node<K, V>, usize)>,
+    _marker: PhantomData<&'a mut V>,
+}
+
+impl<'a, K: Hash + Ord, V: Hash> HRTree<K, V> {
+    /// Returns a mutable iterator over values in-order.
+    pub fn values_mut(&'a mut self) -> ValuesMut<'a, K, V> {
+        let mut stack = Vec::new();
+        let mut cur_ptr: *mut Node<K, V> = &mut *self.root;
+        unsafe {
+            while let Some(children) = (*cur_ptr).children.as_mut() {
+                stack.push((cur_ptr, 0));
+                cur_ptr = &mut *children[0];
+            }
+            stack.push((cur_ptr, 0));
+        }
+        ValuesMut {
+            stack,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<'a, K: Hash + Ord, V: Hash> Iterator for ValuesMut<'a, K, V> {
+    type Item = &'a mut V;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        while let Some((node_ptr, idx)) = self.stack.pop() {
+            unsafe {
+                let node = &mut *node_ptr;
+                if idx < node.keys.len() {
+                    self.stack.push((node_ptr, idx + 1));
+                    if let Some(children) = node.children.as_mut() {
+                        let mut child_ptr: *mut Node<K, V> = &mut *children[idx + 1] as *mut _;
+                        while let Some(gc) = (*child_ptr).children.as_mut() {
+                            self.stack.push((child_ptr, 0));
+                            child_ptr = &mut *gc[0];
+                        }
+                        self.stack.push((child_ptr, 0));
+                    }
+                    return Some(&mut node.values[idx]);
+                }
+            }
+        }
+        None
+    }
+}
+
 enum IntoKeysLayer<K, V> {
     Node(Box<Node<K, V>>),
     Element(K),
@@ -394,6 +443,32 @@ mod tests {
         let values: Vec<_> = BASE_ITEMS.iter().map(|&(_, v)| v).collect();
         let tree = make_tree();
         assert_eq!(tree.values().copied().collect::<Vec<_>>(), values);
+    }
+
+    #[test]
+    fn test_values_mut_0_modification() {
+        let mut tree = make_tree();
+        let collected: Vec<_> = tree.values_mut().map(|v| *v).collect();
+        let expected: Vec<_> = BASE_ITEMS.iter().map(|&(_, v)| v).collect();
+        assert_eq!(collected, expected);
+    }
+
+    #[test]
+    fn test_values_mut_1_modification() {
+        let mut tree = make_tree();
+
+        let num = rand::random::<usize>().rem_euclid(TREE_SIZE);
+        let (_, value) = BASE_ITEMS[num];
+        let mut expected: Vec<_> = BASE_ITEMS.iter().map(|&(_, v)| v).collect();
+        expected[num] = value;
+
+        for (n, v) in tree.values_mut().enumerate() {
+            if n == num {
+                *v = value;
+            }
+        }
+        let collected: Vec<_> = tree.iter().map(|(_, &v)| v).collect();
+        assert_eq!(collected, expected);
     }
 
     #[test]

--- a/src/hrtree_iter.rs
+++ b/src/hrtree_iter.rs
@@ -335,7 +335,25 @@ mod tests {
     }
 
     #[test]
-    fn test_iter_mut_collect_all_values() {
+    fn test_into_iter() {
+        let tree = make_tree();
+        assert_eq!(
+            tree.clone().into_iter().collect::<Vec<_>>(),
+            BASE_ITEMS.clone()
+        );
+    }
+
+    #[test]
+    fn test_iter() {
+        let tree = make_tree();
+        assert_eq!(
+            tree.iter().map(|(&k, &v)| (k, v)).collect::<Vec<_>>(),
+            BASE_ITEMS.clone()
+        );
+    }
+
+    #[test]
+    fn test_iter_mut_0_modification() {
         let mut tree = make_tree();
         let collected: Vec<_> = tree.iter_mut().map(|(_, v)| *v).collect();
         let expected: Vec<_> = BASE_ITEMS.iter().map(|&(_, v)| v).collect();
@@ -343,7 +361,7 @@ mod tests {
     }
 
     #[test]
-    fn test_iter_mut_modify_targeted_value() {
+    fn test_iter_mut_1_modification() {
         let mut tree = make_tree();
 
         let num = rand::random::<usize>().rem_euclid(1000);
@@ -361,40 +379,41 @@ mod tests {
     }
 
     #[test]
-    fn test_iter() {
-        let mut rng = rand::rngs::StdRng::seed_from_u64(42);
-        let mut key_values = Vec::new();
-
-        // add some
-        for _ in 0..1000 {
-            let key: u64 = rng.gen::<u64>();
-            let value: u64 = rng.gen();
-            key_values.push((key, value));
-        }
-        let tree = HRTree::from_iter(key_values.clone());
-        key_values.sort();
-        let keys: Vec<_> = key_values.iter().map(|(k, _)| *k).collect();
-        let values: Vec<_> = key_values.iter().map(|(_, v)| *v).collect();
-
-        // test into_iter()
-        assert_eq!(tree.clone().into_iter().collect::<Vec<_>>(), key_values);
-
-        // test iter()
-        assert_eq!(
-            tree.iter().map(|(&k, &v)| (k, v)).collect::<Vec<_>>(),
-            key_values
-        );
-
-        // test into_values()
+    fn test_into_values() {
+        let values: Vec<_> = BASE_ITEMS.iter().map(|&(_, v)| v).collect();
+        let tree = make_tree();
         assert_eq!(tree.clone().into_values().collect::<Vec<_>>(), values);
+    }
 
-        // test values()
+    #[test]
+    fn test_values() {
+        let values: Vec<_> = BASE_ITEMS.iter().map(|&(_, v)| v).collect();
+        let tree = make_tree();
         assert_eq!(tree.values().copied().collect::<Vec<_>>(), values);
+    }
 
-        // test into_keys()
+    #[test]
+    fn test_into_keys() {
+        let keys: Vec<_> = BASE_ITEMS.iter().map(|&(k, _)| k).collect();
+        let tree = make_tree();
         assert_eq!(tree.clone().into_keys().collect::<Vec<_>>(), keys);
+    }
 
-        // test keys()
+    #[test]
+    fn test_keys() {
+        let keys: Vec<_> = BASE_ITEMS.iter().map(|&(k, _)| k).collect();
+        let tree = make_tree();
         assert_eq!(tree.keys().copied().collect::<Vec<_>>(), keys);
+    }
+
+    #[test]
+    fn test_empty_tree_iterators() {
+        let tree: HRTree<u64, u64> = HRTree::new();
+        assert!(tree.clone().into_iter().next().is_none());
+        assert!(tree.iter().next().is_none());
+        assert!(tree.clone().into_values().next().is_none());
+        assert!(tree.values().next().is_none());
+        assert!(tree.clone().into_keys().next().is_none());
+        assert!(tree.keys().next().is_none());
     }
 }

--- a/src/hrtree_iter.rs
+++ b/src/hrtree_iter.rs
@@ -16,12 +16,36 @@
 //! - `ValuesMut`: mutable in-order traversal yielding `&mut V`;
 //! - `IntoKeys`: immutable in-order traversal consuming the tree and yielding `K`;
 //! - `Keys`: immutable in-order traversal yielding `&K`;
+//!
+//! # Complexity
+//!
+//! All iterators perform an initial descent to the leftmost leaf in **O(h)** time, where *h* is the tree height (≈ log n).
+//! Each call to `next()` then executes a constant amount of work plus at most one further descent (amortized **O(1)** per element).
+//! Memory overhead is **O(h)** for the internal stack of node pointers.
+//!
+//! # Safety (for mutable iterators)
+//!
+//! `IterMut` and `ValuesMut` use raw pointers (`*mut Node<K,V>`) internally to allow multiple mutable borrows during traversal.
+//! Safety is guaranteed by:
+//! 1. Never aliasing a pointer twice: stack-driven control ensures each node is borrowed at most once at a time.
+//! 2. Lifetimes tied to `&'a mut self`, so no pointers outlive the tree borrow.
+//! 3. Strict in-order precedence: pointers are only created when descending children, and popped before reuse.
+//!
+//! # Future Work: Lazy Iterators
+//!
+//! Current iterators are "semi-lazy": they do not collect all items up front, but they do pre-compute the full descent path.
+//! To match `BTreeMap` semantics more closely, we can remove even that pre-computation and make both forward and reverse traversal fully lazy,
+//! support `DoubleEndedIterator`, and implement precise lower/upper-bound seeks.
 
 use std::{hash::Hash, marker::PhantomData};
 
 use crate::hrtree::{HRTree, Node};
 
 impl<K: Hash + Ord, V: Hash> FromIterator<(K, V)> for HRTree<K, V> {
+    /// Builds an [`HRTree`] from an iterator of key-value pairs.
+    ///
+    /// The pairs are collected, sorted by key, and then inserted one by one,
+    /// ensuring the resulting tree is balanced according to the input order.
     fn from_iter<T>(iter: T) -> Self
     where
         T: IntoIterator<Item = (K, V)>,

--- a/src/hrtree_iter.rs
+++ b/src/hrtree_iter.rs
@@ -1,4 +1,4 @@
-use std::hash::Hash;
+use std::{hash::Hash, marker::PhantomData};
 
 use crate::hrtree::{HRTree, Node};
 
@@ -107,6 +107,58 @@ impl<'a, K, V> IntoIterator for &'a HRTree<K, V> {
 impl<K, V> HRTree<K, V> {
     pub fn iter(&self) -> Iter<K, V> {
         self.into_iter()
+    }
+}
+
+pub struct IterMut<'a, K, V> {
+    stack: Vec<(*mut Node<K, V>, usize)>,
+    _marker: PhantomData<&'a mut V>,
+}
+
+impl<'a, K: 'a + Hash + Ord, V: Hash> Iterator for IterMut<'a, K, V> {
+    type Item = (&'a K, &'a mut V);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        while let Some((node_ptr, idx)) = self.stack.pop() {
+            unsafe {
+                let node = &mut *node_ptr;
+                if idx < node.keys.len() {
+                    // Prepare next
+                    self.stack.push((node_ptr, idx + 1));
+                    // Traverse right subtree
+                    if let Some(children) = node.children.as_mut() {
+                        let mut child_ptr: *mut Node<K, V> = &mut *children[idx + 1];
+                        while let Some(gc) = (*child_ptr).children.as_mut() {
+                            self.stack.push((child_ptr, 0));
+                            child_ptr = &mut *gc[0];
+                        }
+                        self.stack.push((child_ptr, 0));
+                    }
+                    return Some((&node.keys[idx], &mut node.values[idx]));
+                }
+            }
+        }
+        None
+    }
+}
+
+impl<'a, K: Hash + Ord, V: Hash> HRTree<K, V> {
+    pub fn iter_mut(&'a mut self) -> IterMut<'a, K, V> {
+        let mut stack = Vec::new();
+        // Unsafe pointer to root
+        let mut cur_ptr: *mut Node<K, V> = &mut *self.root;
+        unsafe {
+            // Descend to leftmost leaf
+            while let Some(children) = (*cur_ptr).children.as_mut() {
+                stack.push((cur_ptr, 0));
+                cur_ptr = &mut *children[0];
+            }
+            stack.push((cur_ptr, 0));
+        }
+        IterMut {
+            stack,
+            _marker: PhantomData,
+        }
     }
 }
 
@@ -271,6 +323,42 @@ mod tests {
     use rand::{Rng, SeedableRng};
 
     use super::HRTree;
+    use once_cell::sync::Lazy;
+
+    static BASE_ITEMS: Lazy<Vec<(u64, u64)>> = Lazy::new(|| {
+        let mut rng = rand::rngs::StdRng::seed_from_u64(42);
+        (0..1000).map(|i| (i, rng.gen::<u64>())).collect()
+    });
+
+    fn make_tree() -> HRTree<u64, u64> {
+        HRTree::from_iter(BASE_ITEMS.clone())
+    }
+
+    #[test]
+    fn test_iter_mut_collect_all_values() {
+        let mut tree = make_tree();
+        let collected: Vec<_> = tree.iter_mut().map(|(_, v)| *v).collect();
+        let expected: Vec<_> = BASE_ITEMS.iter().map(|&(_, v)| v).collect();
+        assert_eq!(collected, expected);
+    }
+
+    #[test]
+    fn test_iter_mut_modify_targeted_value() {
+        let mut tree = make_tree();
+
+        let num = rand::random::<usize>().rem_euclid(1000);
+        let (key, value) = BASE_ITEMS[num];
+        let mut expected: Vec<_> = BASE_ITEMS.iter().map(|&(_, v)| v).collect();
+        expected[num] = value;
+
+        for (k, v) in tree.iter_mut() {
+            if *k == key {
+                *v = value;
+            }
+        }
+        let collected: Vec<_> = tree.iter().map(|(_, &v)| v).collect();
+        assert_eq!(collected, expected);
+    }
 
     #[test]
     fn test_iter() {

--- a/src/hrtree_iter.rs
+++ b/src/hrtree_iter.rs
@@ -490,8 +490,10 @@ mod tests {
         let tree: HRTree<u64, u64> = HRTree::new();
         assert!(tree.clone().into_iter().next().is_none());
         assert!(tree.iter().next().is_none());
+        assert!(tree.clone().iter_mut().next().is_none());
         assert!(tree.clone().into_values().next().is_none());
         assert!(tree.values().next().is_none());
+        assert!(tree.clone().values_mut().next().is_none());
         assert!(tree.clone().into_keys().next().is_none());
         assert!(tree.keys().next().is_none());
     }

--- a/src/hrtree_iter.rs
+++ b/src/hrtree_iter.rs
@@ -406,7 +406,7 @@ mod tests {
     }
 
     #[test]
-    fn test_iter_mut_0_modification() {
+    fn test_iter_mut() {
         let mut tree = make_tree();
         let collected: Vec<_> = tree.iter_mut().map(|(_, v)| *v).collect();
         let expected: Vec<_> = BASE_ITEMS.iter().map(|&(_, v)| v).collect();
@@ -414,7 +414,7 @@ mod tests {
     }
 
     #[test]
-    fn test_iter_mut_1_modification() {
+    fn test_iter_mut_modify() {
         let mut tree = make_tree();
 
         let num = rand::random::<usize>().rem_euclid(TREE_SIZE);
@@ -446,7 +446,7 @@ mod tests {
     }
 
     #[test]
-    fn test_values_mut_0_modification() {
+    fn test_values_mut() {
         let mut tree = make_tree();
         let collected: Vec<_> = tree.values_mut().map(|v| *v).collect();
         let expected: Vec<_> = BASE_ITEMS.iter().map(|&(_, v)| v).collect();
@@ -454,7 +454,7 @@ mod tests {
     }
 
     #[test]
-    fn test_values_mut_1_modification() {
+    fn test_values_mut_modify() {
         let mut tree = make_tree();
 
         let num = rand::random::<usize>().rem_euclid(TREE_SIZE);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@
 pub mod diff;
 pub mod gen_ip;
 pub mod hrtree;
+pub mod hrtree_iter;
 pub(crate) mod internal_service;
 pub mod map;
 pub mod reconcilable;


### PR DESCRIPTION
- [x] `into_iter` returning `IntoIter`, as part of `impl IntoIterator<HRtree<K, V>>`
- [x] `iter` returning `Iter`, mapped to `impl IntoIterator<&HRTree<K, V>>`
- [x] `iter_mut` returning `IterMut`, mapped to `impl IntoIterator<&mut HRTree<K, V>>`
- [x] `into_values` returning `IntoValues`
- [x] `values` returning `Values`
- [x] `values_mut` returning `ValuesMut`
- [x] `into_keys` returning `IntoKeys`
- [x] `keys` returning `Keys`