### PR TITLE
Move Service network config to struct ServiceConfig

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -9,7 +9,7 @@ use criterion::{
     SamplingMode, Throughput,
 };
 
-use reconcile::{DatedMaybeTombstone, HRTree, HashRangeQueryable, Service};
+use reconcile::{service::ServiceConfig, DatedMaybeTombstone, HRTree, HashRangeQueryable, Service};
 
 fn hrtree_new(c: &mut Criterion) {
     let mut group = c.benchmark_group("HRTree::new");
@@ -228,6 +228,16 @@ fn service_send(c: &mut Criterion) {
     let peer_net = "127.0.0.1/8".parse().unwrap();
     let addr1 = "127.0.0.44".parse().unwrap();
     let addr2 = "127.0.0.45".parse().unwrap();
+    let cfg1 = ServiceConfig {
+        port,
+        listen_addr: addr1,
+        peer_net,
+    };
+    let cfg2 = ServiceConfig {
+        port,
+        listen_addr: addr2,
+        peer_net,
+    };
 
     let mut rng = rand::rngs::StdRng::seed_from_u64(42);
 
@@ -255,12 +265,8 @@ fn service_send(c: &mut Criterion) {
                 let tree2 = HRTree::from_iter(key_values[..size].iter().copied());
 
                 // start reconciliation services
-                let service1 = Service::new(tree1, port, addr1, peer_net)
-                    .await
-                    .with_seed(addr2);
-                let service2 = Service::new(tree2, port, addr2, peer_net)
-                    .await
-                    .with_seed(addr1);
+                let service1 = Service::new(tree1, cfg1).await.with_seed(addr2);
+                let service2 = Service::new(tree2, cfg2).await.with_seed(addr1);
                 let task1 = tokio::spawn(service1.clone().run());
                 let task2 = tokio::spawn(service2.clone().run());
 
@@ -292,6 +298,14 @@ fn service_reconcile(c: &mut Criterion) {
     let peer_net = "127.0.0.1/8".parse().unwrap();
     let addr1 = "127.0.0.44".parse().unwrap();
     let addr2 = "127.0.0.45".parse().unwrap();
+    let cfg1 = ServiceConfig::default()
+        .with_port(port)
+        .with_listen_addr(addr1)
+        .with_peer_net(peer_net);
+    let cfg2 = ServiceConfig::default()
+        .with_port(port)
+        .with_listen_addr(addr2)
+        .with_peer_net(peer_net);
 
     let mut rng = rand::rngs::StdRng::seed_from_u64(42);
 
@@ -319,12 +333,8 @@ fn service_reconcile(c: &mut Criterion) {
                 let tree2 = HRTree::from_iter(key_values[..size].iter().copied());
 
                 // start reconciliation services
-                let service1 = Service::new(tree1, port, addr1, peer_net)
-                    .await
-                    .with_seed(addr2);
-                let service2 = Service::new(tree2, port, addr2, peer_net)
-                    .await
-                    .with_seed(addr1);
+                let service1 = Service::new(tree1, cfg1).await.with_seed(addr2);
+                let service2 = Service::new(tree2, cfg2).await.with_seed(addr1);
                 let task1 = tokio::spawn(service1.clone().run());
                 let task2 = tokio::spawn(service2.clone().run());
 

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -9,7 +9,7 @@ use rand::{
 };
 use tracing::info;
 
-use reconcile::{DatedMaybeTombstone, HRTree, HashRangeQueryable, Service};
+use reconcile::{service::ServiceConfig, DatedMaybeTombstone, HRTree, HashRangeQueryable, Service};
 
 #[derive(Parser)]
 struct Args {
@@ -33,7 +33,10 @@ async fn main() {
         elements,
         log_level,
     } = Args::parse();
-
+    let config = ServiceConfig::default()
+        .with_port(port)
+        .with_listen_addr(listen_addr)
+        .with_peer_net(peer_net);
     tracing_subscriber::fmt().with_max_level(log_level).init();
 
     // build collection
@@ -48,7 +51,7 @@ async fn main() {
     let tree = HRTree::from_iter(key_values.into_iter());
     info!("Global hash is {}", tree.hash(&..));
 
-    let mut service = Service::new(tree, port, listen_addr, peer_net).await;
+    let mut service = Service::new(tree, config).await;
 
     for seed in seed {
         service = service.with_seed(seed);

--- a/src/internal_service.rs
+++ b/src/internal_service.rs
@@ -30,6 +30,7 @@ use crate::diff::Diffable;
 use crate::gen_ip::gen_ip;
 use crate::map::Map;
 use crate::reconcilable::{Reconcilable, ReconciliationResult};
+use crate::service::ServiceConfig;
 
 const BUFFER_SIZE: usize = 65507;
 const ACTIVITY_TIMEOUT: Duration = Duration::from_secs(1);
@@ -86,16 +87,16 @@ impl<
             + Diffable<ComparisonItem = C, DifferenceItem = D>,
     > InternalService<M>
 {
-    pub async fn new(map: M, port: u16, listen_addr: IpAddr, peer_net: IpNet) -> Self {
-        let socket = UdpSocket::bind(SocketAddr::new(listen_addr, port))
+    pub async fn new(map: M, config: ServiceConfig) -> Self {
+        let socket = UdpSocket::bind(SocketAddr::new(config.listen_addr, config.port))
             .await
             .unwrap();
         debug!("Listening on: {}", socket.local_addr().unwrap());
         InternalService {
             map: Arc::new(RwLock::new(map)),
-            port,
+            port: config.port,
             socket: Arc::new(socket),
-            peer_net,
+            peer_net: config.peer_net,
             rng: Arc::new(RwLock::new(StdRng::from_entropy())),
             peers: Arc::new(RwLock::new(HashMap::new())),
             pre_insert: Arc::new(RwLock::new(Box::new(|_, _| {}))),
@@ -351,7 +352,7 @@ async fn send_messages_to<K: Serialize, V: Serialize, C: Serialize>(
 mod deadlock_regressions {
     use chrono::Utc;
 
-    use crate::{DatedMaybeTombstone, HRTree, Service};
+    use crate::{service::ServiceConfig, DatedMaybeTombstone, HRTree, Service};
     use std::sync::{
         atomic::{AtomicBool, Ordering},
         Arc,
@@ -361,14 +362,11 @@ mod deadlock_regressions {
     async fn pre_insert_hook_can_call_insert_again_without_deadlock() {
         let tree =
             HRTree::<u8, DatedMaybeTombstone<u8>>::from_iter(vec![(1, (Utc::now(), Some(10_u8)))]);
+        let config = ServiceConfig::default()
+            .with_port(8080)
+            .with_listen_addr("127.0.0.44".parse().unwrap());
         // let tree = HRTree::from_iter(vec![(1, 10), (2, 20)]);
-        let svc = Service::new(
-            tree,
-            8080,
-            "127.0.0.44".parse().unwrap(),
-            "127.0.0.1/8".parse().unwrap(),
-        )
-        .await;
+        let svc = Service::new(tree, config).await;
 
         let flag = Arc::new(AtomicBool::new(false));
         let flag2 = flag.clone();

--- a/src/service.rs
+++ b/src/service.rs
@@ -76,9 +76,9 @@ impl<
     > Service<M>
 {
     /// Create a new `Service`, set up network and tombstones.
-    pub async fn new(map: M, port: u16, listen_addr: IpAddr, peer_net: IpNet) -> Self {
+    pub async fn new(map: M, config: ServiceConfig) -> Self {
         let svc = Service {
-            service: InternalService::new(map, port, listen_addr, peer_net).await,
+            service: InternalService::new(map, config).await,
             tombstones: TimeoutWheel::new(),
         };
         svc.add_pre_insert(|_, _| {});
@@ -250,23 +250,54 @@ impl<
     }
 }
 
+#[derive(Clone, Copy)]
+pub struct ServiceConfig {
+    pub port: u16,
+    pub listen_addr: IpAddr,
+    pub peer_net: IpNet,
+    // may include other options in the future: use_tls, tombstone_ttl, metrics, etc.
+}
+impl Default for ServiceConfig {
+    fn default() -> Self {
+        ServiceConfig {
+            port: 0,
+            listen_addr: "127.0.0.1".parse().unwrap(),
+            peer_net: "127.0.0.1/8".parse().unwrap(),
+        }
+    }
+}
+impl ServiceConfig {
+    pub fn with_port(mut self, port: u16) -> Self {
+        self.port = port;
+        self
+    }
+    pub fn with_listen_addr(mut self, listen_addr: IpAddr) -> Self {
+        self.listen_addr = listen_addr;
+        self
+    }
+    pub fn with_peer_net(mut self, peer_net: IpNet) -> Self {
+        self.peer_net = peer_net;
+        self
+    }
+}
+
 #[cfg(test)]
 mod service_tests {
     use chrono::Utc;
     use std::time::Duration;
 
-    use crate::{DatedMaybeTombstone, HRTree, Service};
+    use crate::{service::ServiceConfig, DatedMaybeTombstone, HRTree, Service};
 
     #[tokio::test]
     async fn tombstones_expiration() {
-        let service = Service::new(
-            HRTree::<u8, DatedMaybeTombstone<String>>::new(),
-            8080,
-            "127.0.0.45".parse().unwrap(),
-            "127.0.0.1/8".parse().unwrap(),
-        )
-        .await
-        .with_tombstone_timeout(Duration::from_millis(1));
+        let config = ServiceConfig {
+            port: 8080,
+            listen_addr: "127.0.0.45".parse().unwrap(),
+            peer_net: "127.0.0.1/8".parse().unwrap(),
+        };
+        let service = Service::new(HRTree::<u8, DatedMaybeTombstone<String>>::new(), config)
+            .await
+            .with_tombstone_timeout(Duration::from_millis(1));
 
         let task = tokio::spawn(service.clone().run());
 

--- a/tests/service.rs
+++ b/tests/service.rs
@@ -6,7 +6,7 @@ use rand::{
     Rng, SeedableRng,
 };
 
-use reconcile::{DatedMaybeTombstone, HRTree, HashRangeQueryable, Service};
+use reconcile::{service::ServiceConfig, DatedMaybeTombstone, HRTree, HashRangeQueryable, Service};
 
 /// Wait for a while until the provided predicate becomes true
 ///
@@ -34,6 +34,14 @@ async fn test() {
     let peer_net = "127.0.0.1/8".parse().unwrap();
     let addr1 = "127.0.0.44".parse().unwrap();
     let addr2 = "127.0.0.45".parse().unwrap();
+    let cfg1 = ServiceConfig::default()
+        .with_port(port)
+        .with_listen_addr(addr1)
+        .with_peer_net(peer_net);
+    let cfg2 = ServiceConfig::default()
+        .with_port(port)
+        .with_listen_addr(addr2)
+        .with_peer_net(peer_net);
 
     // create tree1 with many values
     let mut rng = rand::rngs::StdRng::seed_from_u64(42);
@@ -51,12 +59,8 @@ async fn test() {
     let tree2: HRTree<String, DatedMaybeTombstone<String>> = HRTree::new();
 
     // start reconciliation services for tree1 and tree2
-    let service1 = Service::new(tree1, port, addr1, peer_net)
-        .await
-        .with_seed(addr2);
-    let service2 = Service::new(tree2, port, addr2, peer_net)
-        .await
-        .with_seed(addr1);
+    let service1 = Service::new(tree1, cfg1).await.with_seed(addr2);
+    let service2 = Service::new(tree2, cfg2).await.with_seed(addr1);
     let task2 = tokio::spawn(service2.clone().run());
     assert_eq!(service2.read().hash(&..), 0);
     let task1 = tokio::spawn(service1.clone().run());


### PR DESCRIPTION
A small refactor that centralizes service network settings (port, listen address, peer network) into a new `ServiceConfig` struct and updates `Service::new` to take it instead of separate parameters.

**Changes:**
- Added `ServiceConfig` (fields: `port: u16`, `listen_addr: IpAddr`, `peer_net: IpNet`) with `Default` and builder methods.
- Updated `Service::new(map, config)` signature.
- Revised all call sites (benchmarks, examples, tests) to build a `ServiceConfig` and pass it to `Service::new`. 