### PR TITLE
Add devcontainer CI workflow

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
 	  "dockerfile": "Dockerfile.dev",
 	  "context": ".."
 	},
-	"workspaceFolder": "/workspace",
+  	"workspaceFolder": "/workspaces/reconcile-rs",
 	"remoteUser": "dev",
 	"postCreateCommand": ".devcontainer/init.sh create",
 	"postStartCommand": ".devcontainer/init.sh start",

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -1,0 +1,72 @@
+name: Devcontainer CI
+
+on:
+  push:
+    branches: ["master"]
+  pull_request:
+    branches: ["master"]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  devcontainer-ci:
+    name: Build & Test in Devcontainer
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Cache devcontainer build layers
+        uses: actions/cache@v3
+        with:
+          path: /tmp/.devcontainer-cache
+          key: ${{ runner.os }}-devcontainer-${{ hashFiles('.devcontainer/Dockerfile.dev') }}
+          restore-keys: |
+            ${{ runner.os }}-devcontainer-
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          driver: docker-container
+
+      - name: Setup Node.js (for Devcontainer CLI)
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+
+      - name: Install Devcontainer CLI
+        run: |
+          npm config set prefix ~/.npm-global
+          npm install -g @devcontainers/cli
+
+      - name: Add npm-global bin to PATH
+        run: echo "$HOME/.npm-global/bin" >> $GITHUB_PATH
+
+      - name: Build devcontainer image
+        run: |
+          devcontainer build \
+            --workspace-folder . \
+            --cache-from type=local,src=/tmp/.devcontainer-cache \
+            --cache-to type=local,dest=/tmp/.devcontainer-cache,mode=max \
+            --log-level info
+
+      - name: Start devcontainer
+        run: |
+          devcontainer up \
+            --workspace-folder . \
+            --skip-post-create \
+            --log-level info \
+            --cache-from type=local,src=/tmp/.devcontainer-cache
+
+      - name: Run checks inside devcontainer
+        run: |
+          devcontainer exec --workspace-folder . -- bash -lc "\
+            export CARGO_HOME=\$HOME/.cargo && \
+            mkdir -p \$CARGO_HOME && \
+            cargo fmt -- --check && \
+            cargo clippy --all -- -D warnings && \
+            cargo test --all --verbose \
+          "


### PR DESCRIPTION
This PR adds a CI workflow to validate devcontainer support automatically.

---

## Changes

- **Devcontainer configuration**  
  - `.devcontainer/devcontainer.json`:  
    - Corrects `workspaceFolder` to `/workspaces/reconcile-rs`.  
    - Hooks up `init.sh` and `start.sh` as `postCreateCommand` and `postStartCommand`.  
  - `.devcontainer/init.sh` / `.devcontainer/start.sh`:  
    - Install tooling, set environment variables, etc.

- **CI workflow**  
  - New file `.github/workflows/devcontainer.yml`:  
    1. Builds the devcontainer image with Docker Buildx and layer caching.  
    2. Starts the container in "CI mode" (`--skip-post-create`).  
    3. Executes smoke tests inside the container (format, lint, run tests).  
  - Caches build layers under `/tmp/.devcontainer-cache` to speed up subsequent runs.

---

## Benefits

- **Consistency**: Everyone uses the same development environment locally and in CI.  
- **Reliability**: CI catches any breakage in the Devcontainer setup early.  
- **Performance**: Buildx cache minimizes image rebuild times.
