### PR TITLE
Gate tombstone GC on causal stability (fixes #109)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+*.log

--- a/src/reconcilable.rs
+++ b/src/reconcilable.rs
@@ -25,3 +25,20 @@ impl<V: Clone> Reconcilable for (DateTime<Utc>, V) {
         }
     }
 }
+
+/// Marks values that may represent a deletion (a *tombstone*).
+///
+/// The reconciliation engine uses this to decide which applied updates require
+/// causal-stability tracking before the corresponding key can be garbage-collected.
+/// See the tombstone-resurrection discussion on
+/// [`ReconcileStore`](crate::reconcile_store::ReconcileStore).
+pub trait MaybeTombstone {
+    /// Returns `true` if this value is a deletion marker (tombstone).
+    fn is_tombstone(&self) -> bool;
+}
+
+impl<V> MaybeTombstone for (DateTime<Utc>, Option<V>) {
+    fn is_tombstone(&self) -> bool {
+        self.1.is_none()
+    }
+}

--- a/src/reconcile_engine.rs
+++ b/src/reconcile_engine.rs
@@ -9,9 +9,10 @@
 //! Provides the [`ReconcileEngine`], the inner layer of the [`ReconcileStore`](crate::reconcile_store::ReconcileStore)
 //! that handles communication between instances at the network level.
 
-use std::collections::HashMap;
+use std::collections::hash_map::DefaultHasher;
+use std::collections::{HashMap, HashSet};
 use std::fmt::Debug;
-use std::hash::Hash;
+use std::hash::{Hash, Hasher};
 use std::net::{IpAddr, SocketAddr};
 use std::ops::RangeBounds;
 use std::sync::Arc;
@@ -30,7 +31,7 @@ use tracing::{debug, trace, warn};
 use crate::diff::HashRangeQueryable;
 use crate::diff::{Diffable, HashSegment};
 use crate::gen_ip::gen_ip;
-use crate::reconcilable::Reconcilable;
+use crate::reconcilable::{MaybeTombstone, Reconcilable};
 use crate::reconcile_store::Config;
 use crate::HRTree;
 
@@ -41,6 +42,18 @@ const PEER_EXPIRATION: Duration = Duration::from_secs(60);
 const MAX_SENDTO_RETRIES: u32 = 4;
 
 type PreInsertCallback<K, V> = Box<dyn Send + Sync + Fn(&K, &V)>;
+
+/// Compute a deterministic, cross-node version token for a value.
+///
+/// Used to acknowledge a *specific* version of a tombstone across replicas: a peer
+/// acknowledges the exact value it holds, so a stale acknowledgment for an older
+/// tombstone cannot authorize GC of a newer one. [`DefaultHasher::new`] uses fixed
+/// keys, so the same value hashes identically on every node.
+pub(crate) fn version_hash<V: Hash>(value: &V) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    value.hash(&mut hasher);
+    hasher.finish()
+}
 
 /// The internal reconciliation engine at the network level.
 /// This struct does not handle removals, which are managed by the external layer.
@@ -53,6 +66,16 @@ pub(crate) struct ReconcileEngine<K, V> {
     rng: Arc<RwLock<StdRng>>,
     pub(crate) peers: Arc<RwLock<HashMap<IpAddr, Instant>>>,
     pub(crate) pre_insert: Arc<RwLock<PreInsertCallback<K, V>>>,
+    /// Monotonic set of every peer this node has ever exchanged messages with.
+    ///
+    /// Unlike [`peers`](Self::peers), entries are never expired automatically: a tombstone
+    /// must be acknowledged by every member (or the member explicitly decommissioned) before
+    /// it can be garbage-collected. This is what gates tombstone GC on *causal stability* and
+    /// prevents a peer that is partitioned for longer than the peer-expiration window from
+    /// resurrecting a deleted value on its return.
+    pub(crate) members: Arc<RwLock<HashSet<IpAddr>>>,
+    /// Per-tombstone acknowledgments: `key -> (peer -> version token of the tombstone it holds)`.
+    pub(crate) tombstone_acks: Arc<RwLock<HashMap<K, HashMap<IpAddr, u64>>>>,
 }
 
 impl<K, V> Clone for ReconcileEngine<K, V> {
@@ -65,6 +88,8 @@ impl<K, V> Clone for ReconcileEngine<K, V> {
             rng: self.rng.clone(),
             peers: self.peers.clone(),
             pre_insert: self.pre_insert.clone(),
+            members: self.members.clone(),
+            tombstone_acks: self.tombstone_acks.clone(),
         }
     }
 }
@@ -78,6 +103,10 @@ enum Message<K: Serialize, V: Serialize> {
     /// Provides an individual key-value pair when the protocol
     /// has identified that it differs on the two instances
     Update((K, V)),
+    /// Acknowledges that the sender now holds the tombstone for the given key with the
+    /// given version token (see [`version_hash`]). Enables causal-stability-gated
+    /// tombstone garbage collection on the receiver.
+    Ack((K, u64)),
 }
 
 impl<
@@ -85,6 +114,7 @@ impl<
         V: Clone
             + DeserializeOwned
             + Hash
+            + MaybeTombstone
             + PartialEq
             + Reconcilable
             + Send
@@ -107,6 +137,8 @@ impl<
             rng: Arc::new(RwLock::new(StdRng::from_entropy())),
             peers: Arc::new(RwLock::new(HashMap::new())),
             pre_insert: Arc::new(RwLock::new(Box::new(|_, _| {}))),
+            members: Arc::new(RwLock::new(HashSet::new())),
+            tombstone_acks: Arc::new(RwLock::new(HashMap::new())),
         }
     }
 
@@ -208,6 +240,9 @@ impl<
                     let now = Instant::now();
                     let addr = peer.ip();
                     self.peers.write().insert(addr, now);
+                    // Record the peer as a permanent member so that its acknowledgment is
+                    // required before any tombstone can be garbage-collected (causal stability).
+                    self.members.write().insert(addr);
                 }
             }
         }
@@ -254,6 +289,7 @@ impl<
         trace!("received {} bytes from {peer}", size);
         let mut in_comparison = Vec::new();
         let mut updates = Vec::new();
+        let mut acks: Vec<(K, u64)> = Vec::new();
         let mut deserializer = Deserializer::from_slice(&recv_buf[..size], DefaultOptions::new());
         // read messages in buffer
         loop {
@@ -268,6 +304,36 @@ impl<
                 }
                 Ok(Message::ComparisonItem(segment)) => in_comparison.push(segment),
                 Ok(Message::Update(update)) => updates.push(update),
+                Ok(Message::Ack(ack)) => acks.push(ack),
+            }
+        }
+        // record tombstone acknowledgments received from the peer
+        if !acks.is_empty() {
+            let peer_ip = peer.ip();
+            // Reciprocate acks for tombstones we also hold, so that the deletion originator
+            // (which never receives the tombstone as an inbound update, hence is never acked
+            // by the peer) can still reach causal stability. The `already`-guard bounds this
+            // to at most one extra round-trip and prevents an infinite ack ping-pong.
+            let mut reciprocal_acks = Vec::new();
+            {
+                let map_guard = self.map.read();
+                let mut guard = self.tombstone_acks.write();
+                for (key, version) in acks {
+                    let entry = guard.entry(key.clone()).or_default();
+                    let already = entry.get(&peer_ip) == Some(&version);
+                    entry.insert(peer_ip, version);
+                    if !already {
+                        let holds_same_tombstone = map_guard
+                            .get(&key)
+                            .is_some_and(|v| v.is_tombstone() && version_hash(v) == version);
+                        if holds_same_tombstone {
+                            reciprocal_acks.push(Message::Ack::<K, V>((key, version)));
+                        }
+                    }
+                }
+            }
+            if !reciprocal_acks.is_empty() {
+                send_messages_to(&reciprocal_acks, Arc::clone(&self.socket), &peer, send_buf).await;
             }
         }
         // handle messages
@@ -303,22 +369,77 @@ impl<
         }
         if !updates.is_empty() {
             debug!("received {} updates", updates.len());
-            let mut guard = self.map.write();
-            for (k, remote_v) in updates {
-                match guard.get(&k) {
-                    Some(local_v) => {
-                        let merged_v = local_v.reconcile(&remote_v);
-                        if merged_v != *local_v {
-                            (self.pre_insert.read())(&k, &merged_v);
-                            guard.insert(k, merged_v);
+            // Tombstones we now hold as a result of these updates, to be acknowledged back to
+            // the peer so it can eventually garbage-collect them once causally stable.
+            let mut acks_to_send = Vec::new();
+            {
+                let mut guard = self.map.write();
+                for (k, remote_v) in updates {
+                    let tombstone_version = match guard.get(&k) {
+                        Some(local_v) => {
+                            let merged_v = local_v.reconcile(&remote_v);
+                            if merged_v != *local_v {
+                                (self.pre_insert.read())(&k, &merged_v);
+                                let version =
+                                    merged_v.is_tombstone().then(|| version_hash(&merged_v));
+                                guard.insert(k.clone(), merged_v);
+                                version
+                            } else {
+                                // We already hold an equal-or-newer value; still acknowledge it
+                                // if it is the same tombstone, so the peer learns we have it.
+                                local_v.is_tombstone().then(|| version_hash(local_v))
+                            }
                         }
-                    }
-                    None => {
-                        (self.pre_insert.read())(&k, &remote_v);
-                        guard.insert(k, remote_v);
+                        None => {
+                            (self.pre_insert.read())(&k, &remote_v);
+                            let version = remote_v.is_tombstone().then(|| version_hash(&remote_v));
+                            guard.insert(k.clone(), remote_v);
+                            version
+                        }
+                    };
+                    if let Some(version) = tombstone_version {
+                        acks_to_send.push(Message::Ack::<K, V>((k, version)));
                     }
                 }
             }
+            if !acks_to_send.is_empty() {
+                send_messages_to(&acks_to_send, Arc::clone(&self.socket), &peer, send_buf).await;
+            }
+        }
+    }
+
+    /// Returns `true` if the tombstone for `key` with the given version token has been
+    /// acknowledged by every member (causal stability) and is therefore safe to
+    /// garbage-collect.
+    ///
+    /// When no other replica is known, there is nothing that could resurrect the value, so
+    /// GC is allowed.
+    pub(crate) fn is_tombstone_stable(&self, key: &K, version: u64) -> bool {
+        let members = self.members.read();
+        if members.is_empty() {
+            return true;
+        }
+        let acks = self.tombstone_acks.read();
+        let Some(key_acks) = acks.get(key) else {
+            return false;
+        };
+        members
+            .iter()
+            .all(|peer| key_acks.get(peer) == Some(&version))
+    }
+
+    /// Drop the acknowledgment bookkeeping for a key once its tombstone has been collected.
+    pub(crate) fn forget_tombstone(&self, key: &K) {
+        self.tombstone_acks.write().remove(key);
+    }
+
+    /// Permanently remove a peer from the membership set so that tombstones are no longer held
+    /// back waiting for its acknowledgment. Use when a replica is decommissioned or will never
+    /// return. Also clears any acknowledgments it had recorded.
+    pub(crate) fn decommission_peer(&self, peer: IpAddr) {
+        self.members.write().remove(&peer);
+        for key_acks in self.tombstone_acks.write().values_mut() {
+            key_acks.remove(&peer);
         }
     }
 }
@@ -406,5 +527,94 @@ mod deadlock_regressions {
             flag.load(Ordering::SeqCst),
             "The pre-insert hook never ran to completion (likely deadlocked)"
         );
+    }
+}
+
+#[cfg(test)]
+mod causal_stability {
+    use std::net::IpAddr;
+
+    use chrono::{DateTime, Utc};
+
+    use crate::reconcile_engine::{version_hash, ReconcileEngine};
+    use crate::reconcile_store::Config;
+
+    type Tombstoned = (DateTime<Utc>, Option<i32>);
+
+    async fn engine(addr: &str) -> ReconcileEngine<i32, Tombstoned> {
+        let config = Config::default()
+            .with_port(8080)
+            .with_listen_addr(addr.parse().unwrap());
+        ReconcileEngine::new(config).await
+    }
+
+    #[tokio::test]
+    async fn tombstone_not_stable_until_all_members_ack() {
+        let eng = engine("127.0.0.60").await;
+        let peer_a: IpAddr = "127.0.0.61".parse().unwrap();
+        let peer_b: IpAddr = "127.0.0.62".parse().unwrap();
+        let key = 7;
+        let tombstone: Tombstoned = (Utc::now(), None);
+        let version = version_hash(&tombstone);
+
+        // No member known yet: nothing could resurrect the value, so GC is allowed.
+        assert!(eng.is_tombstone_stable(&key, version));
+
+        // Two members known, neither has acknowledged: not stable.
+        eng.members.write().insert(peer_a);
+        eng.members.write().insert(peer_b);
+        assert!(!eng.is_tombstone_stable(&key, version));
+
+        // Only one member acknowledges: still not stable.
+        eng.tombstone_acks
+            .write()
+            .entry(key)
+            .or_default()
+            .insert(peer_a, version);
+        assert!(!eng.is_tombstone_stable(&key, version));
+
+        // A stale acknowledgment (wrong version) from the other member does not count.
+        eng.tombstone_acks
+            .write()
+            .entry(key)
+            .or_default()
+            .insert(peer_b, version.wrapping_add(1));
+        assert!(!eng.is_tombstone_stable(&key, version));
+
+        // The correct acknowledgment from every member makes it stable.
+        eng.tombstone_acks
+            .write()
+            .entry(key)
+            .or_default()
+            .insert(peer_b, version);
+        assert!(eng.is_tombstone_stable(&key, version));
+    }
+
+    #[tokio::test]
+    async fn decommission_releases_a_silent_peer() {
+        let eng = engine("127.0.0.63").await;
+        let live: IpAddr = "127.0.0.64".parse().unwrap();
+        let gone: IpAddr = "127.0.0.65".parse().unwrap();
+        let key = 9;
+        let tombstone: Tombstoned = (Utc::now(), None);
+        let version = version_hash(&tombstone);
+
+        eng.members.write().insert(live);
+        eng.members.write().insert(gone);
+        eng.tombstone_acks
+            .write()
+            .entry(key)
+            .or_default()
+            .insert(live, version);
+        // `gone` never acknowledges: not stable.
+        assert!(!eng.is_tombstone_stable(&key, version));
+
+        // Decommissioning the silent peer makes the tombstone stable.
+        eng.decommission_peer(gone);
+        assert!(eng.is_tombstone_stable(&key, version));
+
+        // Forgetting the tombstone clears its bookkeeping.
+        eng.forget_tombstone(&key);
+        assert!(eng.tombstone_acks.read().get(&key).is_none());
     }
 }

--- a/src/reconcile_store.rs
+++ b/src/reconcile_store.rs
@@ -20,7 +20,7 @@ use ipnet::IpNet;
 use parking_lot::{MappedRwLockReadGuard, RwLockReadGuard};
 use serde::{de::DeserializeOwned, Serialize};
 
-use crate::reconcile_engine::ReconcileEngine;
+use crate::reconcile_engine::{version_hash, ReconcileEngine};
 use crate::timeout_wheel::TimeoutWheel;
 
 const TOMBSTONE_CLEARING: Duration = Duration::from_secs(1);
@@ -205,10 +205,43 @@ impl<
         self.engine.start_reconciliation(&mut buf).await;
     }
 
+    /// Permanently forget a peer (e.g. a replica that has been decommissioned and will never
+    /// return), so that tombstones are no longer held back waiting for its acknowledgment
+    /// before garbage collection.
+    ///
+    /// This is the escape hatch for the causal-stability contract: a tombstone is normally
+    /// retained until every peer this node has ever communicated with has acknowledged it.
+    /// A replica that is permanently gone must be decommissioned, otherwise its tombstones are
+    /// retained forever.
+    pub fn forget_peer(&self, peer: IpAddr) {
+        self.engine.decommission_peer(peer);
+    }
+
+    /// Garbage-collect tombstones, **gated on causal stability**.
+    ///
+    /// A tombstone is removed from the map only once it is both older than the configured
+    /// timeout *and* acknowledged by every replica this node has ever communicated with (or
+    /// those replicas have been decommissioned via [`forget_peer`](Self::forget_peer)). This
+    /// prevents the classic tombstone-resurrection hazard: a replica partitioned for longer
+    /// than the timeout cannot resurrect a deleted value on its return, because the tombstone
+    /// is kept until that replica has seen it.
     async fn clear_expired_tombstones(&self) {
         loop {
-            while let Some(value) = self.tombstones.pop_expired() {
-                self.engine.map.write().remove(&value);
+            for key in self.tombstones.expired() {
+                // Version token of the tombstone actually stored, matched against peer acks.
+                let version = self.engine.map.read().get(&key).map(version_hash);
+                let Some(version) = version else {
+                    // The key is no longer present (overwritten or already removed): stop
+                    // tracking it.
+                    self.tombstones.remove(&key);
+                    continue;
+                };
+                if self.engine.is_tombstone_stable(&key, version) {
+                    self.tombstones.remove(&key);
+                    self.engine.map.write().remove(&key);
+                    self.engine.forget_tombstone(&key);
+                }
+                // Otherwise keep the tombstone and re-check on a later iteration.
             }
             tokio::time::sleep(TOMBSTONE_CLEARING).await;
         }
@@ -291,7 +324,8 @@ mod reconcile_store_tests {
         store.remove(&0);
         tokio::time::sleep(Duration::from_millis(10)).await; // await its expiration
                                                              // The tombstone should be expired by now
-        assert_eq!(store.tombstones.pop_expired(), Some(0));
+        assert_eq!(store.tombstones.expired(), vec![0]);
+        assert_eq!(store.tombstones.remove(&0), Some(0));
         assert_eq!(store.tombstones.remove(&0), None);
 
         task.abort();

--- a/src/timeout_wheel.rs
+++ b/src/timeout_wheel.rs
@@ -43,17 +43,20 @@ impl<T: Clone + Hash + std::cmp::Eq> TimeoutWheel<T> {
         self.map.write().unwrap().insert(e, instant);
     }
 
-    pub fn pop_expired(&self) -> Option<T> {
+    /// Return all entries whose timeout has elapsed, **without removing them**.
+    ///
+    /// Used by causal-stability-gated tombstone GC: a tombstone may be old enough to
+    /// expire by wall-clock age but must be retained until every replica has acknowledged
+    /// it, so the caller needs to peek expired candidates without dropping the tracking.
+    pub fn expired(&self) -> Vec<T> {
+        let now = Utc::now();
         self.wheel
-            .write()
+            .read()
             .unwrap()
-            .first_entry()
-            .filter(|entry| *entry.key() + self.timeout < Utc::now())
-            .map(|entry| {
-                let value = entry.remove();
-                self.map.write().unwrap().remove(&value);
-                value
-            })
+            .iter()
+            .take_while(|(instant, _)| **instant + self.timeout < now)
+            .map(|(_, value)| value.clone())
+            .collect()
     }
 
     pub fn remove(&self, value: &T) -> Option<T> {

--- a/tests/service.rs
+++ b/tests/service.rs
@@ -128,3 +128,135 @@ async fn test() {
     task2.abort();
     task1.abort();
 }
+
+/// Regression test for issue #109: a tombstone must not be garbage-collected while a replica
+/// that has not acknowledged it is still a member (causal stability), and decommissioning that
+/// replica must release the tombstone for GC.
+#[tokio::test(flavor = "multi_thread")]
+async fn tombstone_is_retained_until_peer_acknowledges() {
+    let port = 8080;
+    let peer_net = "127.0.0.1/8".parse().unwrap();
+    let addr1 = "127.0.0.72".parse().unwrap();
+    let addr2 = "127.0.0.73".parse().unwrap();
+    let cfg1 = Config::default()
+        .with_port(port)
+        .with_listen_addr(addr1)
+        .with_peer_net(peer_net);
+    let cfg2 = Config::default()
+        .with_port(port)
+        .with_listen_addr(addr2)
+        .with_peer_net(peer_net);
+
+    // Aggressive wall-clock expiry so that, without causal-stability gating, the tombstone
+    // would be GC'd almost immediately.
+    let store1 = ReconcileStore::<i32, i32>::new(cfg1)
+        .await
+        .with_seed(addr2)
+        .with_tombstone_timeout(Duration::from_millis(50));
+    let store2 = ReconcileStore::<i32, i32>::new(cfg2)
+        .await
+        .with_seed(addr1)
+        .with_tombstone_timeout(Duration::from_millis(50));
+
+    let task1 = tokio::spawn(store1.clone().run());
+    let task2 = tokio::spawn(store2.clone().run());
+
+    // Establish mutual membership by exchanging a value in each direction.
+    store1.insert(1, 11);
+    assert_until!(store2.get(&1).as_deref() == Some(&11));
+    store2.insert(2, 22);
+    assert_until!(store1.get(&2).as_deref() == Some(&22));
+
+    // "Partition" store2: stop processing its network/GC but keep its in-memory data.
+    task2.abort();
+
+    // Delete key 1 on store1; store2 (a member) cannot acknowledge while partitioned.
+    store1.remove(&1);
+    assert!(store1.get(&1).is_none());
+    let hash_with_tombstone = store1.fingerprint(..);
+
+    // Wait well past both the tombstone timeout (50 ms) and the GC scan period (1 s): the
+    // tombstone must still be present because store2 has not acknowledged it.
+    tokio::time::sleep(Duration::from_millis(1500)).await;
+    assert_eq!(
+        store1.fingerprint(..),
+        hash_with_tombstone,
+        "tombstone was garbage-collected before the partitioned peer acknowledged it (resurrection hazard)"
+    );
+
+    // Decommission the silent peer: the tombstone is now causally stable and may be GC'd.
+    store1.forget_peer(addr2);
+    tokio::time::sleep(Duration::from_millis(1500)).await;
+    assert_ne!(
+        store1.fingerprint(..),
+        hash_with_tombstone,
+        "tombstone was not collected after the silent peer was decommissioned"
+    );
+
+    task1.abort();
+}
+
+/// Regression test for issue #109: a value deleted while a replica is partitioned must not be
+/// resurrected when that replica returns with the stale value.
+#[tokio::test(flavor = "multi_thread")]
+async fn deleted_value_is_not_resurrected_by_returning_peer() {
+    let port = 8080;
+    let peer_net = "127.0.0.1/8".parse().unwrap();
+    let addr1 = "127.0.0.70".parse().unwrap();
+    let addr2 = "127.0.0.71".parse().unwrap();
+    let cfg1 = Config::default()
+        .with_port(port)
+        .with_listen_addr(addr1)
+        .with_peer_net(peer_net);
+    let cfg2 = Config::default()
+        .with_port(port)
+        .with_listen_addr(addr2)
+        .with_peer_net(peer_net);
+
+    let store1 = ReconcileStore::<i32, i32>::new(cfg1)
+        .await
+        .with_seed(addr2)
+        .with_tombstone_timeout(Duration::from_millis(50));
+    let store2 = ReconcileStore::<i32, i32>::new(cfg2)
+        .await
+        .with_seed(addr1)
+        .with_tombstone_timeout(Duration::from_millis(50));
+
+    let task1 = tokio::spawn(store1.clone().run());
+    let task2 = tokio::spawn(store2.clone().run());
+
+    // Both replicas hold key 1 = v, and become members of each other.
+    store1.insert(1, 11);
+    assert_until!(store2.get(&1).as_deref() == Some(&11));
+    store2.insert(2, 22);
+    assert_until!(store1.get(&1).as_deref() == Some(&11));
+    assert_until!(store1.get(&2).as_deref() == Some(&22));
+
+    // Partition store2 while it still holds the stale value 1 = 11.
+    task2.abort();
+    assert_eq!(store2.get(&1).as_deref(), Some(&11));
+
+    // Delete key 1 on store1. The tombstone is held back (store2 has not acknowledged it),
+    // even across many GC scans.
+    store1.remove(&1);
+    tokio::time::sleep(Duration::from_millis(1500)).await;
+    assert!(store1.get(&1).is_none());
+
+    // store2 returns with the stale value and reconciles.
+    let task2 = tokio::spawn(store2.clone().run());
+
+    // The deletion propagates to store2; crucially, the stale value never resurrects on store1.
+    assert_until!(store2.get(&1).is_none());
+    tokio::time::sleep(Duration::from_millis(300)).await;
+    assert!(
+        store1.get(&1).is_none(),
+        "deleted value was resurrected by the returning partitioned peer"
+    );
+    assert!(
+        store2.get(&1).is_none(),
+        "deletion did not reach the returning peer"
+    );
+
+    task1.abort();
+    task2.abort();
+}


### PR DESCRIPTION
## Context

Closes #109.

*Tombstones* (deletion markers `(timestamp, None)`) were garbage-collected (GC) purely on their **local wall-clock age** (`clear_expired_tombstones` → `map.remove`), with no guarantee that every replica had seen the deletion. As a result, a replica partitioned for longer than the tombstone timeout **resurrects the deleted value cluster-wide** on its return, via the engine's `None => insert(remote_v)` branch. This is the classic `gc_grace_seconds` hazard (Dynamo/Cassandra), but at 60 s instead of 10 days.

## Approach: causal-stability-gated GC

As recommended in the issue, a tombstone is now removed from the map **only if** it is both older than the configured timeout **and causally stable** — i.e. acknowledged by every replica this node has ever communicated with.

### Key changes

- **`Message::Ack((key, version))`**: when applying an update, a node acknowledges the tombstone version it now holds back to the sender. Acks are reciprocated once (bounded, no infinite ping-pong) so the **deletion originator** — which never receives the tombstone as an inbound update — also converges.
- **`version_hash`**: a deterministic, cross-node token of the stored tombstone. A stale ack for an older tombstone therefore cannot authorize GC of a newer one.
- **`members`**: a monotonic set of every peer ever seen (never auto-expired, unlike `peers`), used as the quorum for causal stability. This closes the report's scenario where a peer partitioned for longer than `PEER_EXPIRATION` was forgotten and then resurrected the value.
- **`forget_peer`**: escape hatch to decommission a permanently-gone replica, so its tombstones are not retained forever.
- **`TimeoutWheel::expired`**: peeks expired entries **without removing them**, so GC can defer not-yet-stable tombstones instead of dropping the tracking.

### `MaybeTombstone` trait

Adds a small `MaybeTombstone` trait (implemented for `(DateTime<Utc>, Option<V>)`) that lets the engine distinguish a tombstone from a live value without coupling the engine to the store's concrete value type.

## Tests

- **Unit** (`reconcile_engine::causal_stability`): the stability predicate (no members → GC allowed; members without ack → blocked; partial ack or stale version → blocked; full ack → stable) and decommissioning.
- **Integration** (`tests/service.rs`):
  - `tombstone_is_retained_until_peer_acknowledges`: the tombstone survives well past the expiry timeout while the partitioned peer has not acknowledged it, then is collected after `forget_peer`.
  - `deleted_value_is_not_resurrected_by_returning_peer`: reproduces the issue's timeline (deletion during partition, peer returns with the stale value) and asserts **no resurrection**.

## Checks

- `cargo fmt -- --check` ✅
- `cargo clippy --all -- -D warnings` ✅
- `cargo test --all` ✅

## Notes / possible follow-ups

- The causal-stability contract means a permanently-departed replica's tombstones are retained until it is explicitly decommissioned (`forget_peer`) — expected and documented behavior.
- Tombstone persistence (no-persistence finding / F15) is out of scope here: a restart still loses in-memory state. Tracked separately in #122.
- Physical-clock LWW under skew (F5) is also out of scope; tracked in #110.

https://claude.ai/code/session_01WYsY1AsBTTKZ3jK1B9BaPj