### PR TITLE
Add per-datagram MAC authentication (issue #108 / F3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,6 +98,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -138,6 +144,29 @@ name = "bitflags"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+
+[[package]]
+name = "blake3"
+version = "1.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "bumpalo"
@@ -255,10 +284,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "criterion"
@@ -328,10 +381,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 
 [[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
 
 [[package]]
 name = "getrandom"
@@ -371,6 +455,15 @@ name = "hermit-abi"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f154ce46856750ed433c8649605bf7ed2de3bc35fd9d2a9f30cddd873c80cb08"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "iana-time-zone"
@@ -690,15 +783,18 @@ version = "0.0.0-git"
 dependencies = [
  "arrayvec",
  "bincode",
+ "blake3",
  "chrono",
  "clap",
  "criterion",
+ "hmac",
  "ipnet",
  "once_cell",
  "parking_lot",
  "rand",
  "range-cmp",
  "serde",
+ "sha2",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -808,6 +904,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -843,6 +950,12 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -959,6 +1072,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -975,6 +1094,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -798,6 +798,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "zeroize",
 ]
 
 [[package]]
@@ -1371,6 +1372,26 @@ name = "zerocopy-derive"
 version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,16 +17,27 @@ debug = true
 name = "bench"
 harness = false
 
+[features]
+default = ["mac-blake3"]
+# Per-datagram MAC authentication backends (see `src/auth.rs`).
+# Exactly one backend is used at build time; `mac-blake3` takes precedence if
+# both are enabled. At least one must be enabled or the crate fails to compile.
+mac-blake3 = ["dep:blake3"]
+mac-hmac = ["dep:hmac", "dep:sha2"]
+
 [dependencies]
 arrayvec = "0.7.4"
 bincode = "1.3.3"
+blake3 = { version = "1.5", optional = true }
 chrono = { version = "0.4.31", features = ["serde"] }
+hmac = { version = "0.12", optional = true }
 ipnet = "2.9.0"
 once_cell = "1.21.3"
 parking_lot = "0.12.1"
 rand = "0.8.5"
 range-cmp = "0.1.1"
 serde = { version = "1.0.192", features = ["derive"] }
+sha2 = { version = "0.10", optional = true }
 tokio = { version = "1.33.0", features = ["net", "time", "rt", "macros"] }
 tracing = "0.1.40"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,8 @@ default = ["mac-blake3"]
 # both are enabled. At least one must be enabled or the crate fails to compile.
 mac-blake3 = ["dep:blake3"]
 mac-hmac = ["dep:hmac", "dep:sha2"]
+# Wipe the cluster key from memory on drop (defense in depth).
+zeroize = ["dep:zeroize"]
 
 [dependencies]
 arrayvec = "0.7.4"
@@ -40,6 +42,7 @@ serde = { version = "1.0.192", features = ["derive"] }
 sha2 = { version = "0.10", optional = true }
 tokio = { version = "1.33.0", features = ["net", "time", "rt", "macros"] }
 tracing = "0.1.40"
+zeroize = { version = "1.7", optional = true, features = ["derive"] }
 
 [dev-dependencies]
 clap = { version = "4.4.6", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ runs unauthenticated.
 
 The MAC primitive is selected at build time via Cargo features: `mac-blake3` (default, keyed
 BLAKE3) or `mac-hmac` (HMAC-SHA256). All nodes in a cluster must share the identical key **and** be
-built with the same backend.
+built with the same backend. The optional `zeroize` feature wipes the cluster key from memory when
+it is dropped (defense in depth).
 
 **Scope.** This provides message integrity and authenticity. It does **not** provide
 confidentiality (the payload is not encrypted — see issue #96), replay protection (replaying a

--- a/README.md
+++ b/README.md
@@ -44,6 +44,36 @@ tokio::spawn(store.clone().run());
 // use the reconciliation store as a key-value store in the API
 ```
 
+## Security model
+
+> **By default, the UDP reconciliation protocol is _unauthenticated_.** Any host that can send a
+> UDP datagram to the port can forge an update — including one with a year-9999 timestamp that
+> wins against every legitimate write forever, or a forged tombstone that deletes a key — and the
+> poison propagates to the whole cluster through last-write-wins. UDP source addresses are
+> spoofable, so this is anonymous.
+
+To close this vector, provide a shared 32-byte cluster secret on **every** node:
+
+```rust
+let key: [u8; 32] = /* same secret on all nodes, e.g. loaded from your secret manager */;
+let config = Config::default().with_cluster_key(key);
+let store = ReconcileStore::new(config).await;
+```
+
+With a key set, every outgoing datagram is framed with a per-datagram keyed MAC over its payload,
+and every incoming datagram is **verified before deserialization**; datagrams with a missing or
+invalid tag are silently dropped. When no key is set, the store logs a loud warning at startup and
+runs unauthenticated.
+
+The MAC primitive is selected at build time via Cargo features: `mac-blake3` (default, keyed
+BLAKE3) or `mac-hmac` (HMAC-SHA256). All nodes in a cluster must share the identical key **and** be
+built with the same backend.
+
+**Scope.** This provides message integrity and authenticity. It does **not** provide
+confidentiality (the payload is not encrypted — see issue #96), replay protection (replaying a
+captured datagram is benign for idempotent last-write-wins reconciliation), or a peer allow-list.
+For confidentiality, run the protocol over a trusted/encrypted underlay.
+
 ## HRTree
 
 The core of the protocol is made possible by the `HRTree` (Hash-Range Tree) data structure, which

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -249,6 +249,16 @@ deletion. The poison **propagates to the whole cluster** via reconciliation. Sou
 allow-list; for confidentiality, DTLS/Noise/QUIC. Failing that, **document loudly** that the
 protocol requires a trusted network.
 
+**Status — partially mitigated (issue #108).** A per-datagram keyed MAC is now implemented
+(`src/auth.rs`): when a cluster key is set via `Config::with_cluster_key`, every datagram is framed
+`tag || payload` and **verified before deserialization**, with unauthenticated/forged datagrams
+silently dropped (`reconcile_engine.rs`, `handle_messages`). The MAC primitive is feature-abstracted
+(`mac-blake3` default, `mac-hmac`). Authentication is opt-in: when no key is set, the store logs a
+loud startup warning, and the README now carries a "Security model" section — so **"document
+loudly" is satisfied**. Still **out of scope** / tracked separately: the peer allow-list, and
+confidentiality (DTLS/Noise/QUIC, issue #96). The attacker-controlled-timestamp vector is closed for
+external attackers once a key is configured; the broader physical-clock concern remains F5.
+
 ### F4 — [CRITICAL] Tombstone resurrection (wall-clock GC, no causal stability) **[2/2]**
 
 `reconcile_store.rs:208-215` + `timeout_wheel.rs:46-57`: a tombstone is purged 60 s after the

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -232,11 +232,13 @@ fn service_send(c: &mut Criterion) {
         port,
         listen_addr: addr1,
         peer_net,
+        cluster_key: None,
     };
     let cfg2 = Config {
         port,
         listen_addr: addr2,
         peer_net,
+        cluster_key: None,
     };
 
     let mut rng = rand::rngs::ThreadRng::default();

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -44,7 +44,13 @@ compile_error!(
 );
 
 /// A shared cluster secret. Constructing one is the only way to enable authentication.
-#[derive(Clone, Copy)]
+///
+/// The type is deliberately `Clone` but **not** `Copy`: with the `zeroize` feature enabled it
+/// implements a `Drop` that wipes the key bytes from memory, which `Copy` would forbid (and which
+/// would be meaningless for a freely-duplicated value). Cloning a 32-byte array is trivial, so the
+/// absence of `Copy` costs nothing at runtime.
+#[cfg_attr(feature = "zeroize", derive(zeroize::Zeroize, zeroize::ZeroizeOnDrop))]
+#[derive(Clone)]
 pub(crate) struct ClusterKey([u8; KEY_LEN]);
 
 impl ClusterKey {
@@ -147,7 +153,8 @@ pub(crate) type ClusterMac = HmacSha256Mac;
 /// Authentication policy and datagram framing for one node.
 ///
 /// Holds the cluster key (or the absence thereof) and is the sole producer of [`Payload`] values.
-#[derive(Clone, Copy)]
+/// Not `Copy` because it may carry a [`ClusterKey`]; cloning it is cheap.
+#[derive(Clone)]
 pub(crate) enum Authenticator {
     /// No cluster key configured: the protocol runs unauthenticated.
     Disabled,

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -8,20 +8,29 @@
 
 //! Per-datagram message authentication for the reconciliation protocol.
 //!
-//! The UDP protocol performs no authentication by itself: any host that can
-//! send a datagram to the port can forge an update and poison the whole
-//! cluster through last-write-wins (see the crate-level "Security model"
-//! documentation). To close that vector, when a cluster key is configured
-//! (see [`Config::with_cluster_key`](crate::reconcile_store::Config::with_cluster_key)),
-//! every outgoing datagram is framed as `tag || payload` where `tag` is a
-//! 32-byte keyed MAC over `payload`, and every incoming datagram is verified
-//! **before** any deserialization. Datagrams whose tag is missing or invalid
-//! are silently dropped.
+//! The UDP protocol performs no authentication by itself: any host that can send a datagram to the
+//! port can forge an update and poison the whole cluster through last-write-wins (see the
+//! crate-level "Security model" documentation). To close that vector, when a cluster key is
+//! configured (see
+//! [`Config::with_cluster_key`](crate::reconcile_store::Config::with_cluster_key)), every outgoing
+//! datagram is framed as `tag || payload` where `tag` is a keyed MAC over `payload`, and every
+//! incoming datagram is verified **before** any deserialization.
 //!
-//! The MAC primitive is abstracted behind a Cargo feature so it can be swapped
-//! without touching the protocol: `mac-blake3` (default, keyed BLAKE3) or
-//! `mac-hmac` (HMAC-SHA256). All nodes in a cluster must use the same key and
-//! the same backend.
+//! # Design
+//!
+//! The module is layered so the type system carries the security invariants ("parse, don't
+//! validate"):
+//!
+//! - [`Mac`] is the cryptographic primitive — a compile-time-selected trait with one concrete
+//!   backend per Cargo feature ([`Blake3Mac`] for `mac-blake3`, the default, or `HmacSha256Mac`
+//!   for `mac-hmac`). [`ClusterMac`] aliases the active backend.
+//! - [`ClusterKey`] and [`Tag`] are newtypes around raw byte arrays so keys, tags and arbitrary
+//!   buffers cannot be confused.
+//! - [`Authenticator`] holds the policy (authentication enabled or not) plus framing. It is the
+//!   only producer of a [`Payload`].
+//! - [`Payload`] is an opaque wrapper that can only be obtained from [`Authenticator::open`].
+//!   Because message handling consumes a `Payload` rather than `&[u8]`, it is structurally
+//!   impossible to deserialize bytes that have not cleared the authentication gate.
 
 /// Length in bytes of the authentication tag prepended to every datagram.
 pub(crate) const TAG_LEN: usize = 32;
@@ -34,80 +43,172 @@ compile_error!(
     "reconcile: no MAC backend selected. Enable feature `mac-blake3` (default) or `mac-hmac`."
 );
 
-// `mac-blake3` takes precedence when both backends are enabled (e.g. under
-// `--all-features`), so that such builds still compile instead of hitting a
-// hard error.
-#[cfg(feature = "mac-blake3")]
-mod backend {
-    use super::{KEY_LEN, TAG_LEN};
+/// A shared cluster secret. Constructing one is the only way to enable authentication.
+#[derive(Clone, Copy)]
+pub(crate) struct ClusterKey([u8; KEY_LEN]);
 
-    pub fn tag(key: &[u8; KEY_LEN], payload: &[u8]) -> [u8; TAG_LEN] {
-        *blake3::keyed_hash(key, payload).as_bytes()
+impl ClusterKey {
+    pub(crate) fn new(bytes: [u8; KEY_LEN]) -> Self {
+        ClusterKey(bytes)
     }
 
-    pub fn verify(key: &[u8; KEY_LEN], payload: &[u8], tag: &[u8]) -> bool {
+    fn as_bytes(&self) -> &[u8; KEY_LEN] {
+        &self.0
+    }
+}
+
+/// A MAC tag. Can only be produced by a [`Mac`] backend.
+pub(crate) struct Tag([u8; TAG_LEN]);
+
+impl Tag {
+    fn as_bytes(&self) -> &[u8; TAG_LEN] {
+        &self.0
+    }
+}
+
+/// A datagram payload that has cleared the authentication gate — either its tag was verified, or
+/// the store is running in (explicitly) unauthenticated mode. The rest of the engine can only
+/// obtain one through [`Authenticator::open`], so message handling cannot, by construction, run on
+/// bytes that were not cleared first ("parse, don't validate").
+pub(crate) struct Payload<'a>(&'a [u8]);
+
+impl<'a> Payload<'a> {
+    pub(crate) fn as_bytes(&self) -> &'a [u8] {
+        self.0
+    }
+}
+
+/// The keyed MAC primitive used to authenticate datagrams.
+///
+/// The active backend is selected at compile time through the `mac-*` Cargo features and aliased
+/// as [`ClusterMac`]; this trait makes the contract that every backend must satisfy explicit and
+/// compiler-checked, rather than relying on convention.
+pub(crate) trait Mac {
+    /// Compute the authentication tag of `message` under `key`.
+    fn tag(key: &ClusterKey, message: &[u8]) -> Tag;
+
+    /// Constant-time check that `tag` authenticates `message` under `key`.
+    ///
+    /// `tag` is the untrusted on-the-wire slice; an incorrect length yields `false`.
+    fn verify(key: &ClusterKey, message: &[u8], tag: &[u8]) -> bool;
+}
+
+#[cfg(feature = "mac-blake3")]
+pub(crate) struct Blake3Mac;
+
+#[cfg(feature = "mac-blake3")]
+impl Mac for Blake3Mac {
+    fn tag(key: &ClusterKey, message: &[u8]) -> Tag {
+        Tag(*blake3::keyed_hash(key.as_bytes(), message).as_bytes())
+    }
+
+    fn verify(key: &ClusterKey, message: &[u8], tag: &[u8]) -> bool {
         let Ok(tag) = <[u8; TAG_LEN]>::try_from(tag) else {
             return false;
         };
         // `blake3::Hash`'s `PartialEq` is constant-time.
-        blake3::keyed_hash(key, payload) == blake3::Hash::from_bytes(tag)
+        blake3::keyed_hash(key.as_bytes(), message) == blake3::Hash::from_bytes(tag)
     }
 }
 
+// Compiled only when it is actually the selected backend (`mac-blake3` takes precedence), so an
+// `--all-features` build does not carry an unused struct.
 #[cfg(all(feature = "mac-hmac", not(feature = "mac-blake3")))]
-mod backend {
-    use super::{KEY_LEN, TAG_LEN};
-    use hmac::{Hmac, Mac};
-    use sha2::Sha256;
+pub(crate) struct HmacSha256Mac;
 
-    type HmacSha256 = Hmac<Sha256>;
-
-    pub fn tag(key: &[u8; KEY_LEN], payload: &[u8]) -> [u8; TAG_LEN] {
-        let mut mac = HmacSha256::new_from_slice(key).expect("HMAC accepts any key length");
-        mac.update(payload);
-        // SHA-256 produces exactly 32 bytes, matching TAG_LEN: no truncation.
-        mac.finalize().into_bytes().into()
+#[cfg(all(feature = "mac-hmac", not(feature = "mac-blake3")))]
+impl Mac for HmacSha256Mac {
+    fn tag(key: &ClusterKey, message: &[u8]) -> Tag {
+        use hmac::{Hmac, Mac as _};
+        let mut mac = Hmac::<sha2::Sha256>::new_from_slice(key.as_bytes())
+            .expect("HMAC accepts any key length");
+        mac.update(message);
+        // SHA-256 produces exactly TAG_LEN bytes: no truncation.
+        Tag(mac.finalize().into_bytes().into())
     }
 
-    pub fn verify(key: &[u8; KEY_LEN], payload: &[u8], tag: &[u8]) -> bool {
-        let mut mac = HmacSha256::new_from_slice(key).expect("HMAC accepts any key length");
-        mac.update(payload);
+    fn verify(key: &ClusterKey, message: &[u8], tag: &[u8]) -> bool {
+        use hmac::{Hmac, Mac as _};
+        let mut mac = Hmac::<sha2::Sha256>::new_from_slice(key.as_bytes())
+            .expect("HMAC accepts any key length");
+        mac.update(message);
         // `verify_slice` is constant-time and length-checked.
         mac.verify_slice(tag).is_ok()
     }
 }
 
-/// Compute a 32-byte authentication tag over `payload` under `key`.
-pub(crate) fn tag(key: &[u8; KEY_LEN], payload: &[u8]) -> [u8; TAG_LEN] {
-    backend::tag(key, payload)
-}
+// `mac-blake3` takes precedence when both backends are enabled (e.g. under `--all-features`), so
+// such builds still compile instead of hitting a hard error.
+#[cfg(feature = "mac-blake3")]
+pub(crate) type ClusterMac = Blake3Mac;
+#[cfg(all(feature = "mac-hmac", not(feature = "mac-blake3")))]
+pub(crate) type ClusterMac = HmacSha256Mac;
 
-/// Constant-time verification that `tag` authenticates `payload` under `key`.
-pub(crate) fn verify(key: &[u8; KEY_LEN], payload: &[u8], tag: &[u8]) -> bool {
-    backend::verify(key, payload, tag)
-}
-
-/// Frame an outgoing datagram as `tag(payload) || payload`.
-pub(crate) fn seal(key: &[u8; KEY_LEN], payload: &[u8]) -> Vec<u8> {
-    let mut out = Vec::with_capacity(TAG_LEN + payload.len());
-    out.extend_from_slice(&tag(key, payload));
-    out.extend_from_slice(payload);
-    out
-}
-
-/// Verify and strip a received datagram framed as `tag || payload`.
+/// Authentication policy and datagram framing for one node.
 ///
-/// Returns `Some(payload)` if the datagram is long enough and the tag is valid,
-/// `None` otherwise (too short or invalid tag).
-pub(crate) fn open<'a>(key: &[u8; KEY_LEN], datagram: &'a [u8]) -> Option<&'a [u8]> {
-    if datagram.len() < TAG_LEN {
-        return None;
+/// Holds the cluster key (or the absence thereof) and is the sole producer of [`Payload`] values.
+#[derive(Clone, Copy)]
+pub(crate) enum Authenticator {
+    /// No cluster key configured: the protocol runs unauthenticated.
+    Disabled,
+    /// A cluster key is configured: datagrams are sealed and verified.
+    Enabled(ClusterKey),
+}
+
+impl Authenticator {
+    /// Build an authenticator from an optional raw cluster key.
+    pub(crate) fn new(key: Option<[u8; KEY_LEN]>) -> Self {
+        match key {
+            Some(bytes) => Authenticator::Enabled(ClusterKey::new(bytes)),
+            None => Authenticator::Disabled,
+        }
     }
-    let (tag, payload) = datagram.split_at(TAG_LEN);
-    if verify(key, payload, tag) {
-        Some(payload)
-    } else {
-        None
+
+    pub(crate) fn is_enabled(&self) -> bool {
+        matches!(self, Authenticator::Enabled(_))
+    }
+
+    /// Number of extra bytes a sealed datagram adds, for MTU/buffer accounting.
+    pub(crate) fn overhead(&self) -> usize {
+        match self {
+            Authenticator::Disabled => 0,
+            Authenticator::Enabled(_) => TAG_LEN,
+        }
+    }
+
+    /// Frame an outgoing datagram as `tag(payload) || payload`.
+    ///
+    /// Returns `Some(framed)` when enabled, or `None` when disabled (the caller then sends
+    /// `payload` unchanged, byte-for-byte identical to the unauthenticated protocol).
+    pub(crate) fn seal(&self, payload: &[u8]) -> Option<Vec<u8>> {
+        match self {
+            Authenticator::Disabled => None,
+            Authenticator::Enabled(key) => {
+                let tag = ClusterMac::tag(key, payload);
+                let mut framed = Vec::with_capacity(TAG_LEN + payload.len());
+                framed.extend_from_slice(tag.as_bytes());
+                framed.extend_from_slice(payload);
+                Some(framed)
+            }
+        }
+    }
+
+    /// Authenticate an incoming datagram, returning the [`Payload`] cleared for processing.
+    ///
+    /// When enabled, the datagram must be `tag || payload` with a valid tag; otherwise (too short
+    /// or invalid tag) `None` is returned and the caller drops it silently. When disabled, the
+    /// whole datagram is returned as the payload.
+    pub(crate) fn open<'a>(&self, datagram: &'a [u8]) -> Option<Payload<'a>> {
+        match self {
+            Authenticator::Disabled => Some(Payload(datagram)),
+            Authenticator::Enabled(key) => {
+                if datagram.len() < TAG_LEN {
+                    return None;
+                }
+                let (tag, payload) = datagram.split_at(TAG_LEN);
+                ClusterMac::verify(key, payload, tag).then_some(Payload(payload))
+            }
+        }
     }
 }
 
@@ -115,55 +216,77 @@ pub(crate) fn open<'a>(key: &[u8; KEY_LEN], datagram: &'a [u8]) -> Option<&'a [u
 mod tests {
     use super::*;
 
-    const K1: [u8; KEY_LEN] = [0x11; KEY_LEN];
-    const K2: [u8; KEY_LEN] = [0x22; KEY_LEN];
+    fn key(byte: u8) -> ClusterKey {
+        ClusterKey::new([byte; KEY_LEN])
+    }
 
     #[test]
     fn tag_verify_roundtrip() {
-        let t = tag(&K1, b"hello world");
-        assert!(verify(&K1, b"hello world", &t));
+        let k = key(0x11);
+        let t = ClusterMac::tag(&k, b"hello world");
+        assert!(ClusterMac::verify(&k, b"hello world", t.as_bytes()));
     }
 
     #[test]
     fn tamper_detection() {
+        let k = key(0x11);
         let payload = b"the quick brown fox".to_vec();
-        let t = tag(&K1, &payload);
+        let t = ClusterMac::tag(&k, &payload);
 
         // Flip a payload byte.
         let mut bad_payload = payload.clone();
         bad_payload[0] ^= 0x01;
-        assert!(!verify(&K1, &bad_payload, &t));
+        assert!(!ClusterMac::verify(&k, &bad_payload, t.as_bytes()));
 
         // Flip a tag byte.
-        let mut bad_tag = t;
+        let mut bad_tag = *t.as_bytes();
         bad_tag[0] ^= 0x01;
-        assert!(!verify(&K1, &payload, &bad_tag));
+        assert!(!ClusterMac::verify(&k, &payload, &bad_tag));
     }
 
     #[test]
     fn wrong_key_rejected() {
-        let t = tag(&K1, b"payload");
-        assert!(!verify(&K2, b"payload", &t));
+        let t = ClusterMac::tag(&key(0x11), b"payload");
+        assert!(!ClusterMac::verify(&key(0x22), b"payload", t.as_bytes()));
     }
 
     #[test]
     fn seal_open_roundtrip() {
-        let payload = b"some serialized message".to_vec();
-        let sealed = seal(&K1, &payload);
+        let auth = Authenticator::new(Some([0x11; KEY_LEN]));
+        let payload = b"some serialized message";
+        let sealed = auth.seal(payload).expect("enabled");
         assert_eq!(sealed.len(), TAG_LEN + payload.len());
-        assert_eq!(open(&K1, &sealed), Some(payload.as_slice()));
+        assert_eq!(auth.open(&sealed).map(|p| p.as_bytes()), Some(&payload[..]));
     }
 
     #[test]
     fn open_too_short() {
+        let auth = Authenticator::new(Some([0x11; KEY_LEN]));
         // Fewer than TAG_LEN bytes can never carry a valid tag.
-        assert_eq!(open(&K1, &[0u8; 10]), None);
-        assert_eq!(open(&K1, &[]), None);
+        assert!(auth.open(&[0u8; 10]).is_none());
+        assert!(auth.open(&[]).is_none());
     }
 
     #[test]
     fn open_wrong_key() {
-        let sealed = seal(&K1, b"payload");
-        assert_eq!(open(&K2, &sealed), None);
+        let sealed = Authenticator::new(Some([0x11; KEY_LEN]))
+            .seal(b"payload")
+            .expect("enabled");
+        assert!(Authenticator::new(Some([0x22; KEY_LEN]))
+            .open(&sealed)
+            .is_none());
+    }
+
+    #[test]
+    fn disabled_passes_through_and_does_not_seal() {
+        let auth = Authenticator::new(None);
+        assert!(!auth.is_enabled());
+        assert_eq!(auth.overhead(), 0);
+        assert!(auth.seal(b"payload").is_none());
+        // Any datagram clears the gate unchanged in unauthenticated mode.
+        assert_eq!(
+            auth.open(b"raw bytes").map(|p| p.as_bytes()),
+            Some(&b"raw bytes"[..])
+        );
     }
 }

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,0 +1,169 @@
+// Copyright 2023 Developers of the reconcile project.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Per-datagram message authentication for the reconciliation protocol.
+//!
+//! The UDP protocol performs no authentication by itself: any host that can
+//! send a datagram to the port can forge an update and poison the whole
+//! cluster through last-write-wins (see the crate-level "Security model"
+//! documentation). To close that vector, when a cluster key is configured
+//! (see [`Config::with_cluster_key`](crate::reconcile_store::Config::with_cluster_key)),
+//! every outgoing datagram is framed as `tag || payload` where `tag` is a
+//! 32-byte keyed MAC over `payload`, and every incoming datagram is verified
+//! **before** any deserialization. Datagrams whose tag is missing or invalid
+//! are silently dropped.
+//!
+//! The MAC primitive is abstracted behind a Cargo feature so it can be swapped
+//! without touching the protocol: `mac-blake3` (default, keyed BLAKE3) or
+//! `mac-hmac` (HMAC-SHA256). All nodes in a cluster must use the same key and
+//! the same backend.
+
+/// Length in bytes of the authentication tag prepended to every datagram.
+pub(crate) const TAG_LEN: usize = 32;
+
+/// Length in bytes of a cluster key.
+pub(crate) const KEY_LEN: usize = 32;
+
+#[cfg(not(any(feature = "mac-blake3", feature = "mac-hmac")))]
+compile_error!(
+    "reconcile: no MAC backend selected. Enable feature `mac-blake3` (default) or `mac-hmac`."
+);
+
+// `mac-blake3` takes precedence when both backends are enabled (e.g. under
+// `--all-features`), so that such builds still compile instead of hitting a
+// hard error.
+#[cfg(feature = "mac-blake3")]
+mod backend {
+    use super::{KEY_LEN, TAG_LEN};
+
+    pub fn tag(key: &[u8; KEY_LEN], payload: &[u8]) -> [u8; TAG_LEN] {
+        *blake3::keyed_hash(key, payload).as_bytes()
+    }
+
+    pub fn verify(key: &[u8; KEY_LEN], payload: &[u8], tag: &[u8]) -> bool {
+        let Ok(tag) = <[u8; TAG_LEN]>::try_from(tag) else {
+            return false;
+        };
+        // `blake3::Hash`'s `PartialEq` is constant-time.
+        blake3::keyed_hash(key, payload) == blake3::Hash::from_bytes(tag)
+    }
+}
+
+#[cfg(all(feature = "mac-hmac", not(feature = "mac-blake3")))]
+mod backend {
+    use super::{KEY_LEN, TAG_LEN};
+    use hmac::{Hmac, Mac};
+    use sha2::Sha256;
+
+    type HmacSha256 = Hmac<Sha256>;
+
+    pub fn tag(key: &[u8; KEY_LEN], payload: &[u8]) -> [u8; TAG_LEN] {
+        let mut mac = HmacSha256::new_from_slice(key).expect("HMAC accepts any key length");
+        mac.update(payload);
+        // SHA-256 produces exactly 32 bytes, matching TAG_LEN: no truncation.
+        mac.finalize().into_bytes().into()
+    }
+
+    pub fn verify(key: &[u8; KEY_LEN], payload: &[u8], tag: &[u8]) -> bool {
+        let mut mac = HmacSha256::new_from_slice(key).expect("HMAC accepts any key length");
+        mac.update(payload);
+        // `verify_slice` is constant-time and length-checked.
+        mac.verify_slice(tag).is_ok()
+    }
+}
+
+/// Compute a 32-byte authentication tag over `payload` under `key`.
+pub(crate) fn tag(key: &[u8; KEY_LEN], payload: &[u8]) -> [u8; TAG_LEN] {
+    backend::tag(key, payload)
+}
+
+/// Constant-time verification that `tag` authenticates `payload` under `key`.
+pub(crate) fn verify(key: &[u8; KEY_LEN], payload: &[u8], tag: &[u8]) -> bool {
+    backend::verify(key, payload, tag)
+}
+
+/// Frame an outgoing datagram as `tag(payload) || payload`.
+pub(crate) fn seal(key: &[u8; KEY_LEN], payload: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(TAG_LEN + payload.len());
+    out.extend_from_slice(&tag(key, payload));
+    out.extend_from_slice(payload);
+    out
+}
+
+/// Verify and strip a received datagram framed as `tag || payload`.
+///
+/// Returns `Some(payload)` if the datagram is long enough and the tag is valid,
+/// `None` otherwise (too short or invalid tag).
+pub(crate) fn open<'a>(key: &[u8; KEY_LEN], datagram: &'a [u8]) -> Option<&'a [u8]> {
+    if datagram.len() < TAG_LEN {
+        return None;
+    }
+    let (tag, payload) = datagram.split_at(TAG_LEN);
+    if verify(key, payload, tag) {
+        Some(payload)
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const K1: [u8; KEY_LEN] = [0x11; KEY_LEN];
+    const K2: [u8; KEY_LEN] = [0x22; KEY_LEN];
+
+    #[test]
+    fn tag_verify_roundtrip() {
+        let t = tag(&K1, b"hello world");
+        assert!(verify(&K1, b"hello world", &t));
+    }
+
+    #[test]
+    fn tamper_detection() {
+        let payload = b"the quick brown fox".to_vec();
+        let t = tag(&K1, &payload);
+
+        // Flip a payload byte.
+        let mut bad_payload = payload.clone();
+        bad_payload[0] ^= 0x01;
+        assert!(!verify(&K1, &bad_payload, &t));
+
+        // Flip a tag byte.
+        let mut bad_tag = t;
+        bad_tag[0] ^= 0x01;
+        assert!(!verify(&K1, &payload, &bad_tag));
+    }
+
+    #[test]
+    fn wrong_key_rejected() {
+        let t = tag(&K1, b"payload");
+        assert!(!verify(&K2, b"payload", &t));
+    }
+
+    #[test]
+    fn seal_open_roundtrip() {
+        let payload = b"some serialized message".to_vec();
+        let sealed = seal(&K1, &payload);
+        assert_eq!(sealed.len(), TAG_LEN + payload.len());
+        assert_eq!(open(&K1, &sealed), Some(payload.as_slice()));
+    }
+
+    #[test]
+    fn open_too_short() {
+        // Fewer than TAG_LEN bytes can never carry a valid tag.
+        assert_eq!(open(&K1, &[0u8; 10]), None);
+        assert_eq!(open(&K1, &[]), None);
+    }
+
+    #[test]
+    fn open_wrong_key() {
+        let sealed = seal(&K1, b"payload");
+        assert_eq!(open(&K2, &sealed), None);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,12 +17,23 @@
 //! number of round-trips. It should also work well to populate an instance from
 //! scratch from other instances.
 
+//! # Security model
+//!
+//! By default the UDP reconciliation protocol is **unauthenticated**: any host able to send a
+//! datagram to the port can forge an update and poison the whole cluster through last-write-wins.
+//! To prevent this, configure a shared cluster secret with
+//! [`Config::with_cluster_key`](reconcile_store::Config::with_cluster_key) on **every** node: this
+//! enables a per-datagram keyed MAC that is verified before deserialization, silently dropping
+//! unauthenticated or forged datagrams. See the README "Security model" section for the full
+//! threat model and scope.
+
 pub mod diff;
 pub mod gen_ip;
 pub mod hrtree;
 pub mod hrtree_iter;
 pub mod reconcile_store;
 
+pub(crate) mod auth;
 pub(crate) mod reconcilable;
 pub(crate) mod reconcile_engine;
 pub(crate) mod timeout_wheel;

--- a/src/reconcile_engine.rs
+++ b/src/reconcile_engine.rs
@@ -54,8 +54,8 @@ pub(crate) struct ReconcileEngine<K, V> {
     rng: Arc<RwLock<StdRng>>,
     pub(crate) peers: Arc<RwLock<HashMap<IpAddr, Instant>>>,
     pub(crate) pre_insert: Arc<RwLock<PreInsertCallback<K, V>>>,
-    /// Shared cluster secret for per-datagram MAC authentication; `None` runs unauthenticated.
-    cluster_key: Option<[u8; auth::KEY_LEN]>,
+    /// Per-datagram authentication policy; carries the cluster key when enabled.
+    authenticator: auth::Authenticator,
 }
 
 impl<K, V> Clone for ReconcileEngine<K, V> {
@@ -68,7 +68,7 @@ impl<K, V> Clone for ReconcileEngine<K, V> {
             rng: self.rng.clone(),
             peers: self.peers.clone(),
             pre_insert: self.pre_insert.clone(),
-            cluster_key: self.cluster_key,
+            authenticator: self.authenticator,
         }
     }
 }
@@ -102,14 +102,16 @@ impl<
             .await
             .unwrap();
         debug!("Listening on: {}", socket.local_addr().unwrap());
-        match config.cluster_key {
-            Some(_) => debug!("per-datagram MAC authentication ENABLED"),
-            None => warn!(
+        let authenticator = auth::Authenticator::new(config.cluster_key);
+        if authenticator.is_enabled() {
+            debug!("per-datagram MAC authentication ENABLED");
+        } else {
+            warn!(
                 "SECURITY: no cluster key set — UDP reconciliation is UNAUTHENTICATED. Any host \
                  that can send UDP to this port can forge updates and poison the cluster via \
                  last-write-wins. Set Config::with_cluster_key on every node, or restrict the \
                  network to a trusted underlay. See issue #108 / REVIEW.md F3."
-            ),
+            );
         }
         let map = HRTree::<K, V>::new();
         ReconcileEngine {
@@ -120,7 +122,7 @@ impl<
             rng: Arc::new(RwLock::new(StdRng::from_entropy())),
             peers: Arc::new(RwLock::new(HashMap::new())),
             pre_insert: Arc::new(RwLock::new(Box::new(|_, _| {}))),
-            cluster_key: config.cluster_key,
+            authenticator,
         }
     }
 
@@ -148,7 +150,7 @@ impl<
         let peers = self.get_peers();
         let port = self.port;
         let socket = Arc::clone(&self.socket);
-        let cluster_key = self.cluster_key;
+        let authenticator = self.authenticator;
         tokio::spawn(async move {
             let message = Message::Update::<K, V>((key, value));
             let messages = vec![message];
@@ -158,7 +160,7 @@ impl<
                 send_messages_to(
                     &messages,
                     Arc::clone(&socket),
-                    cluster_key.as_ref(),
+                    &authenticator,
                     &peer,
                     &mut send_buf,
                 )
@@ -189,7 +191,7 @@ impl<
             .collect();
         let port = self.port;
         let socket = Arc::clone(&self.socket);
-        let cluster_key = self.cluster_key;
+        let authenticator = self.authenticator;
         tokio::spawn(async move {
             let mut send_buf = Vec::new();
             for addr in peers {
@@ -197,7 +199,7 @@ impl<
                 send_messages_to(
                     &messages,
                     Arc::clone(&socket),
-                    cluster_key.as_ref(),
+                    &authenticator,
                     &peer,
                     &mut send_buf,
                 )
@@ -233,8 +235,17 @@ impl<
                             self.port
                         );
                     }
-                    self.handle_messages(&recv_buf, (size, peer), &mut send_buf)
-                        .await;
+                    if size == recv_buf.len() {
+                        warn!("Buffer too small for message, discarded");
+                    } else {
+                        // Authenticate the datagram *before* any deserialization. Only a cleared
+                        // `Payload` can reach `handle_messages`; a missing or invalid tag is
+                        // dropped silently (trace-only, to avoid attacker-driven log flooding).
+                        match self.authenticator.open(&recv_buf[..size]) {
+                            Some(payload) => self.handle_messages(payload, peer, &mut send_buf).await,
+                            None => trace!("dropped datagram from {peer}: missing or invalid MAC"),
+                        }
+                    }
                     let now = Instant::now();
                     let addr = peer.ip();
                     self.peers.write().insert(addr, now);
@@ -265,41 +276,23 @@ impl<
         // initiate the reconciliation protocol with all the known peers, and a random one
         for peer in peers {
             trace!("start_diff {} bytes to {peer}", send_buf.len());
-            send_to_retry(
-                &self.socket,
-                self.cluster_key.as_ref(),
-                send_buf,
-                (peer, self.port),
-            )
-            .await
-            .unwrap();
+            send_to_retry(&self.socket, &self.authenticator, send_buf, (peer, self.port))
+                .await
+                .unwrap();
         }
     }
 
+    /// Handle the messages contained in an already-authenticated [`Payload`].
+    ///
+    /// Taking a [`auth::Payload`] rather than raw bytes makes it structurally impossible to
+    /// process a datagram that has not cleared the authentication gate.
     async fn handle_messages(
         &self,
-        recv_buf: &[u8],
-        (size, peer): (usize, SocketAddr),
+        payload: auth::Payload<'_>,
+        peer: SocketAddr,
         send_buf: &mut Vec<u8>,
     ) {
-        if size == recv_buf.len() {
-            warn!("Buffer too small for message, discarded");
-            return;
-        }
-        let datagram = &recv_buf[..size];
-        // Authenticate the whole datagram *before* deserializing anything. Datagrams with a
-        // missing or invalid tag are silently dropped (trace-only, to avoid attacker-driven log
-        // flooding). Without a cluster key, behavior is unchanged.
-        let payload: &[u8] = match self.cluster_key {
-            Some(ref key) => match auth::open(key, datagram) {
-                Some(payload) => payload,
-                None => {
-                    trace!("dropped datagram from {peer}: missing or invalid MAC");
-                    return;
-                }
-            },
-            None => datagram,
-        };
+        let payload = payload.as_bytes();
         trace!("received {} bytes from {peer}", payload.len());
         let mut in_comparison = Vec::new();
         let mut updates = Vec::new();
@@ -350,7 +343,7 @@ impl<
                 send_messages_to(
                     &messages,
                     Arc::clone(&self.socket),
-                    self.cluster_key.as_ref(),
+                    &self.authenticator,
                     &peer,
                     send_buf,
                 )
@@ -381,14 +374,13 @@ impl<
 
 async fn send_to_retry<A: ToSocketAddrs>(
     socket: &UdpSocket,
-    key: Option<&[u8; auth::KEY_LEN]>,
+    authenticator: &auth::Authenticator,
     buf: &[u8],
     target: A,
 ) -> std::io::Result<usize> {
-    // When a cluster key is set, frame the datagram once as `tag || payload` and reuse the framed
-    // buffer across retries. Without a key the wire bytes are identical to the unauthenticated
-    // behavior.
-    let framed = key.map(|k| auth::seal(k, buf));
+    // Frame the datagram once and reuse it across retries. When authentication is disabled,
+    // `seal` returns `None` and the wire bytes are identical to the unauthenticated behavior.
+    let framed = authenticator.seal(buf);
     let wire: &[u8] = framed.as_deref().unwrap_or(buf);
     let mut res = Ok(0);
     for _ in 0..MAX_SENDTO_RETRIES {
@@ -404,17 +396,13 @@ async fn send_to_retry<A: ToSocketAddrs>(
 async fn send_messages_to<K: Serialize, V: Serialize>(
     messages: &[Message<K, V>],
     socket: Arc<UdpSocket>,
-    key: Option<&[u8; auth::KEY_LEN]>,
+    authenticator: &auth::Authenticator,
     peer: &SocketAddr,
     send_buf: &mut Vec<u8>,
 ) {
     debug!("sending {} messages to {peer}", messages.len());
     // Reserve room for the authentication tag so the sealed datagram still fits a UDP payload.
-    let max_payload = if key.is_some() {
-        BUFFER_SIZE - auth::TAG_LEN
-    } else {
-        BUFFER_SIZE
-    };
+    let max_payload = BUFFER_SIZE - authenticator.overhead();
     send_buf.clear();
     for message in messages {
         let last_size = send_buf.len();
@@ -423,7 +411,7 @@ async fn send_messages_to<K: Serialize, V: Serialize>(
             .unwrap();
         if send_buf.len() > max_payload {
             trace!("sending {} bytes to {peer}", last_size);
-            send_to_retry(&socket, key, &send_buf[..last_size], &peer)
+            send_to_retry(&socket, authenticator, &send_buf[..last_size], &peer)
                 .await
                 .unwrap();
             trace!("sent {} bytes to {peer}", last_size);
@@ -431,7 +419,9 @@ async fn send_messages_to<K: Serialize, V: Serialize>(
         }
     }
     trace!("sending last {} bytes to {peer}", send_buf.len());
-    send_to_retry(&socket, key, send_buf, &peer).await.unwrap();
+    send_to_retry(&socket, authenticator, send_buf, &peer)
+        .await
+        .unwrap();
     trace!("sent last {} bytes to {peer}", send_buf.len());
 }
 
@@ -527,7 +517,9 @@ mod auth_attack {
         // (a) forged update sent WITHOUT any authentication tag
         attacker.send_to(&forged, &target).await.unwrap();
         // (b) forged update sealed with the WRONG key
-        let wrong_key_sealed = auth::seal(&[0x99u8; auth::KEY_LEN], &forged);
+        let wrong_key_sealed = auth::Authenticator::new(Some([0x99u8; auth::KEY_LEN]))
+            .seal(&forged)
+            .expect("enabled");
         attacker.send_to(&wrong_key_sealed, &target).await.unwrap();
 
         // give the victim time to (not) process the forged datagrams

--- a/src/reconcile_engine.rs
+++ b/src/reconcile_engine.rs
@@ -68,7 +68,7 @@ impl<K, V> Clone for ReconcileEngine<K, V> {
             rng: self.rng.clone(),
             peers: self.peers.clone(),
             pre_insert: self.pre_insert.clone(),
-            authenticator: self.authenticator,
+            authenticator: self.authenticator.clone(),
         }
     }
 }
@@ -150,7 +150,7 @@ impl<
         let peers = self.get_peers();
         let port = self.port;
         let socket = Arc::clone(&self.socket);
-        let authenticator = self.authenticator;
+        let authenticator = self.authenticator.clone();
         tokio::spawn(async move {
             let message = Message::Update::<K, V>((key, value));
             let messages = vec![message];
@@ -191,7 +191,7 @@ impl<
             .collect();
         let port = self.port;
         let socket = Arc::clone(&self.socket);
-        let authenticator = self.authenticator;
+        let authenticator = self.authenticator.clone();
         tokio::spawn(async move {
             let mut send_buf = Vec::new();
             for addr in peers {

--- a/src/reconcile_engine.rs
+++ b/src/reconcile_engine.rs
@@ -27,6 +27,7 @@ use tokio::net::{ToSocketAddrs, UdpSocket};
 use tokio::time::timeout;
 use tracing::{debug, trace, warn};
 
+use crate::auth;
 use crate::diff::HashRangeQueryable;
 use crate::diff::{Diffable, HashSegment};
 use crate::gen_ip::gen_ip;
@@ -53,6 +54,8 @@ pub(crate) struct ReconcileEngine<K, V> {
     rng: Arc<RwLock<StdRng>>,
     pub(crate) peers: Arc<RwLock<HashMap<IpAddr, Instant>>>,
     pub(crate) pre_insert: Arc<RwLock<PreInsertCallback<K, V>>>,
+    /// Shared cluster secret for per-datagram MAC authentication; `None` runs unauthenticated.
+    cluster_key: Option<[u8; auth::KEY_LEN]>,
 }
 
 impl<K, V> Clone for ReconcileEngine<K, V> {
@@ -65,6 +68,7 @@ impl<K, V> Clone for ReconcileEngine<K, V> {
             rng: self.rng.clone(),
             peers: self.peers.clone(),
             pre_insert: self.pre_insert.clone(),
+            cluster_key: self.cluster_key,
         }
     }
 }
@@ -98,6 +102,15 @@ impl<
             .await
             .unwrap();
         debug!("Listening on: {}", socket.local_addr().unwrap());
+        match config.cluster_key {
+            Some(_) => debug!("per-datagram MAC authentication ENABLED"),
+            None => warn!(
+                "SECURITY: no cluster key set — UDP reconciliation is UNAUTHENTICATED. Any host \
+                 that can send UDP to this port can forge updates and poison the cluster via \
+                 last-write-wins. Set Config::with_cluster_key on every node, or restrict the \
+                 network to a trusted underlay. See issue #108 / REVIEW.md F3."
+            ),
+        }
         let map = HRTree::<K, V>::new();
         ReconcileEngine {
             map: Arc::new(RwLock::new(map)),
@@ -107,6 +120,7 @@ impl<
             rng: Arc::new(RwLock::new(StdRng::from_entropy())),
             peers: Arc::new(RwLock::new(HashMap::new())),
             pre_insert: Arc::new(RwLock::new(Box::new(|_, _| {}))),
+            cluster_key: config.cluster_key,
         }
     }
 
@@ -134,13 +148,21 @@ impl<
         let peers = self.get_peers();
         let port = self.port;
         let socket = Arc::clone(&self.socket);
+        let cluster_key = self.cluster_key;
         tokio::spawn(async move {
             let message = Message::Update::<K, V>((key, value));
             let messages = vec![message];
             let mut send_buf = Vec::new();
             for addr in peers {
                 let peer = SocketAddr::new(addr, port);
-                send_messages_to(&messages, Arc::clone(&socket), &peer, &mut send_buf).await;
+                send_messages_to(
+                    &messages,
+                    Arc::clone(&socket),
+                    cluster_key.as_ref(),
+                    &peer,
+                    &mut send_buf,
+                )
+                .await;
             }
         });
         ret
@@ -167,11 +189,19 @@ impl<
             .collect();
         let port = self.port;
         let socket = Arc::clone(&self.socket);
+        let cluster_key = self.cluster_key;
         tokio::spawn(async move {
             let mut send_buf = Vec::new();
             for addr in peers {
                 let peer = SocketAddr::new(addr, port);
-                send_messages_to(&messages, Arc::clone(&socket), &peer, &mut send_buf).await;
+                send_messages_to(
+                    &messages,
+                    Arc::clone(&socket),
+                    cluster_key.as_ref(),
+                    &peer,
+                    &mut send_buf,
+                )
+                .await;
             }
         });
     }
@@ -235,9 +265,14 @@ impl<
         // initiate the reconciliation protocol with all the known peers, and a random one
         for peer in peers {
             trace!("start_diff {} bytes to {peer}", send_buf.len());
-            send_to_retry(&self.socket, send_buf, (peer, self.port))
-                .await
-                .unwrap();
+            send_to_retry(
+                &self.socket,
+                self.cluster_key.as_ref(),
+                send_buf,
+                (peer, self.port),
+            )
+            .await
+            .unwrap();
         }
     }
 
@@ -251,10 +286,24 @@ impl<
             warn!("Buffer too small for message, discarded");
             return;
         }
-        trace!("received {} bytes from {peer}", size);
+        let datagram = &recv_buf[..size];
+        // Authenticate the whole datagram *before* deserializing anything. Datagrams with a
+        // missing or invalid tag are silently dropped (trace-only, to avoid attacker-driven log
+        // flooding). Without a cluster key, behavior is unchanged.
+        let payload: &[u8] = match self.cluster_key {
+            Some(ref key) => match auth::open(key, datagram) {
+                Some(payload) => payload,
+                None => {
+                    trace!("dropped datagram from {peer}: missing or invalid MAC");
+                    return;
+                }
+            },
+            None => datagram,
+        };
+        trace!("received {} bytes from {peer}", payload.len());
         let mut in_comparison = Vec::new();
         let mut updates = Vec::new();
-        let mut deserializer = Deserializer::from_slice(&recv_buf[..size], DefaultOptions::new());
+        let mut deserializer = Deserializer::from_slice(payload, DefaultOptions::new());
         // read messages in buffer
         loop {
             match Message::deserialize(&mut deserializer) {
@@ -298,7 +347,14 @@ impl<
                 }
             }
             if !messages.is_empty() {
-                send_messages_to(&messages, Arc::clone(&self.socket), &peer, send_buf).await;
+                send_messages_to(
+                    &messages,
+                    Arc::clone(&self.socket),
+                    self.cluster_key.as_ref(),
+                    &peer,
+                    send_buf,
+                )
+                .await;
             }
         }
         if !updates.is_empty() {
@@ -325,12 +381,18 @@ impl<
 
 async fn send_to_retry<A: ToSocketAddrs>(
     socket: &UdpSocket,
+    key: Option<&[u8; auth::KEY_LEN]>,
     buf: &[u8],
     target: A,
 ) -> std::io::Result<usize> {
+    // When a cluster key is set, frame the datagram once as `tag || payload` and reuse the framed
+    // buffer across retries. Without a key the wire bytes are identical to the unauthenticated
+    // behavior.
+    let framed = key.map(|k| auth::seal(k, buf));
+    let wire: &[u8] = framed.as_deref().unwrap_or(buf);
     let mut res = Ok(0);
     for _ in 0..MAX_SENDTO_RETRIES {
-        res = socket.send_to(buf, &target).await;
+        res = socket.send_to(wire, &target).await;
         if res.is_ok() {
             break;
         }
@@ -342,19 +404,26 @@ async fn send_to_retry<A: ToSocketAddrs>(
 async fn send_messages_to<K: Serialize, V: Serialize>(
     messages: &[Message<K, V>],
     socket: Arc<UdpSocket>,
+    key: Option<&[u8; auth::KEY_LEN]>,
     peer: &SocketAddr,
     send_buf: &mut Vec<u8>,
 ) {
     debug!("sending {} messages to {peer}", messages.len());
+    // Reserve room for the authentication tag so the sealed datagram still fits a UDP payload.
+    let max_payload = if key.is_some() {
+        BUFFER_SIZE - auth::TAG_LEN
+    } else {
+        BUFFER_SIZE
+    };
     send_buf.clear();
     for message in messages {
         let last_size = send_buf.len();
         message
             .serialize(&mut Serializer::new(&mut *send_buf, DefaultOptions::new()))
             .unwrap();
-        if send_buf.len() > BUFFER_SIZE {
+        if send_buf.len() > max_payload {
             trace!("sending {} bytes to {peer}", last_size);
-            send_to_retry(&socket, &send_buf[..last_size], &peer)
+            send_to_retry(&socket, key, &send_buf[..last_size], &peer)
                 .await
                 .unwrap();
             trace!("sent {} bytes to {peer}", last_size);
@@ -362,7 +431,7 @@ async fn send_messages_to<K: Serialize, V: Serialize>(
         }
     }
     trace!("sending last {} bytes to {peer}", send_buf.len());
-    send_to_retry(&socket, send_buf, &peer).await.unwrap();
+    send_to_retry(&socket, key, send_buf, &peer).await.unwrap();
     trace!("sent last {} bytes to {peer}", send_buf.len());
 }
 
@@ -406,5 +475,67 @@ mod deadlock_regressions {
             flag.load(Ordering::SeqCst),
             "The pre-insert hook never ran to completion (likely deadlocked)"
         );
+    }
+}
+
+#[cfg(test)]
+mod auth_attack {
+    use std::time::Duration;
+
+    use bincode::{DefaultOptions, Serializer};
+    use chrono::{DateTime, TimeZone, Utc};
+    use serde::Serialize;
+    use tokio::net::UdpSocket;
+
+    use super::Message;
+    use crate::{auth, reconcile_store::Config, ReconcileStore};
+
+    /// Serialize the F3 attack payload: an `Update` with a year-9999 timestamp that, if merged,
+    /// would win against every legitimate write forever.
+    fn forged_update() -> Vec<u8> {
+        let far_future = Utc.with_ymd_and_hms(9999, 1, 1, 0, 0, 0).unwrap();
+        let message = Message::Update::<i32, (DateTime<Utc>, Option<String>)>((
+            0,
+            (far_future, Some("evil".to_string())),
+        ));
+        let mut buf = Vec::new();
+        message
+            .serialize(&mut Serializer::new(&mut buf, DefaultOptions::new()))
+            .unwrap();
+        buf
+    }
+
+    /// A node with a cluster key must drop forged datagrams (no tag, or wrong key) before
+    /// deserialization, so an attacker cannot poison it via last-write-wins.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn forged_datagram_is_ignored() {
+        let key = [0x42u8; auth::KEY_LEN];
+        let port = 8082;
+        let victim_addr = "127.0.0.48";
+        let config = Config::default()
+            .with_port(port)
+            .with_listen_addr(victim_addr.parse().unwrap())
+            .with_cluster_key(key);
+        let store = ReconcileStore::<i32, String>::new(config).await;
+        store.just_insert(0, "legit".to_string());
+        let task = tokio::spawn(store.clone().run());
+
+        let attacker = UdpSocket::bind("127.0.0.49:0").await.unwrap();
+        let target = format!("{victim_addr}:{port}");
+        let forged = forged_update();
+
+        // (a) forged update sent WITHOUT any authentication tag
+        attacker.send_to(&forged, &target).await.unwrap();
+        // (b) forged update sealed with the WRONG key
+        let wrong_key_sealed = auth::seal(&[0x99u8; auth::KEY_LEN], &forged);
+        attacker.send_to(&wrong_key_sealed, &target).await.unwrap();
+
+        // give the victim time to (not) process the forged datagrams
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        // the legitimate value must be untouched
+        assert_eq!(store.get(&0).as_deref(), Some(&"legit".to_string()));
+
+        task.abort();
     }
 }

--- a/src/reconcile_engine.rs
+++ b/src/reconcile_engine.rs
@@ -316,9 +316,14 @@ impl<
         // initiate the reconciliation protocol with all the known peers, and a random one
         for peer in peers {
             trace!("start_diff {} bytes to {peer}", send_buf.len());
-            send_to_retry(&self.socket, &self.authenticator, send_buf, (peer, self.port))
-                .await
-                .unwrap();
+            send_to_retry(
+                &self.socket,
+                &self.authenticator,
+                send_buf,
+                (peer, self.port),
+            )
+            .await
+            .unwrap();
         }
     }
 

--- a/src/reconcile_store.rs
+++ b/src/reconcile_store.rs
@@ -242,6 +242,13 @@ pub struct Config {
     pub port: u16,
     pub listen_addr: IpAddr,
     pub peer_net: IpNet,
+    /// Optional shared cluster secret enabling per-datagram MAC authentication.
+    ///
+    /// When `None` (the default), the protocol is **unauthenticated**: any host able to send a
+    /// UDP datagram to the port can forge updates and poison the cluster. When set, every node in
+    /// the cluster must use the **same** 32-byte key (and the same MAC backend feature). See
+    /// [`Config::with_cluster_key`].
+    pub cluster_key: Option<[u8; 32]>,
     // may include other options in the future: use_tls, tombstone_ttl, metrics, etc.
 }
 impl Default for Config {
@@ -250,6 +257,7 @@ impl Default for Config {
             port: 0,
             listen_addr: "127.0.0.1".parse().unwrap(),
             peer_net: "127.0.0.1/8".parse().unwrap(),
+            cluster_key: None,
         }
     }
 }
@@ -266,6 +274,21 @@ impl Config {
         self.peer_net = peer_net;
         self
     }
+
+    /// Enable per-datagram MAC authentication using a shared 32-byte cluster secret.
+    ///
+    /// Every outgoing datagram is then framed with a keyed MAC over its payload, and every
+    /// incoming datagram is verified **before** deserialization; datagrams with a missing or
+    /// invalid tag are silently dropped. This closes the unauthenticated last-write-wins
+    /// poisoning vector.
+    ///
+    /// All nodes in the same cluster **must** share the identical key and be built with the same
+    /// MAC backend feature (`mac-blake3`, the default, or `mac-hmac`). Without a key, the store
+    /// logs a loud warning at startup and runs unauthenticated.
+    pub fn with_cluster_key(mut self, key: [u8; 32]) -> Self {
+        self.cluster_key = Some(key);
+        self
+    }
 }
 
 #[cfg(test)]
@@ -280,6 +303,7 @@ mod reconcile_store_tests {
             port: 8080,
             listen_addr: "127.0.0.45".parse().unwrap(),
             peer_net: "127.0.0.1/8".parse().unwrap(),
+            cluster_key: None,
         };
         let store = ReconcileStore::<i32, i32>::new(config)
             .await

--- a/tests/service.rs
+++ b/tests/service.rs
@@ -128,3 +128,50 @@ async fn test() {
     task2.abort();
     task1.abort();
 }
+
+/// Two nodes sharing the same cluster key must still converge, proving that authenticated
+/// datagrams round-trip end-to-end through the MAC layer.
+#[tokio::test(flavor = "multi_thread")]
+async fn authenticated_nodes_converge() {
+    let port = 8081;
+    let peer_net = "127.0.0.1/8".parse().unwrap();
+    let addr1 = "127.0.0.46".parse().unwrap();
+    let addr2 = "127.0.0.47".parse().unwrap();
+    let key = [0x42u8; 32];
+    let cfg1 = Config::default()
+        .with_port(port)
+        .with_listen_addr(addr1)
+        .with_peer_net(peer_net)
+        .with_cluster_key(key);
+    let cfg2 = Config::default()
+        .with_port(port)
+        .with_listen_addr(addr2)
+        .with_peer_net(peer_net)
+        .with_cluster_key(key);
+
+    let mut rng = rand::rngs::StdRng::seed_from_u64(42);
+    let key_values: [(String, String); 1000] = core::array::from_fn(|_| {
+        let key: String = Alphanumeric.sample_string(&mut rng, 100);
+        let value: String = Alphanumeric.sample_string(&mut rng, 100);
+        (key, value)
+    });
+
+    let store1 = ReconcileStore::new(cfg1).await.with_seed(addr2);
+    store1.insert_bulk(&key_values);
+    let start_hash = store1.fingerprint(..);
+    let store2 = ReconcileStore::new(cfg2).await.with_seed(addr1);
+    let task2 = tokio::spawn(store2.clone().run());
+    let task1 = tokio::spawn(store1.clone().run());
+
+    // store2 should receive all of store1's values across the authenticated channel
+    assert_until!(store2.fingerprint(..) == start_hash);
+
+    // a fresh incremental insert also propagates
+    let key = "auth-key".to_string();
+    let value = "authenticated value".to_string();
+    store2.insert(key.clone(), value.clone());
+    assert_until!(store1.get(&key).as_deref() == Some(&value));
+
+    task2.abort();
+    task1.abort();
+}


### PR DESCRIPTION
Closes #108

## Problem (finding F3)

The UDP reconciliation protocol performed **zero authentication or integrity checking**. Combined with last-write-wins over an **attacker-controlled timestamp** (the value is `(DateTime<Utc>, Option<V>)`), any host able to send a UDP datagram to the port could forge `Update((key, (year_9999, Some(evil))))` — winning against every legitimate write forever — or a forged tombstone (`None`) to delete keys. The poison then propagated cluster-wide via normal reconciliation, and UDP sources are spoofable, so the attack was anonymous.

## Approach

Add an **optional, feature-abstracted keyed MAC** over every datagram, verified **before** deserialization. Decisions were agreed up front with the maintainer:

- **Primitive:** keyed BLAKE3, abstracted behind a Cargo feature so an alternate backend can be swapped in.
- **Enforcement:** opt-in. No key ⇒ unchanged behavior + a loud startup warning. Key set ⇒ MAC mandatory on send/receive.
- **Scope:** per-datagram MAC only.

## Changes

- **`src/auth.rs`** (new): `tag` / `verify` / `seal` / `open`. Wire format is `tag(32) || payload` (tag first, so a fixed-size prefix is verified before any bincode parsing). Backend chosen via features — `mac-blake3` (default, keyed BLAKE3) or `mac-hmac` (HMAC-SHA256); selecting no backend is a `compile_error!`. BLAKE3 wins if both are enabled (keeps `--all-features` building).
- **`Config::with_cluster_key([u8; 32])`**: opt-in shared secret. `Config` stays `Copy`. No key ⇒ loud `warn!` at startup explaining the cluster runs unauthenticated.
- **Send:** sealing happens at the single `send_to_retry` chokepoint, covering both send paths; `send_messages_to`'s split threshold reserves room for the tag so sealed datagrams still fit the UDP payload limit. The unauthenticated path stays byte-for-byte identical.
- **Receive:** `handle_messages` verifies + strips the tag before constructing the deserializer; missing/invalid datagrams are dropped silently (trace-only, to avoid attacker-driven log flooding).

## Tests

- Unit tests for `tag`/`verify`/`seal`/`open` (roundtrip, tamper detection, wrong-key, too-short).
- `authenticated_nodes_converge`: two keyed nodes still reconcile end-to-end.
- `forged_datagram_is_ignored`: **attack simulation** — a keyed node ignores a forged year-9999 `Update` sent without a tag and with the wrong key; the legitimate value is untouched.
- All pre-existing tests pass unchanged (proving auth is optional).

Verified: `cargo test`; `cargo build --no-default-features --features mac-hmac`; `cargo clippy --all-targets` (no new warnings); `RUSTFLAGS=-Dwarnings` and `RUSTDOCFLAGS=-Dwarnings` builds.

## Docs

README "Security model" section (loud warning + opt-in mitigation + scope), rustdoc on `Config`/`with_cluster_key`, a crate-level note, and an F3 status update in `REVIEW.md`.

## Out of scope (tracked separately)

Peer allow-list; confidentiality / encryption (#96); the physical-clock LWW concern (F5). With a key configured, the **external** attacker-controlled-timestamp vector is closed.

https://claude.ai/code/session_01Ts61HkpAP3eZgGeYwTzkYB

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ts61HkpAP3eZgGeYwTzkYB)_