### PR TITLE
Fix #106: decide diff emptiness/equality on size, not hash

### DIFF
--- a/src/diff.rs
+++ b/src/diff.rs
@@ -89,22 +89,8 @@ impl<K: Clone, T: HashRangeQueryable<Key = K>> Diffable for T {
         differences: &mut Vec<Self::DifferenceItem>,
     ) {
         for segment in in_comparison {
-            let HashSegment { range, hash, size } = segment.clone();
+            let HashSegment { range, hash, size } = segment;
             let local_hash = self.hash(&range);
-            if hash == local_hash {
-                continue;
-            } else if hash == 0 {
-                differences.push(range);
-                continue;
-            } else if local_hash == 0 {
-                // present on remote; bounce back to the remote
-                out_comparison.push(HashSegment {
-                    range,
-                    hash: 0,
-                    size: 0,
-                });
-                continue;
-            }
             let (start_bound, end_bound) = range;
             let start_index = match start_bound.as_ref() {
                 Bound::Unbounded => 0,
@@ -117,9 +103,25 @@ impl<K: Clone, T: HashRangeQueryable<Key = K>> Diffable for T {
                 Bound::Excluded(key) => self.insertion_position(key),
             };
             let local_size = end_index - start_index;
-            if size == 0 || local_size == 0 {
-                // handled by the hash checks above
-                unreachable!();
+            // NOTE: decisions about emptiness and equality are made on the exact
+            // `size`/`local_size`, never on `hash`/`local_hash`. A range fingerprint
+            // is an XOR of per-element hashes, so a *non-empty* range can legitimately
+            // hash to 0; using `hash == 0` as an "empty" sentinel (or `hash ==
+            // local_hash` alone as "equal") would alias such ranges and cause silent,
+            // permanent divergence. See issue #106.
+            if hash == local_hash && size == local_size {
+                continue;
+            } else if size == 0 {
+                differences.push((start_bound, end_bound));
+                continue;
+            } else if local_size == 0 {
+                // present on remote; bounce back to the remote
+                out_comparison.push(HashSegment {
+                    range: (start_bound, end_bound),
+                    hash: 0,
+                    size: 0,
+                });
+                continue;
             } else if size == 1 && local_size == 1 {
                 // ask the remote to send us the conflicting item
                 out_comparison.push(HashSegment {

--- a/tests/diff.rs
+++ b/tests/diff.rs
@@ -1,5 +1,5 @@
 use std::hash::Hash;
-use std::ops::Bound;
+use std::ops::{Bound, RangeBounds};
 
 use reconcile::diff::{DiffRange, Diffable, HashRangeQueryable, HashSegment};
 use reconcile::hrtree::HRTree;
@@ -107,4 +107,116 @@ fn test_compare() {
             (&75, &"Everyone!")
         ]
     )
+}
+
+/// Per-element hash with a *forced collision*: keys `1` and `2` both hash to the
+/// same value, so any range containing exactly `{1, 2}` XORs to `0` even though it
+/// is non-empty. Every other key hashes to a distinct, non-zero value.
+///
+/// This lets us deterministically reproduce issue #106 (the `hash == 0` sentinel
+/// aliasing a non-empty range) without relying on a real, non-portable
+/// `DefaultHasher` collision.
+fn elem_hash(key: i32) -> u64 {
+    match key {
+        1 | 2 => 7,
+        k => (k as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15) | 1,
+    }
+}
+
+/// Minimal in-memory store over sorted `i32` keys implementing the public
+/// [`HashRangeQueryable`] trait, with a controllable per-element hash (see
+/// [`elem_hash`]). The blanket impl gives us [`Diffable`] for free, so we can
+/// drive it through the same [`diff`]/[`reconcile`] helpers as `HRTree`.
+struct MockStore {
+    keys: Vec<i32>,
+}
+
+impl MockStore {
+    fn new(mut keys: Vec<i32>) -> Self {
+        keys.sort_unstable();
+        keys.dedup();
+        MockStore { keys }
+    }
+
+    /// Collect the keys this store holds that fall inside any of the given ranges.
+    fn keys_in_ranges(&self, ranges: &[DiffRange<i32>]) -> Vec<i32> {
+        let mut out: Vec<i32> = self
+            .keys
+            .iter()
+            .copied()
+            .filter(|k| ranges.iter().any(|r| r.contains(k)))
+            .collect();
+        out.sort_unstable();
+        out.dedup();
+        out
+    }
+}
+
+impl HashRangeQueryable for MockStore {
+    type Key = i32;
+
+    fn hash<R: RangeBounds<i32>>(&self, range: &R) -> u64 {
+        self.keys
+            .iter()
+            .filter(|k| range.contains(k))
+            .fold(0, |acc, &k| acc ^ elem_hash(k))
+    }
+
+    fn insertion_position(&self, key: &i32) -> usize {
+        self.keys.partition_point(|k| k < key)
+    }
+
+    fn key_at(&self, index: usize) -> &i32 {
+        &self.keys[index]
+    }
+
+    fn len(&self) -> usize {
+        self.keys.len()
+    }
+}
+
+/// Regression test for issue #106 (headline counterexample).
+///
+/// A holds `{1, 2}`, whose range hash XORs to `0` (`elem_hash(1) ^ elem_hash(2)`),
+/// while empty B also hashes to `0`. The buggy code short-circuited on the very
+/// first `hash == local_hash` (`0 == 0`) check and concluded "in sync", silently
+/// losing both elements. With the size-based decision, A must be found to owe
+/// `{1, 2}` to B.
+#[test]
+fn nonempty_range_hashing_to_zero_vs_empty() {
+    let a = MockStore::new(vec![1, 2]);
+    let b = MockStore::new(vec![]);
+
+    // Sanity: the non-empty range really does hash to the empty sentinel value.
+    assert_eq!(a.hash(&..), 0);
+    assert_eq!(b.hash(&..), 0);
+
+    let (local_diff_ranges, remote_diff_ranges) = diff(&a, &b);
+
+    // A owns {1, 2} that B is missing; B owns nothing.
+    assert_eq!(a.keys_in_ranges(&local_diff_ranges), vec![1, 2]);
+    assert_eq!(b.keys_in_ranges(&remote_diff_ranges), Vec::<i32>::new());
+}
+
+/// Regression test for issue #106 (branches B/C): a non-empty range whose hash is
+/// `0` must not be mistaken for an empty range when the peer holds different,
+/// non-empty content over the same range.
+///
+/// A holds `{1, 2}` (range hash `0`, size 2); B holds `{1, 2, 5}` (range hash
+/// `elem_hash(5)`, size 3). The buggy code, seeing A's advertised `hash == 0`,
+/// treated A as empty, pushed A's whole range as a difference, and never
+/// discovered B's extra key `5`. The fix refines the range and isolates `5`.
+#[test]
+fn nonempty_collision_vs_different_content() {
+    let a = MockStore::new(vec![1, 2]);
+    let b = MockStore::new(vec![1, 2, 5]);
+
+    assert_eq!(a.hash(&..), 0);
+    assert_ne!(b.hash(&..), 0);
+
+    let (local_diff_ranges, remote_diff_ranges) = diff(&a, &b);
+
+    // A (local) owns nothing B is missing; B (remote) owns {5} that A is missing.
+    assert_eq!(a.keys_in_ranges(&local_diff_ranges), Vec::<i32>::new());
+    assert_eq!(b.keys_in_ranges(&remote_diff_ranges), vec![5]);
 }


### PR DESCRIPTION
Closes #106.

The range fingerprint is an XOR of per-element hashes, so a non-empty
range can legitimately hash to 0. `diff_round` overloaded `hash == 0`
as an "empty range" sentinel and `hash == local_hash` alone as "equal",
which aliased such ranges: two stores could silently conclude they were
in sync while data was missing, causing permanent, undetected divergence
(split-brain).

Compute `local_size` before the emptiness/equality branches and decide
on the exact `size`/`local_size` fields instead of the ambiguous hash:

- equal      : `hash == local_hash && size == local_size`
- remote empty: `size == 0`
- local empty : `local_size == 0`

The previously `unreachable!()` size==0 / local_size==0 arm is folded
into these branches. No wire-format change; every HashSegment already
carries an exact `size`.

Add deterministic regression tests (a mock store with a forced
per-element hash collision) reproducing the headline counterexample and
the related branch-B/C divergence; both fail before this change.