### PR TITLE
Harden diff_round against crafted HashSegment bounds (#112)

### DIFF
--- a/src/diff.rs
+++ b/src/diff.rs
@@ -12,6 +12,7 @@
 use std::ops::{Bound, RangeBounds};
 
 use serde::{Deserialize, Serialize};
+use tracing::debug;
 
 /// Provides the necessary methods to be able
 /// to efficiently determine and compare
@@ -92,17 +93,41 @@ impl<K: Clone, T: HashRangeQueryable<Key = K>> Diffable for T {
             let HashSegment { range, hash, size } = segment;
             let local_hash = self.hash(&range);
             let (start_bound, end_bound) = range;
+            // `HashSegment` derives `Deserialize` and is fed straight from the wire
+            // (`reconcile_engine`), with no validation. A crafted or version-mismatched peer
+            // can therefore send bound shapes this engine never emits. Our protocol only
+            // produces `Included`/`Unbounded` start bounds and `Excluded`/`Unbounded` end
+            // bounds (see `start_diff` and the segments pushed below). Rather than reaching
+            // `unimplemented!()` — a remote-triggerable panic that would kill the
+            // reconciliation task (issue #112) — we drop any other bound shape and move on.
             let start_index = match start_bound.as_ref() {
                 Bound::Unbounded => 0,
                 Bound::Included(key) => self.insertion_position(key),
-                Bound::Excluded(_) => unimplemented!(),
+                Bound::Excluded(_) => {
+                    debug!("dropping segment with unsupported excluded start bound");
+                    continue;
+                }
             };
             let end_index = match end_bound.as_ref() {
                 Bound::Unbounded => self.len(),
-                Bound::Included(_) => unimplemented!(),
                 Bound::Excluded(key) => self.insertion_position(key),
+                Bound::Included(_) => {
+                    debug!("dropping segment with unsupported included end bound");
+                    continue;
+                }
             };
-            let local_size = end_index - start_index;
+            // A crafted segment can also carry an inverted or out-of-order range
+            // (`start_index > end_index`, e.g. `Included(100)..Excluded(5)`). That would
+            // underflow `end_index - start_index` (panic in debug, wrap to a huge `usize`
+            // in release) and then index out of bounds in `key_at`. Drop such segments
+            // instead of trusting the arithmetic.
+            let local_size = match end_index.checked_sub(start_index) {
+                Some(local_size) => local_size,
+                None => {
+                    debug!("dropping segment with inverted range");
+                    continue;
+                }
+            };
             // NOTE: decisions about emptiness and equality are made on the exact
             // `size`/`local_size`, never on `hash`/`local_hash`. A range fingerprint
             // is an XOR of per-element hashes, so a *non-empty* range can legitimately
@@ -167,5 +192,127 @@ impl<K: Clone, T: HashRangeQueryable<Key = K>> Diffable for T {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Minimal in-memory store over sorted, distinct `i32` keys implementing
+    /// [`HashRangeQueryable`]. The blanket impl above gives us [`Diffable`] for free, so we
+    /// can drive crafted [`HashSegment`]s straight through [`diff_round`] — the code path a
+    /// hostile peer reaches over the network. Living in the same module, the test can build
+    /// the otherwise-private `HashSegment` directly.
+    struct MockStore {
+        keys: Vec<i32>,
+    }
+
+    impl MockStore {
+        fn new(mut keys: Vec<i32>) -> Self {
+            keys.sort_unstable();
+            keys.dedup();
+            MockStore { keys }
+        }
+    }
+
+    impl HashRangeQueryable for MockStore {
+        type Key = i32;
+
+        fn hash<R: RangeBounds<i32>>(&self, range: &R) -> u64 {
+            self.keys
+                .iter()
+                .filter(|k| range.contains(k))
+                .fold(0, |acc, &k| {
+                    acc ^ (k as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15) | 1
+                })
+        }
+
+        fn insertion_position(&self, key: &i32) -> usize {
+            self.keys.partition_point(|k| k < key)
+        }
+
+        fn key_at(&self, index: usize) -> &i32 {
+            &self.keys[index]
+        }
+
+        fn len(&self) -> usize {
+            self.keys.len()
+        }
+    }
+
+    /// Run a single crafted segment through `diff_round` and return whatever it produced.
+    /// The point of these tests is that the call *returns* at all (no panic).
+    fn round(
+        store: &MockStore,
+        segment: HashSegment<i32>,
+    ) -> (Vec<HashSegment<i32>>, Vec<DiffRange<i32>>) {
+        let mut out_comparison = Vec::new();
+        let mut differences = Vec::new();
+        store.diff_round(vec![segment], &mut out_comparison, &mut differences);
+        (out_comparison, differences)
+    }
+
+    /// Issue #112: an `Excluded` start bound used to reach `unimplemented!()`. Both early
+    /// `hash`/`size` checks are bypassed (the range is non-empty so `local_hash != 0`, and
+    /// `size`/`hash` are chosen to differ), so control reaches the bound match. The segment
+    /// must be dropped, not panic.
+    #[test]
+    fn excluded_start_bound_is_dropped_not_panicking() {
+        let store = MockStore::new(vec![10, 20, 30]);
+        let segment = HashSegment {
+            range: (Bound::Excluded(0), Bound::Unbounded),
+            hash: 1,
+            size: 1,
+        };
+        let (out_comparison, differences) = round(&store, segment);
+        assert!(out_comparison.is_empty());
+        assert!(differences.is_empty());
+    }
+
+    /// Issue #112: an `Included` end bound used to reach `unimplemented!()`.
+    #[test]
+    fn included_end_bound_is_dropped_not_panicking() {
+        let store = MockStore::new(vec![10, 20, 30]);
+        let segment = HashSegment {
+            range: (Bound::Unbounded, Bound::Included(20)),
+            hash: 1,
+            size: 1,
+        };
+        let (out_comparison, differences) = round(&store, segment);
+        assert!(out_comparison.is_empty());
+        assert!(differences.is_empty());
+    }
+
+    /// Issue #112: an inverted range (`start_index > end_index`) used to underflow
+    /// `end_index - start_index` (panic in debug, huge `usize` then out-of-bounds `key_at`
+    /// in release). It must be dropped instead.
+    #[test]
+    fn inverted_range_is_dropped_not_panicking() {
+        let store = MockStore::new(vec![10, 20, 30]);
+        let segment = HashSegment {
+            // start_index = insertion_position(100) = 3, end_index = insertion_position(5) = 0
+            range: (Bound::Included(100), Bound::Excluded(5)),
+            hash: 1,
+            size: 1,
+        };
+        let (out_comparison, differences) = round(&store, segment);
+        assert!(out_comparison.is_empty());
+        assert!(differences.is_empty());
+    }
+
+    /// A well-formed segment from an empty peer over our whole, non-empty range must still be
+    /// recognised as a difference we owe — i.e. the validation guards do not swallow the
+    /// legitimate `(Unbounded, Unbounded)` shape the protocol actually uses.
+    #[test]
+    fn wellformed_segment_still_processed() {
+        let store = MockStore::new(vec![10, 20, 30]);
+        let segment = HashSegment {
+            range: (Bound::Unbounded, Bound::Unbounded),
+            hash: 0,
+            size: 0,
+        };
+        let (_out_comparison, differences) = round(&store, segment);
+        assert_eq!(differences, vec![(Bound::Unbounded, Bound::Unbounded)]);
     }
 }


### PR DESCRIPTION
## Summary

Fixes the second remote-DoS vector described in #112. `HashSegment` derives `Deserialize` and is fed straight from the network (`reconcile_engine.rs:269,280`) with no validation, so `diff_round` could be driven by a crafted or version-mismatched peer into:

- `unimplemented!()` on an `Excluded` start bound (`diff.rs:112`) or an `Included` end bound (`diff.rs:116`) → panic;
- an underflow of `end_index - start_index` on an inverted/out-of-order range (`diff.rs:119`) → panic in debug, wrap to a huge `usize` in release, then out-of-bounds `key_at`.

Either path panics and kills the reconciliation task (unauthenticated remote DoS, same task-death consequence as the malformed-packet issue #107).

## Changes

`src/diff.rs` — `diff_round`:
- **Unsupported bound shapes** (`Excluded` start / `Included` end) are now dropped with a `debug!` log + `continue` instead of `unimplemented!()`. The engine itself only ever emits `Included`/`Unbounded` starts and `Excluded`/`Unbounded` ends (see `start_diff` and the segments pushed within `diff_round`), so dropping other shapes is safe for our own protocol and never panics on a hostile peer.
- **Inverted ranges** are handled by computing `local_size` with `checked_sub`; `None` (i.e. `start_index > end_index`) is dropped rather than underflowing. The subsequent refinement branch already relied on `end_index >= start_index`, which is now guaranteed.
- Added a `#[cfg(test)]` module with a small `HashRangeQueryable` mock (the blanket impl gives `Diffable` for free, and same-module visibility lets the test build the otherwise-private `HashSegment`). Tests reproduce each former panic — excluded start, included end, inverted range — and assert the segments are dropped without panicking, plus a sanity test that the legitimate `Unbounded..Unbounded` shape is still processed into a difference.

## Note on `overflow-checks`

The issue also suggests enabling `overflow-checks = true` for defense in depth. I deliberately did **not** flip it globally on the release profile: for a network-facing task it converts any latent integer wrap into a panic — i.e. the very task-death DoS this change closes — so the targeted `checked_sub` guard at the validated boundary is the safer defense. Happy to add it if you'd prefer the broader net.

## Testing

- `cargo test` — all green (lib unit tests incl. 4 new, integration `diff`/`service` tests, doc-tests).
- `cargo clippy --lib` — no warnings from changed code.
- `cargo fmt --check` — clean.

Closes #112

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dbv7fUZ669c1Rx9wDKUhKe)_