### PR TITLE
Fix #113: remove stray println! in with_mut hot path + add property/convergence tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,10 +140,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "bitflags"
-version = "2.9.0"
+name = "bit-set"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bitflags"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "blake3"
@@ -408,6 +423,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -426,6 +463,18 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
 ]
 
 [[package]]
@@ -548,6 +597,12 @@ name = "libc"
 version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "lock_api"
@@ -713,6 +768,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand 0.9.4",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quote"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -722,14 +802,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -739,7 +835,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -748,7 +854,25 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.16",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -791,7 +915,8 @@ dependencies = [
  "ipnet",
  "once_cell",
  "parking_lot",
- "rand",
+ "proptest",
+ "rand 0.8.5",
  "range-cmp",
  "serde",
  "sha2",
@@ -846,10 +971,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
+name = "rustix"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -970,6 +1120,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.4",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "thread_local"
 version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1079,6 +1242,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1103,6 +1272,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "walkdir"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1117,6 +1295,15 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -1357,6 +1544,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ zeroize = { version = "1.7", optional = true, features = ["derive"] }
 [dev-dependencies]
 clap = { version = "4.4.6", features = ["derive"] }
 criterion = "0.5.1"
+proptest = "1.11.0"
 rand = "0.8.5"
 tokio = { version = "1.33.0", features = ["macros", "rt-multi-thread"] }
 tracing-subscriber = "0.3.17"

--- a/src/hrtree.rs
+++ b/src/hrtree.rs
@@ -312,7 +312,6 @@ impl<K: Hash + Ord, V: Hash> HRTree<K, V> {
                     node.hashes[index] = new_hash;
                     let diff_hash = old_hash ^ new_hash;
                     node.tree_hash ^= diff_hash;
-                    println!("{diff_hash}");
                     diff_hash
                 }
                 Err(index) => {

--- a/tests/fuzz_packets.rs
+++ b/tests/fuzz_packets.rs
@@ -1,0 +1,98 @@
+// Copyright 2023 Developers of the reconcile project.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Malformed-packet fuzzing of the receive loop (issue #113).
+//!
+//! A single malformed datagram from any host must never panic or kill the
+//! receive task — otherwise an unauthenticated remote could DoS the whole
+//! cluster. We run a store *without* a cluster key so that arbitrary bytes reach
+//! the bincode deserialization path (`handle_messages`), bombard it with random
+//! and deliberately-corrupt datagrams, and assert that the receive task stays
+//! alive and the local state is untouched.
+
+use std::time::Duration;
+
+use rand::{Rng, SeedableRng};
+use tokio::net::UdpSocket;
+
+use reconcile::{reconcile_store::Config, ReconcileStore};
+
+/// Generate a batch of adversarial payloads: pure random noise of varied
+/// lengths (including empty and larger-than-buffer), plus a few structured
+/// "almost valid" shapes (truncated length prefixes, huge declared lengths)
+/// that tend to trip naive bincode decoders.
+fn malformed_payloads(seed: u64) -> Vec<Vec<u8>> {
+    let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
+    let mut payloads = Vec::new();
+
+    // Random noise across a wide range of sizes (0 .. a few KB to exceed the
+    // receive buffer and exercise the oversized-datagram branch too).
+    for _ in 0..200 {
+        let len = rng.gen_range(0..4096);
+        let mut buf = vec![0u8; len];
+        rng.fill(&mut buf[..]);
+        payloads.push(buf);
+    }
+
+    // All-zero and all-one buffers of various sizes.
+    for len in [0usize, 1, 7, 64, 1024, 4096] {
+        payloads.push(vec![0u8; len]);
+        payloads.push(vec![0xFFu8; len]);
+    }
+
+    // Corrupt bincode-ish framings: a small leading byte (a plausible enum
+    // variant / sequence tag) followed by truncated or oversized content.
+    for tag in 0u8..=4 {
+        payloads.push(vec![tag]);
+        payloads.push(vec![tag, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]);
+        let mut huge_len = vec![tag];
+        huge_len.extend_from_slice(&u64::MAX.to_le_bytes());
+        payloads.push(huge_len);
+    }
+
+    payloads
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn malformed_datagrams_do_not_panic_or_corrupt_state() {
+    let port = 8085;
+    let victim_addr = "127.0.0.70";
+    let config = Config::default()
+        .with_port(port)
+        .with_listen_addr(victim_addr.parse().unwrap());
+    // No cluster key: arbitrary bytes are *not* dropped at the auth gate and
+    // reach the deserializer, which is exactly the path we want to fuzz.
+    let store = ReconcileStore::<i32, String>::new(config).await;
+    store.just_insert(0, "legit".to_string());
+
+    let task = tokio::spawn(store.clone().run());
+
+    let attacker = UdpSocket::bind("127.0.0.71:0").await.unwrap();
+    let target = format!("{victim_addr}:{port}");
+
+    for payload in malformed_payloads(0xDEAD_BEEF) {
+        // Sending may legitimately fail for over-MTU buffers on some platforms;
+        // those are not the property under test, so ignore send errors.
+        let _ = attacker.send_to(&payload, &target).await;
+        // Yield occasionally so the receive loop interleaves with the sender.
+        tokio::task::yield_now().await;
+    }
+
+    // Give the victim time to (attempt to) process everything.
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    // The receive task must still be running (a panic would have finished it).
+    assert!(
+        !task.is_finished(),
+        "receive task died on a malformed datagram"
+    );
+    // The legitimate value must be untouched by any garbage datagram.
+    assert_eq!(store.get(&0).as_deref(), Some(&"legit".to_string()));
+
+    task.abort();
+}

--- a/tests/proptest_hrtree.rs
+++ b/tests/proptest_hrtree.rs
@@ -1,0 +1,338 @@
+// Copyright 2023 Developers of the reconcile project.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Property-based / generative tests (issue #113).
+//!
+//! These exercise the two invariants that matter most for a reconciliation
+//! library and that fixed-seed example tests cannot cover exhaustively:
+//!
+//! 1. The hand-rolled B-tree (`HRTree`) behaves like a `BTreeMap` oracle for
+//!    every random `insert`/`remove`/`get`/`range` sequence, and its internal
+//!    [`HRTree::check_invariants`] holds after *every* mutation (this is where
+//!    the `TODO` rebalancing edge cases in `src/hrtree.rs` would surface).
+//! 2. Any two stores converge to identical state after running the full diff
+//!    loop, the returned diff ranges equal the true symmetric difference of the
+//!    key sets, and convergence survives reordered, duplicated and dropped
+//!    messages — modelling the lossy UDP transport.
+
+use std::collections::BTreeMap;
+use std::ops::Bound;
+
+use proptest::prelude::*;
+use rand::rngs::StdRng;
+use rand::seq::SliceRandom;
+use rand::{Rng, SeedableRng};
+
+use reconcile::diff::{DiffRange, Diffable, HashRangeQueryable, HashSegment};
+use reconcile::hrtree::{hash, HRTree};
+
+// ---------------------------------------------------------------------------
+// Property 1: HRTree is observationally equivalent to a BTreeMap oracle, and
+// every internal invariant holds after every single mutation.
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Debug)]
+enum Op {
+    Insert(u8, u16),
+    Remove(u8),
+    Get(u8),
+}
+
+fn op_strategy() -> impl Strategy<Value = Op> {
+    // Small key space (u8) so that `remove`/`get` actually hit existing keys
+    // often, and node splits/merges are exercised with modest sequence lengths.
+    prop_oneof![
+        (any::<u8>(), any::<u16>()).prop_map(|(k, v)| Op::Insert(k, v)),
+        any::<u8>().prop_map(Op::Remove),
+        any::<u8>().prop_map(Op::Get),
+    ]
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(256))]
+
+    #[test]
+    fn hrtree_matches_btreemap_oracle(ops in prop::collection::vec(op_strategy(), 0..400)) {
+        let mut tree: HRTree<u8, u16> = HRTree::new();
+        let mut oracle: BTreeMap<u8, u16> = BTreeMap::new();
+
+        for op in ops {
+            match op {
+                Op::Insert(k, v) => {
+                    prop_assert_eq!(tree.insert(k, v), oracle.insert(k, v));
+                }
+                Op::Remove(k) => {
+                    prop_assert_eq!(tree.remove(&k), oracle.remove(&k));
+                }
+                Op::Get(k) => {
+                    prop_assert_eq!(tree.get(&k), oracle.get(&k));
+                }
+            }
+            // The core safety net: structural, ordering, height, size and hash
+            // caches must all hold after *every* mutation. Panics here would be
+            // the rebalancing bugs the issue is worried about.
+            tree.check_invariants();
+            prop_assert_eq!(tree.len(), oracle.len());
+        }
+
+        // Full-range iteration yields the exact sorted oracle contents.
+        let got: Vec<(u8, u16)> = tree.get_range(&..).map(|(k, v)| (*k, *v)).collect();
+        let want: Vec<(u8, u16)> = oracle.iter().map(|(k, v)| (*k, *v)).collect();
+        prop_assert_eq!(got, want);
+
+        // The cumulated hash equals the XOR of the per-element hashes (and is
+        // order-independent), matching the diff protocol's fingerprint.
+        let expected_hash = oracle.iter().fold(0u64, |acc, (k, v)| acc ^ hash(k, v));
+        prop_assert_eq!(tree.hash(&..), expected_hash);
+    }
+
+    #[test]
+    fn hrtree_range_queries_match_oracle(
+        entries in prop::collection::vec((any::<u8>(), any::<u16>()), 0..200),
+        lo in any::<u8>(),
+        hi in any::<u8>(),
+    ) {
+        let mut tree: HRTree<u8, u16> = HRTree::new();
+        let mut oracle: BTreeMap<u8, u16> = BTreeMap::new();
+        for (k, v) in entries {
+            tree.insert(k, v);
+            oracle.insert(k, v);
+        }
+        let (lo, hi) = if lo <= hi { (lo, hi) } else { (hi, lo) };
+        let range = (Bound::Included(lo), Bound::Excluded(hi));
+
+        let got: Vec<(u8, u16)> = tree.get_range(&range).map(|(k, v)| (*k, *v)).collect();
+        let want: Vec<(u8, u16)> = oracle.range(range).map(|(k, v)| (*k, *v)).collect();
+        prop_assert_eq!(&got, &want);
+
+        // Range hash is consistent with iterating the same range.
+        let expected = want.iter().fold(0u64, |acc, (k, v)| acc ^ hash(k, v));
+        prop_assert_eq!(tree.hash(&range), expected);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Property 2: convergence of the diff protocol.
+//
+// We model a universe of (key, value) pairs and give each store an arbitrary
+// subset. Shared keys carry identical values (the diff algorithm reconciles the
+// *set* of keys; per-key conflict resolution is the job of `ReconcileStore`'s
+// last-write-wins layer, not of the raw `HRTree`). The true symmetric
+// difference of the key sets is therefore well defined and we assert the
+// protocol discovers exactly it.
+// ---------------------------------------------------------------------------
+
+type Tree = HRTree<u64, u64>;
+
+/// One full diff exchange, optionally perturbing the in-flight message vectors
+/// each round with `perturb` to model an adversarial transport (reordering and
+/// duplication). Returns `(a_owes, b_owes)`: the ranges `a` must send to `b` and
+/// vice-versa.
+fn run_diff(
+    a: &Tree,
+    b: &Tree,
+    perturb: &mut dyn FnMut(&mut Vec<HashSegment<u64>>),
+) -> (Vec<DiffRange<u64>>, Vec<DiffRange<u64>>) {
+    let mut a_diffs = Vec::new();
+    let mut b_diffs = Vec::new();
+    let mut a_seg = a.start_diff();
+    let mut b_seg = Vec::new();
+
+    let mut guard = 0;
+    while !a_seg.is_empty() {
+        perturb(&mut a_seg);
+        b.diff_round(std::mem::take(&mut a_seg), &mut b_seg, &mut b_diffs);
+        perturb(&mut b_seg);
+        a.diff_round(std::mem::take(&mut b_seg), &mut a_seg, &mut a_diffs);
+
+        guard += 1;
+        // Bounded number of refinement rounds: the protocol fans out by 16 per
+        // round, so even with duplication this terminates quickly.
+        assert!(guard < 100_000, "diff loop failed to terminate");
+    }
+    (a_diffs, b_diffs)
+}
+
+/// Collect the (key, value) pairs that `tree` holds inside any of `ranges`.
+fn items_in(tree: &Tree, ranges: &[DiffRange<u64>]) -> Vec<(u64, u64)> {
+    let mut out: Vec<(u64, u64)> = ranges
+        .iter()
+        .flat_map(|r| tree.get_range(r).map(|(k, v)| (*k, *v)).collect::<Vec<_>>())
+        .collect();
+    out.sort_unstable();
+    out.dedup();
+    out
+}
+
+/// Keys of `tree` covered by `ranges`.
+fn keys_in(tree: &Tree, ranges: &[DiffRange<u64>]) -> Vec<u64> {
+    items_in(tree, ranges).into_iter().map(|(k, _)| k).collect()
+}
+
+fn sorted_items(tree: &Tree) -> Vec<(u64, u64)> {
+    tree.get_range(&..).map(|(k, v)| (*k, *v)).collect()
+}
+
+/// Build two trees from a universe and per-entry membership flags. Returns the
+/// trees plus the oracle key sets `(only_a, only_b, union)`.
+fn build_pair(
+    universe: &[(u64, u64, bool, bool)],
+) -> (Tree, Tree, Vec<u64>, Vec<u64>, BTreeMap<u64, u64>) {
+    // Deduplicate by key, keeping the first occurrence so shared keys are
+    // guaranteed identical values across both trees.
+    let mut seen = BTreeMap::new();
+    let mut a = HRTree::new();
+    let mut b = HRTree::new();
+    let mut only_a = Vec::new();
+    let mut only_b = Vec::new();
+    let mut union = BTreeMap::new();
+    for &(k, v, in_a, in_b) in universe {
+        if seen.insert(k, v).is_some() {
+            continue; // already handled this key
+        }
+        if in_a {
+            a.insert(k, v);
+        }
+        if in_b {
+            b.insert(k, v);
+        }
+        match (in_a, in_b) {
+            (true, false) => only_a.push(k),
+            (false, true) => only_b.push(k),
+            _ => {}
+        }
+        if in_a || in_b {
+            union.insert(k, v);
+        }
+    }
+    only_a.sort_unstable();
+    only_b.sort_unstable();
+    (a, b, only_a, only_b, union)
+}
+
+fn universe_strategy() -> impl Strategy<Value = Vec<(u64, u64, bool, bool)>> {
+    prop::collection::vec(
+        (any::<u64>(), any::<u64>(), any::<bool>(), any::<bool>()),
+        0..80,
+    )
+}
+
+/// Apply both sides of a diff result, reconciling the two trees in place.
+fn apply_full(a: &mut Tree, b: &mut Tree, a_diffs: &[DiffRange<u64>], b_diffs: &[DiffRange<u64>]) {
+    let a_items = items_in(a, a_diffs);
+    let b_items = items_in(b, b_diffs);
+    for (k, v) in a_items {
+        b.insert(k, v);
+    }
+    for (k, v) in b_items {
+        a.insert(k, v);
+    }
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(256))]
+
+    /// Clean channel: a single diff exchange must discover exactly the symmetric
+    /// difference of the key sets and reconcile the two trees to the union.
+    #[test]
+    fn two_trees_converge_and_diff_is_symmetric_difference(universe in universe_strategy()) {
+        let (mut a, mut b, only_a, only_b, union) = build_pair(&universe);
+
+        let mut noop = |_: &mut Vec<HashSegment<u64>>| {};
+        let (a_diffs, b_diffs) = run_diff(&a, &b, &mut noop);
+
+        // The discovered diff ranges cover exactly the symmetric difference.
+        prop_assert_eq!(keys_in(&a, &a_diffs), only_a);
+        prop_assert_eq!(keys_in(&b, &b_diffs), only_b);
+
+        apply_full(&mut a, &mut b, &a_diffs, &b_diffs);
+        a.check_invariants();
+        b.check_invariants();
+
+        // Both trees now hold the full union and agree.
+        let want: Vec<(u64, u64)> = union.into_iter().collect();
+        prop_assert_eq!(sorted_items(&a), want.clone());
+        prop_assert_eq!(sorted_items(&b), want);
+        prop_assert!(a == b);
+    }
+
+    /// Reordered + duplicated messages: an adversarial transport that shuffles
+    /// every batch and duplicates one segment per round must not prevent
+    /// convergence, and must still find exactly the symmetric difference.
+    #[test]
+    fn convergence_survives_reordered_and_duplicated_messages(
+        universe in universe_strategy(),
+        seed in any::<u64>(),
+    ) {
+        let (mut a, mut b, only_a, only_b, union) = build_pair(&universe);
+
+        let mut rng = StdRng::seed_from_u64(seed);
+        let mut perturb = |segs: &mut Vec<HashSegment<u64>>| {
+            if !segs.is_empty() {
+                // Duplicate a single random segment (bounded growth) ...
+                let i = rng.gen_range(0..segs.len());
+                let dup = segs[i].clone();
+                segs.push(dup);
+            }
+            // ... and deliver the batch out of order.
+            segs.shuffle(&mut rng);
+        };
+
+        let (a_diffs, b_diffs) = run_diff(&a, &b, &mut perturb);
+
+        prop_assert_eq!(keys_in(&a, &a_diffs), only_a);
+        prop_assert_eq!(keys_in(&b, &b_diffs), only_b);
+
+        apply_full(&mut a, &mut b, &a_diffs, &b_diffs);
+        a.check_invariants();
+        b.check_invariants();
+
+        let want: Vec<(u64, u64)> = union.into_iter().collect();
+        prop_assert_eq!(sorted_items(&a), want.clone());
+        prop_assert_eq!(sorted_items(&b), want);
+        prop_assert!(a == b);
+    }
+
+    /// Dropped messages: each lossy cycle delivers updates in only one direction
+    /// (the other direction's updates are dropped), modelling lost UDP
+    /// datagrams. The protocol must never corrupt state (invariants hold
+    /// throughout) and must converge once a complete exchange finally gets
+    /// through — exactly the real transport's retransmission guarantee.
+    #[test]
+    fn convergence_is_eventual_despite_dropped_messages(
+        universe in universe_strategy(),
+        schedule in prop::collection::vec(any::<bool>(), 0..16),
+    ) {
+        let (mut a, mut b, _only_a, _only_b, union) = build_pair(&universe);
+
+        let mut noop = |_: &mut Vec<HashSegment<u64>>| {};
+        for deliver_a_to_b in schedule {
+            let (a_diffs, b_diffs) = run_diff(&a, &b, &mut noop);
+            // Drop one whole direction this cycle.
+            if deliver_a_to_b {
+                apply_full(&mut a, &mut b, &a_diffs, &[]);
+            } else {
+                apply_full(&mut a, &mut b, &[], &b_diffs);
+            }
+            // Partial, lossy application must still leave both trees valid.
+            a.check_invariants();
+            b.check_invariants();
+        }
+
+        // A final, complete exchange (guaranteed retransmission) converges.
+        let (a_diffs, b_diffs) = run_diff(&a, &b, &mut noop);
+        apply_full(&mut a, &mut b, &a_diffs, &b_diffs);
+        a.check_invariants();
+        b.check_invariants();
+
+        let want: Vec<(u64, u64)> = union.into_iter().collect();
+        prop_assert_eq!(sorted_items(&a), want.clone());
+        prop_assert_eq!(sorted_items(&b), want);
+        prop_assert!(a == b);
+    }
+}


### PR DESCRIPTION
Closes #113.

Addresses the two grouped quality issues from the peer review (findings F11 + F12).

## Part 1 — stray `println!` in the `with_mut` hot path (quick fix)

Deleted the debug `println!("{diff_hash}")` at `src/hrtree.rs:315`. It fired on **every** in-place mutation routed through `ReconcileStore::get_mut`, taking a stdout lock + syscall per mutation, polluting any consumer's output and bypassing the crate's `tracing` infrastructure.

## Part 2 — generative / property-based testing of the core invariants

No `proptest`/`quickcheck`/`fuzz` existed before; the convergence invariant was covered by a single fixed-seed integration test, and `check_invariants()` only ran on author-chosen sequences. This PR adds a real generative suite.

Added `proptest` as a **dev-dependency** (does not affect `cargo publish`).

### `tests/proptest_hrtree.rs`
- **B-tree oracle**: random `insert`/`remove`/`get` sequences against a `BTreeMap`, with `check_invariants()` asserted after **every** mutation — directly targets the hand-rolled rebalancing edge cases (the `TODO` at `src/hrtree.rs:97`).
- **Range queries & hashes**: `get_range` and the cumulated/range fingerprints match the oracle.
- **Convergence (clean channel)**: two random trees run the full diff loop, reconcile to the union, and the returned diff ranges equal the **true symmetric difference** of the key sets.
- **Reordered + duplicated messages**: convergence and symmetric-difference coverage still hold when every in-flight batch is shuffled and a segment is duplicated each round.
- **Dropped messages**: convergence is *eventual* under one-directional message loss, with invariants holding throughout — modelling the lossy UDP transport's retransmission guarantee.

### `tests/fuzz_packets.rs`
- Bombards a **keyless** store's receive loop with random and deliberately-corrupt datagrams (so bytes reach the bincode deserializer), asserting the receive task never panics/dies and local state stays intact. Covers the malformed-packet panic surface (unauthenticated remote DoS).

## Validation

Full CI pipeline run locally:
- `cargo fmt --check` ✅
- `cargo clippy --all --tests` — no new warnings (pre-existing warnings untouched) ✅
- `cargo test --all` ✅ — **44 passed, 0 failed** (6 new tests)

https://claude.ai/code/session_019vc8rwEDJiHHNo3KSeM2Tr

---
_Generated by [Claude Code](https://claude.ai/code/session_019vc8rwEDJiHHNo3KSeM2Tr)_