### PR TITLE
Fix critical remote DoS: drop malformed UDP datagrams instead of panicking

### DIFF
--- a/src/reconcile_engine.rs
+++ b/src/reconcile_engine.rs
@@ -264,7 +264,12 @@ impl<
                             break;
                         }
                     }
-                    panic!("failed to deserialize message: {:?}", kind);
+                    // Never panic on network input: a single malformed datagram from any
+                    // host would otherwise kill the receive loop (unauthenticated remote
+                    // DoS). Drop the rest of the datagram and keep the loop alive, just like
+                    // the oversized-datagram case above.
+                    warn!("failed to deserialize datagram from {peer}, dropping it: {kind:?}");
+                    break;
                 }
                 Ok(Message::ComparisonItem(segment)) => in_comparison.push(segment),
                 Ok(Message::Update(update)) => updates.push(update),

--- a/tests/service.rs
+++ b/tests/service.rs
@@ -128,3 +128,45 @@ async fn test() {
     task2.abort();
     task1.abort();
 }
+
+/// Regression test for the remote DoS where a single malformed UDP datagram panicked the
+/// receive loop, silently killing reconciliation (issue #107).
+///
+/// We send a malformed datagram to each node, then check that reconciliation still works.
+/// Before the fix, the receive loop task would panic and die, and the propagation assertion
+/// below would time out.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_malformed_datagram_does_not_crash() {
+    let port = 8082;
+    let peer_net = "127.0.0.1/8".parse().unwrap();
+    let addr1 = "127.0.0.46".parse().unwrap();
+    let addr2 = "127.0.0.47".parse().unwrap();
+    let cfg1 = Config::default()
+        .with_port(port)
+        .with_listen_addr(addr1)
+        .with_peer_net(peer_net);
+    let cfg2 = Config::default()
+        .with_port(port)
+        .with_listen_addr(addr2)
+        .with_peer_net(peer_net);
+
+    let store1 = ReconcileStore::new(cfg1).await.with_seed(addr2);
+    let store2 = ReconcileStore::new(cfg2).await.with_seed(addr1);
+    let task1 = tokio::spawn(store1.clone().run());
+    let task2 = tokio::spawn(store2.clone().run());
+
+    // 0x02 is an invalid bincode enum tag for `Message`; before the fix this panicked the
+    // receive loop. Send it to both nodes' protocol sockets from an unrelated socket.
+    let attacker = tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
+    attacker.send_to(&[0x02], (addr1, port)).await.unwrap();
+    attacker.send_to(&[0x02], (addr2, port)).await.unwrap();
+
+    // Reconciliation must still work: a value inserted on one node reaches the other.
+    let key = "key".to_string();
+    let value = "value".to_string();
+    store1.insert(key.clone(), value.clone());
+    assert_until!(store2.get(&key).as_deref() == Some(&value));
+
+    task2.abort();
+    task1.abort();
+}


### PR DESCRIPTION
## Summary

Fixes the critical, unauthenticated remote denial of service described in #107.

`ReconcileEngine::handle_messages` called `panic!` on any UDP datagram that failed bincode deserialization and was not a clean `UnexpectedEof`. A **single malformed byte from any host** (no authentication required, e.g. `echo -ne '\x02' | nc -u <host> <port>`, where `0x02` is an invalid `Message` enum tag) killed the receive loop:

- Under `service.run().await` directly in `main`, the panic unwinds and the whole process exits.
- Under `tokio::spawn(store.run())`, the panicking task dies silently (its `JoinHandle` is never awaited) → **zombie node**: local reads keep working, but the receive loop *and* the tombstone-GC loop (joined via `tokio::join!`) are dead forever, so the node never reconciles again, undetectably.

## Fix

`src/reconcile_engine.rs`: replace the `panic!` with `warn!` + `break`, dropping the offending datagram while keeping the receive loop alive. This mirrors the existing oversized-datagram handling a few lines above (`warn!` + return). Network input must never panic.

## Test

`tests/service.rs`: new regression test `test_malformed_datagram_does_not_crash` that sends a malformed datagram (`0x02`) to two running nodes and asserts that a value inserted on one node still propagates to the other. Before the fix the receive loop would die and the propagation assertion times out; after the fix reconciliation completes normally.

## Note / out of scope

`recv_from(...).await.unwrap()` in the same loop can also panic on a local socket error. That is not part of this issue's attacker-controlled surface, so it is left unchanged here and could be a separate hardening follow-up.

Closes #107

---
_Generated by [Claude Code](https://claude.ai/code/session_01AudRYhVLSV8zKx315KapYp)_