### PR TITLE
fix(ci): resolve clippy mismatched_lifetime_syntaxes breaking -Dwarnings CI

### DIFF
--- a/src/hrtree_iter.rs
+++ b/src/hrtree_iter.rs
@@ -174,7 +174,7 @@ impl<K, V> HRTree<K, V> {
     /// let pairs: Vec<_> = tree.iter().collect();
     /// assert_eq!(pairs, vec![(&1, &"a"), (&2, &"b")]);
     /// ```
-    pub fn iter(&self) -> Iter<K, V> {
+    pub fn iter(&self) -> Iter<'_, K, V> {
         self.into_iter()
     }
 }


### PR DESCRIPTION
## Problem

CI (`lint-and-test` and `Build & Test in Devcontainer`) currently fails on **every** PR — not because of the PR's contents, but because of a clippy warning that is now an error under the workflows' `RUSTFLAGS: -Dwarnings`:

```
error: hiding a lifetime that's elided elsewhere is confusing
   --> src/hrtree_iter.rs:177:17
    | pub fn iter(&self) -> Iter<K, V> {
    = note: `-D mismatched-lifetime-syntaxes` implied by `-D warnings`
```

`mismatched_lifetime_syntaxes` became a stable clippy lint on recent toolchains: `&self` elides a lifetime that is then *hidden* in the returned `Iter<K, V>`, which the lint considers confusing.

## Fix

One line — make the elision explicit with `'_`:

```rust
pub fn iter(&self) -> Iter<'_, K, V> {
```

This is the exact suggestion clippy emits. No behavior change (pure type-signature annotation).

## Verification

Ran the full CI sequence locally on this branch:
- `cargo fmt --check` ✅
- `cargo clippy --all` with `-Dwarnings` ✅ (was the failing step)
- `cargo test --all` ✅ (all unit, integration and doc-tests pass)

This was documented as finding **F17** in `REVIEW.md`. It is the only occurrence of the lint in the crate.

https://claude.ai/code/session_01MTFxvGfxqaffMhp6kb6etG

---
_Generated by [Claude Code](https://claude.ai/code/session_01MTFxvGfxqaffMhp6kb6etG)_