### PR TITLE
Replace 64-bit XOR fingerprint with 256-bit additive BLAKE3 (#111)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,9 @@ default = ["mac-blake3"]
 # Per-datagram MAC authentication backends (see `src/auth.rs`).
 # Exactly one backend is used at build time; `mac-blake3` takes precedence if
 # both are enabled. At least one must be enabled or the crate fails to compile.
-mac-blake3 = ["dep:blake3"]
+# (BLAKE3 itself is always pulled in: it backs the range fingerprint, see
+# `src/fingerprint.rs`.)
+mac-blake3 = []
 mac-hmac = ["dep:hmac", "dep:sha2"]
 # Wipe the cluster key from memory on drop (defense in depth).
 zeroize = ["dep:zeroize"]
@@ -30,7 +32,7 @@ zeroize = ["dep:zeroize"]
 [dependencies]
 arrayvec = "0.7.4"
 bincode = "1.3.3"
-blake3 = { version = "1.5", optional = true }
+blake3 = "1.5"
 chrono = { version = "0.4.31", features = ["serde"] }
 hmac = { version = "0.12", optional = true }
 ipnet = "2.9.0"

--- a/README.md
+++ b/README.md
@@ -80,7 +80,10 @@ For confidentiality, run the protocol over a trusted/encrypted underlay.
 The core of the protocol is made possible by the `HRTree` (Hash-Range Tree) data structure, which
 allows `O(log(n))` access, insertion and removal, as well as `O(log(n))`
 cumulated hash range-query. The latter property enables querying
-the cumulated (XORed) hash of all key-value pairs between two keys.
+the cumulated fingerprint of all key-value pairs between two keys. The fingerprint is a
+256-bit BLAKE3-per-element hash combined by addition modulo 2²⁵⁶ — a stable, portable wire
+token, chosen over a 64-bit XOR for collision resistance and cross-version interoperability
+(see `src/fingerprint.rs`).
 
 Although we did come we the idea independently, it exactly matches a paper
 published on Arxiv in February 2023: [Range-Based Set

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -134,10 +134,11 @@ impl<K: Clone, T: HashRangeQueryable<Key = K>> Diffable for T {
             };
             // NOTE: decisions about emptiness and equality are made on the exact
             // `size`/`local_size`, never on `hash`/`local_hash`. A range fingerprint
-            // is an XOR of per-element hashes, so a *non-empty* range can legitimately
-            // hash to 0; using `hash == 0` as an "empty" sentinel (or `hash ==
+            // combines per-element hashes by addition modulo 2²⁵⁶ (see
+            // `crate::fingerprint`), so a *non-empty* range can legitimately fingerprint
+            // to `ZERO`; using `hash == ZERO` as an "empty" sentinel (or `hash ==
             // local_hash` alone as "equal") would alias such ranges and cause silent,
-            // permanent divergence. See issue #106.
+            // permanent divergence. See issues #106 and #111.
             if hash == local_hash && size == local_size {
                 continue;
             } else if size == 0 {
@@ -223,12 +224,13 @@ mod tests {
     impl HashRangeQueryable for MockStore {
         type Key = i32;
 
-        fn hash<R: RangeBounds<i32>>(&self, range: &R) -> u64 {
+        fn hash<R: RangeBounds<i32>>(&self, range: &R) -> Fingerprint {
             self.keys
                 .iter()
                 .filter(|k| range.contains(k))
-                .fold(0, |acc, &k| {
-                    acc ^ (k as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15) | 1
+                .fold(Fingerprint::ZERO, |acc, &k| {
+                    let m = (k as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15) | 1;
+                    acc + Fingerprint([m, 0, 0, 0])
                 })
         }
 
@@ -266,7 +268,7 @@ mod tests {
         let store = MockStore::new(vec![10, 20, 30]);
         let segment = HashSegment {
             range: (Bound::Excluded(0), Bound::Unbounded),
-            hash: 1,
+            hash: Fingerprint([1, 0, 0, 0]),
             size: 1,
         };
         let (out_comparison, differences) = round(&store, segment);
@@ -280,7 +282,7 @@ mod tests {
         let store = MockStore::new(vec![10, 20, 30]);
         let segment = HashSegment {
             range: (Bound::Unbounded, Bound::Included(20)),
-            hash: 1,
+            hash: Fingerprint([1, 0, 0, 0]),
             size: 1,
         };
         let (out_comparison, differences) = round(&store, segment);
@@ -297,7 +299,7 @@ mod tests {
         let segment = HashSegment {
             // start_index = insertion_position(100) = 3, end_index = insertion_position(5) = 0
             range: (Bound::Included(100), Bound::Excluded(5)),
-            hash: 1,
+            hash: Fingerprint([1, 0, 0, 0]),
             size: 1,
         };
         let (out_comparison, differences) = round(&store, segment);
@@ -313,7 +315,7 @@ mod tests {
         let store = MockStore::new(vec![10, 20, 30]);
         let segment = HashSegment {
             range: (Bound::Unbounded, Bound::Unbounded),
-            hash: 0,
+            hash: Fingerprint::ZERO,
             size: 0,
         };
         let (_out_comparison, differences) = round(&store, segment);

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -13,6 +13,8 @@ use std::ops::{Bound, RangeBounds};
 
 use serde::{Deserialize, Serialize};
 
+use crate::fingerprint::Fingerprint;
+
 /// Provides the necessary methods to be able
 /// to efficiently determine and compare
 /// differences between two key stores:
@@ -26,8 +28,10 @@ use serde::{Deserialize, Serialize};
 /// This is a low-level trait.
 pub trait HashRangeQueryable {
     type Key;
-    /// Cumulated hash over a given range of keys. For instance, it could be the XOR of all the hashes of the elements in the range.
-    fn hash<R: RangeBounds<Self::Key>>(&self, range: &R) -> u64;
+    /// Cumulated [`Fingerprint`] over a given range of keys: the combination
+    /// (256-bit addition, see [`crate::fingerprint`]) of the per-element hashes
+    /// of every element in the range.
+    fn hash<R: RangeBounds<Self::Key>>(&self, range: &R) -> Fingerprint;
     /// Position of the given key in the collection, if it exists, or position where it would be after insertion otherwise
     fn insertion_position(&self, key: &Self::Key) -> usize;
     /// Reference to the [`Key`](HashRangeQueryable::Key) at a given position. Panics if the key is not in the collection.
@@ -43,7 +47,7 @@ pub trait HashRangeQueryable {
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct HashSegment<K> {
     range: (Bound<K>, Bound<K>),
-    hash: u64,
+    hash: Fingerprint,
     size: usize,
 }
 
@@ -118,7 +122,7 @@ impl<K: Clone, T: HashRangeQueryable<Key = K>> Diffable for T {
                 // present on remote; bounce back to the remote
                 out_comparison.push(HashSegment {
                     range: (start_bound, end_bound),
-                    hash: 0,
+                    hash: Fingerprint::ZERO,
                     size: 0,
                 });
                 continue;
@@ -126,7 +130,7 @@ impl<K: Clone, T: HashRangeQueryable<Key = K>> Diffable for T {
                 // ask the remote to send us the conflicting item
                 out_comparison.push(HashSegment {
                     range: (start_bound.clone(), end_bound.clone()),
-                    hash: 0,
+                    hash: Fingerprint::ZERO,
                     size: 0,
                 });
                 // send the conflicting item to the remote

--- a/src/fingerprint.rs
+++ b/src/fingerprint.rs
@@ -1,0 +1,346 @@
+// Copyright 2023 Developers of the reconcile project.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Range fingerprint primitive used by the reconciliation protocol.
+//!
+//! The reconciliation protocol compares two collections by exchanging a
+//! *fingerprint* (a combined hash) of the elements in a range of keys. For this
+//! to be correct and safe, the fingerprint must satisfy two properties:
+//!
+//! 1. **Algebraically strong combiner.** Fingerprints of sub-ranges are
+//!    combined into the fingerprint of their union, and elements are added and
+//!    removed incrementally as the tree mutates. The naive combiner — a 64-bit
+//!    XOR of per-element hashes — is `GF(2)`-linear and self-inverse: cancelling
+//!    or repeated element hashes vanish, and an adversary can *solve* (Gaussian
+//!    elimination) for crafted elements that make a divergent range collide in
+//!    fingerprint, causing silent missed differences. 64 bits also invites
+//!    accidental birthday collisions (~2³²) over a cluster's lifetime.
+//!
+//!    Instead we use a **256-bit "hash-then-add" combiner**: each element hashes
+//!    to a 256-bit value and fingerprints combine by **addition modulo 2²⁵⁶**
+//!    (with carry propagation across the whole 256-bit word). This forms an
+//!    abelian group — combine is `+`, remove is `-` — and, unlike XOR, addition
+//!    with carries is *not* `GF(2)`-linear, defeating offline collision crafting.
+//!    The 256-bit width pushes accidental birthday collisions to ~2¹²⁸.
+//!
+//! 2. **Stable, versioned hash function.** The fingerprint is the **wire
+//!    reconciliation token**: two nodes must compute the *same* fingerprint for
+//!    the same data, forever, across Rust versions, platforms (32- vs 64-bit),
+//!    and endianness. `std`'s [`DefaultHasher`](std::collections::hash_map::DefaultHasher)
+//!    is explicitly documented as unspecified and unstable across releases, so
+//!    we pin the element hash to **BLAKE3** and feed integers in fixed
+//!    little-endian width (see the `Blake3Hasher` adapter). The golden-vector tests at the
+//!    bottom of this module freeze the wire format so any change that would
+//!    break interoperability fails CI.
+//!
+//! See issue #111 and: A. Meyer, *Range-Based Set Reconciliation*
+//! (arXiv:2212.13567); Clarke et al., *Incremental Multiset Hash Functions*
+//! (ASIACRYPT 2003).
+
+use std::hash::{Hash, Hasher};
+use std::ops::{Add, AddAssign, Neg, Sub, SubAssign};
+
+use serde::{Deserialize, Serialize};
+
+/// A 256-bit range fingerprint, stored as four little-endian 64-bit limbs
+/// (limb 0 is least significant).
+///
+/// Fingerprints form an abelian group under addition modulo 2²⁵⁶:
+/// [`combine`](Fingerprint::combine)/`+` merges the fingerprints of disjoint
+/// ranges (and adds a single element), while `-` removes an element again. The
+/// identity [`ZERO`](Fingerprint::ZERO) is the fingerprint of the empty range.
+///
+/// NOTE: a *non-empty* range can legitimately fingerprint to [`ZERO`](Fingerprint::ZERO) (elements
+/// whose hashes sum to a multiple of 2²⁵⁶). The reconciliation protocol must
+/// therefore never treat `fingerprint == ZERO` as "empty"; emptiness is decided
+/// on the element count. See issue #106.
+#[derive(Clone, Copy, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct Fingerprint(pub [u64; 4]);
+
+impl Fingerprint {
+    /// The fingerprint of the empty range and the additive identity.
+    pub const ZERO: Fingerprint = Fingerprint([0; 4]);
+
+    /// Interpret 32 bytes (little-endian) as a fingerprint.
+    fn from_bytes(bytes: &[u8; 32]) -> Fingerprint {
+        let mut limbs = [0u64; 4];
+        for (limb, chunk) in limbs.iter_mut().zip(bytes.chunks_exact(8)) {
+            *limb = u64::from_le_bytes(chunk.try_into().unwrap());
+        }
+        Fingerprint(limbs)
+    }
+
+    /// Combine two fingerprints (addition modulo 2²⁵⁶, with carry propagation).
+    #[must_use]
+    pub fn combine(self, other: Fingerprint) -> Fingerprint {
+        let mut out = [0u64; 4];
+        let mut carry = 0u128;
+        for (o, (&a, &b)) in out.iter_mut().zip(self.0.iter().zip(other.0.iter())) {
+            let sum = a as u128 + b as u128 + carry;
+            *o = sum as u64;
+            carry = sum >> 64;
+        }
+        Fingerprint(out)
+    }
+
+    /// Remove `other` from `self` (subtraction modulo 2²⁵⁶); the inverse of
+    /// [`combine`](Fingerprint::combine).
+    #[must_use]
+    pub fn remove(self, other: Fingerprint) -> Fingerprint {
+        let mut out = [0u64; 4];
+        let mut borrow = 0i128;
+        for (o, (&a, &b)) in out.iter_mut().zip(self.0.iter().zip(other.0.iter())) {
+            let diff = a as i128 - b as i128 - borrow;
+            if diff < 0 {
+                *o = (diff + (1i128 << 64)) as u64;
+                borrow = 1;
+            } else {
+                *o = diff as u64;
+                borrow = 0;
+            }
+        }
+        Fingerprint(out)
+    }
+}
+
+impl Add for Fingerprint {
+    type Output = Fingerprint;
+    fn add(self, rhs: Fingerprint) -> Fingerprint {
+        self.combine(rhs)
+    }
+}
+
+impl AddAssign for Fingerprint {
+    fn add_assign(&mut self, rhs: Fingerprint) {
+        *self = self.combine(rhs);
+    }
+}
+
+impl Sub for Fingerprint {
+    type Output = Fingerprint;
+    fn sub(self, rhs: Fingerprint) -> Fingerprint {
+        self.remove(rhs)
+    }
+}
+
+impl SubAssign for Fingerprint {
+    fn sub_assign(&mut self, rhs: Fingerprint) {
+        *self = self.remove(rhs);
+    }
+}
+
+impl Neg for Fingerprint {
+    type Output = Fingerprint;
+    fn neg(self) -> Fingerprint {
+        Fingerprint::ZERO.remove(self)
+    }
+}
+
+impl std::fmt::Debug for Fingerprint {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        // Most-significant limb first, so the hex reads like a big-endian number.
+        write!(
+            f,
+            "Fingerprint({:016x}{:016x}{:016x}{:016x})",
+            self.0[3], self.0[2], self.0[1], self.0[0]
+        )
+    }
+}
+
+impl std::fmt::Display for Fingerprint {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "{:016x}{:016x}{:016x}{:016x}",
+            self.0[3], self.0[2], self.0[1], self.0[0]
+        )
+    }
+}
+
+/// A [`Hasher`] that feeds bytes into BLAKE3 and yields a 256-bit
+/// [`Fingerprint`].
+///
+/// Integer `write_*` methods are overridden to emit a **fixed little-endian**
+/// byte width, independent of the host endianness and pointer width, so that a
+/// 32-bit and a 64-bit node (or a big-endian and a little-endian one) feed
+/// BLAKE3 the exact same bytes for the same value. This is what makes the
+/// fingerprint a stable wire token.
+struct Blake3Hasher(blake3::Hasher);
+
+impl Blake3Hasher {
+    fn new() -> Blake3Hasher {
+        Blake3Hasher(blake3::Hasher::new())
+    }
+
+    fn fingerprint(&self) -> Fingerprint {
+        Fingerprint::from_bytes(self.0.finalize().as_bytes())
+    }
+}
+
+impl Hasher for Blake3Hasher {
+    fn write(&mut self, bytes: &[u8]) {
+        self.0.update(bytes);
+    }
+
+    // Fixed-width little-endian integer encodings (portable across platforms).
+    fn write_u8(&mut self, i: u8) {
+        self.0.update(&[i]);
+    }
+    fn write_u16(&mut self, i: u16) {
+        self.0.update(&i.to_le_bytes());
+    }
+    fn write_u32(&mut self, i: u32) {
+        self.0.update(&i.to_le_bytes());
+    }
+    fn write_u64(&mut self, i: u64) {
+        self.0.update(&i.to_le_bytes());
+    }
+    fn write_u128(&mut self, i: u128) {
+        self.0.update(&i.to_le_bytes());
+    }
+    fn write_usize(&mut self, i: usize) {
+        // Encode as a fixed 64-bit value so 32- and 64-bit nodes agree.
+        self.0.update(&(i as u64).to_le_bytes());
+    }
+    fn write_i8(&mut self, i: i8) {
+        self.0.update(&i.to_le_bytes());
+    }
+    fn write_i16(&mut self, i: i16) {
+        self.0.update(&i.to_le_bytes());
+    }
+    fn write_i32(&mut self, i: i32) {
+        self.0.update(&i.to_le_bytes());
+    }
+    fn write_i64(&mut self, i: i64) {
+        self.0.update(&i.to_le_bytes());
+    }
+    fn write_i128(&mut self, i: i128) {
+        self.0.update(&i.to_le_bytes());
+    }
+    fn write_isize(&mut self, i: isize) {
+        self.0.update(&(i as i64).to_le_bytes());
+    }
+
+    fn finish(&self) -> u64 {
+        // Not used to build fingerprints (we call `fingerprint()` instead), but
+        // the trait requires it; return the low 64 bits of the digest.
+        let bytes = self.0.finalize();
+        u64::from_le_bytes(bytes.as_bytes()[..8].try_into().unwrap())
+    }
+}
+
+/// Compute the 256-bit [`Fingerprint`] of a single key-value element.
+///
+/// This is the per-element hash that the [`HRTree`](crate::hrtree::HRTree)
+/// combines into range fingerprints. It is BLAKE3 over the key bytes followed by
+/// the value bytes, fed in a fixed, portable encoding (see the `Blake3Hasher` adapter),
+/// and is part of the wire protocol — see the golden-vector tests.
+pub fn hash<K: Hash, V: Hash>(key: &K, value: &V) -> Fingerprint {
+    let mut hasher = Blake3Hasher::new();
+    key.hash(&mut hasher);
+    value.hash(&mut hasher);
+    hasher.fingerprint()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn zero_is_identity() {
+        let f = hash(&42u64, &"hello");
+        assert_eq!(f + Fingerprint::ZERO, f);
+        assert_eq!(f - Fingerprint::ZERO, f);
+        assert_eq!(Fingerprint::ZERO + f, f);
+    }
+
+    #[test]
+    fn add_then_remove_is_identity() {
+        let a = hash(&1u64, &10u64);
+        let b = hash(&2u64, &20u64);
+        let c = hash(&3u64, &30u64);
+        let combined = a + b + c;
+        assert_eq!(combined - b - a - c, Fingerprint::ZERO);
+        assert_eq!(combined - c, a + b);
+    }
+
+    #[test]
+    fn add_is_commutative_and_associative() {
+        let a = hash(&1u64, &10u64);
+        let b = hash(&2u64, &20u64);
+        let c = hash(&3u64, &30u64);
+        assert_eq!(a + b, b + a);
+        assert_eq!((a + b) + c, a + (b + c));
+    }
+
+    #[test]
+    fn neg_is_additive_inverse() {
+        let a = hash(&7u64, &"x");
+        assert_eq!(a + (-a), Fingerprint::ZERO);
+        assert_eq!(-(-a), a);
+    }
+
+    #[test]
+    fn add_propagates_carry_across_limbs() {
+        let all_ones = Fingerprint([u64::MAX; 4]);
+        // (2²⁵⁶ - 1) + 1 wraps to 0.
+        assert_eq!(all_ones + Fingerprint([1, 0, 0, 0]), Fingerprint::ZERO);
+        // Carry out of limb 0 lands in limb 1.
+        assert_eq!(
+            Fingerprint([u64::MAX, 0, 0, 0]) + Fingerprint([1, 0, 0, 0]),
+            Fingerprint([0, 1, 0, 0])
+        );
+    }
+
+    #[test]
+    fn sub_borrows_across_limbs() {
+        // 0 - 1 wraps to 2²⁵⁶ - 1 (all limbs MAX).
+        assert_eq!(
+            Fingerprint::ZERO - Fingerprint([1, 0, 0, 0]),
+            Fingerprint([u64::MAX; 4])
+        );
+    }
+
+    // --- Golden vectors: freeze the wire format. ---
+    //
+    // These pin the exact bytes that go on the wire. If a change to the element
+    // hash (BLAKE3, the feeding order/encoding) or the combiner ever alters
+    // them, this test fails — that change would silently break interoperability
+    // between nodes and must be a deliberate, versioned wire-format bump.
+
+    #[test]
+    fn golden_element_hash() {
+        // BLAKE3(key=50u64 little-endian || value="Hello" || 0xff str terminator).
+        assert_eq!(
+            hash(&50u64, &"Hello"),
+            Fingerprint([
+                0x3a24_dc5c_8162_625b,
+                0x8096_8c6a_b597_489b,
+                0x105e_ba4e_6a69_90c8,
+                0x4e24_03d1_e7ce_04f7,
+            ])
+        );
+    }
+
+    #[test]
+    fn golden_combined_fingerprint() {
+        // Order-independent combination of three elements (the building block of
+        // a range fingerprint).
+        let combined =
+            hash(&25u64, &"World!") + hash(&50u64, &"Hello") + hash(&75u64, &"Everyone!");
+        assert_eq!(
+            combined,
+            Fingerprint([
+                0x6be8_b71e_bc22_e801,
+                0x6c53_2dca_19b5_e70c,
+                0x7422_4b2c_43a0_0032,
+                0xacf7_6a81_40c9_c730,
+            ])
+        );
+    }
+}

--- a/src/hrtree.rs
+++ b/src/hrtree.rs
@@ -12,7 +12,11 @@
 //! It is the core of the protocol, as it allows `O(log(n))` access,
 //! insertion and removal, as well as `O(log(n))` cumulated hash range-query.
 //! The latter property enables querying
-//! the cumulated (XORed) hash of all key-value pairs between two keys.
+//! the cumulated [`Fingerprint`] of all key-value pairs between two keys.
+//!
+//! The per-element hash and the way fingerprints are combined (256-bit addition,
+//! *not* XOR) live in [`crate::fingerprint`]; see that module and issue #111 for
+//! why the combiner and hash function are chosen the way they are.
 
 //! Although we did come we the idea independently, it exactly matches a paper
 //! published on Arxiv in February 2023:
@@ -22,8 +26,7 @@
 //! and [`HashRangeQueryable`] traits.
 
 use std::cmp::Ordering;
-use std::collections::hash_map::DefaultHasher;
-use std::hash::{Hash, Hasher};
+use std::hash::Hash;
 use std::ops::{Bound, RangeBounds};
 
 use arrayvec::ArrayVec;
@@ -31,27 +34,21 @@ use range_cmp::{RangeComparable, RangeOrdering};
 use tracing::trace;
 
 use crate::diff::HashRangeQueryable;
-
-pub fn hash<K: Hash, V: Hash>(key: &K, value: &V) -> u64 {
-    let mut hasher = DefaultHasher::new();
-    key.hash(&mut hasher);
-    value.hash(&mut hasher);
-    hasher.finish()
-}
+use crate::fingerprint::{hash, Fingerprint};
 
 const B: usize = 6;
 const MIN_CAPACITY: usize = B - 1;
 const MAX_CAPACITY: usize = 2 * B - 1;
 
-type InsertionTuple<K, V> = Option<(K, V, u64, Box<Node<K, V>>)>;
+type InsertionTuple<K, V> = Option<(K, V, Fingerprint, Box<Node<K, V>>)>;
 
 #[derive(Clone, Debug, Default)]
 pub(crate) struct Node<K, V> {
     pub(crate) keys: ArrayVec<K, MAX_CAPACITY>,
     pub(crate) values: ArrayVec<V, MAX_CAPACITY>,
-    hashes: ArrayVec<u64, MAX_CAPACITY>,
+    hashes: ArrayVec<Fingerprint, MAX_CAPACITY>,
     pub(crate) children: Option<ArrayVec<Box<Node<K, V>>, { MAX_CAPACITY + 1 }>>,
-    tree_hash: u64,
+    tree_hash: Fingerprint,
     tree_size: usize,
 }
 
@@ -62,20 +59,20 @@ impl<K, V> Node<K, V> {
             values: ArrayVec::new(),
             hashes: ArrayVec::new(),
             children: None,
-            tree_hash: 0,
+            tree_hash: Fingerprint::ZERO,
             tree_size: 0,
         }
     }
 
     fn refresh_hash_size(&mut self) {
-        let mut cum_hash = 0;
+        let mut cum_hash = Fingerprint::ZERO;
         for hash in self.hashes.iter() {
-            cum_hash ^= hash;
+            cum_hash += *hash;
         }
         let mut tot_size = self.keys.len();
         if let Some(children) = self.children.as_ref() {
             for child in children {
-                cum_hash ^= child.tree_hash;
+                cum_hash += child.tree_hash;
                 tot_size += child.tree_size;
             }
         }
@@ -88,9 +85,9 @@ impl<K, V> Node<K, V> {
         index: usize,
         key: K,
         value: V,
-        hash: u64,
+        hash: Fingerprint,
         right_child: Option<Box<Node<K, V>>>,
-        diff_hash: u64,
+        diff_hash: Fingerprint,
     ) -> InsertionTuple<K, V> {
         assert_eq!(self.children.is_none(), right_child.is_none());
         if self.keys.is_full() {
@@ -105,7 +102,7 @@ impl<K, V> Node<K, V> {
                     .children
                     .as_mut()
                     .map(|children| ArrayVec::from_iter(children.drain(mid + 1..))),
-                tree_hash: 0,
+                tree_hash: Fingerprint::ZERO,
                 tree_size: 0,
             });
             let mid_key = self.keys.pop().unwrap();
@@ -130,7 +127,7 @@ impl<K, V> Node<K, V> {
             self.values.insert(index, value);
             self.hashes.insert(index, hash);
             self.tree_size += 1;
-            self.tree_hash ^= diff_hash;
+            self.tree_hash += diff_hash;
             if let Some(right_child) = right_child {
                 assert!(self.children.is_some());
                 self.children
@@ -157,12 +154,12 @@ impl<K, V> Node<K, V> {
             let v = left_sibling.values.pop().unwrap();
             let h = left_sibling.hashes.pop().unwrap();
             left_sibling.tree_size -= 1;
-            left_sibling.tree_hash ^= h;
+            left_sibling.tree_hash -= h;
             // take last child from left sibling if any
             let c = left_sibling.children.as_mut().map(|children| {
                 let c = children.pop().unwrap();
                 left_sibling.tree_size -= c.tree_size;
-                left_sibling.tree_hash ^= c.tree_hash;
+                left_sibling.tree_hash -= c.tree_hash;
                 c
             });
             // NOTE: separator (k, v, h) is left of child c
@@ -177,11 +174,11 @@ impl<K, V> Node<K, V> {
             current.values.insert(0, v);
             current.hashes.insert(0, h);
             current.tree_size += 1;
-            current.tree_hash ^= h;
+            current.tree_hash += h;
             // move child c in current node if any
             if let Some(c) = c {
                 current.tree_size += c.tree_size;
-                current.tree_hash ^= c.tree_hash;
+                current.tree_hash += c.tree_hash;
                 current.children.as_mut().unwrap().insert(0, c);
             }
         } else if index + 1 < children.len() && children[index + 1].keys.len() > MIN_CAPACITY {
@@ -192,12 +189,12 @@ impl<K, V> Node<K, V> {
             let v = right_sibling.values.remove(0);
             let h = right_sibling.hashes.remove(0);
             right_sibling.tree_size -= 1;
-            right_sibling.tree_hash ^= h;
+            right_sibling.tree_hash -= h;
             // take first child from right sibling if any
             let c = right_sibling.children.as_mut().map(|children| {
                 let c = children.remove(0);
                 right_sibling.tree_size -= c.tree_size;
-                right_sibling.tree_hash ^= c.tree_hash;
+                right_sibling.tree_hash -= c.tree_hash;
                 c
             });
             // NOTE: separator (k, v, h) is right of child c
@@ -212,11 +209,11 @@ impl<K, V> Node<K, V> {
             current.values.push(v);
             current.hashes.push(h);
             current.tree_size += 1;
-            current.tree_hash ^= h;
+            current.tree_hash += h;
             // move child c in current node if any
             if let Some(c) = c {
                 current.tree_size += c.tree_size;
-                current.tree_hash ^= c.tree_hash;
+                current.tree_hash += c.tree_hash;
                 current.children.as_mut().unwrap().push(c);
             }
         } else {
@@ -240,7 +237,7 @@ impl<K, V> Node<K, V> {
             current.values.push(v);
             current.hashes.push(h);
             current.tree_size += 1;
-            current.tree_hash ^= h;
+            current.tree_hash += h;
             // move values of right_sibling in current node
             for k in right_sibling.keys {
                 current.keys.push(k);
@@ -257,7 +254,7 @@ impl<K, V> Node<K, V> {
                 }
             }
             current.tree_size += right_sibling.tree_size;
-            current.tree_hash ^= right_sibling.tree_hash;
+            current.tree_hash += right_sibling.tree_hash;
         }
     }
 }
@@ -301,7 +298,7 @@ impl<K: Hash + Ord, V: Hash> HRTree<K, V> {
             node: &mut Node<K, V>,
             key: &K,
             callback: F,
-        ) -> u64 {
+        ) -> Fingerprint {
             match node.keys.binary_search(key) {
                 Ok(index) => {
                     let v = Some(&mut node.values[index]);
@@ -310,20 +307,20 @@ impl<K: Hash + Ord, V: Hash> HRTree<K, V> {
                     let old_hash = node.hashes[index];
                     let new_hash = hash(key, &node.values[index]);
                     node.hashes[index] = new_hash;
-                    let diff_hash = old_hash ^ new_hash;
-                    node.tree_hash ^= diff_hash;
-                    println!("{diff_hash}");
+                    // signed delta to apply to this node and every ancestor's fingerprint
+                    let diff_hash = new_hash - old_hash;
+                    node.tree_hash += diff_hash;
                     diff_hash
                 }
                 Err(index) => {
                     if let Some(children) = node.children.as_mut() {
                         let diff_hash = aux(children[index].as_mut(), key, callback);
-                        node.tree_hash ^= diff_hash;
+                        node.tree_hash += diff_hash;
                         diff_hash
                     } else {
                         callback(None);
                         // callback cannot change the content of the tree, no invariant to restore
-                        0
+                        Fingerprint::ZERO
                     }
                 }
             }
@@ -367,14 +364,15 @@ impl<K: Hash + Ord, V: Hash> HRTree<K, V> {
             node: &mut Node<K, V>,
             key: K,
             value: V,
-        ) -> (InsertionTuple<K, V>, u64, Option<V>) {
+        ) -> (InsertionTuple<K, V>, Fingerprint, Option<V>) {
             match node.keys.binary_search(&key) {
                 Ok(index) => {
                     let old_hash = node.hashes[index];
                     let new_hash = hash(&key, &value);
-                    let diff_hash = old_hash ^ new_hash;
+                    // signed delta to apply to this node and every ancestor
+                    let diff_hash = new_hash - old_hash;
                     node.hashes[index] = new_hash;
-                    node.tree_hash ^= diff_hash;
+                    node.tree_hash += diff_hash;
                     let ret = std::mem::replace(&mut node.values[index], value);
                     (None, diff_hash, Some(ret))
                 }
@@ -389,7 +387,7 @@ impl<K: Hash + Ord, V: Hash> HRTree<K, V> {
                             if ret.is_none() {
                                 node.tree_size += 1;
                             }
-                            node.tree_hash ^= diff_hash;
+                            node.tree_hash += diff_hash;
                         }
                         (to_insert, diff_hash, ret)
                     } else {
@@ -423,11 +421,11 @@ impl<K: Hash + Ord, V: Hash> HRTree<K, V> {
     }
 
     pub fn remove(&mut self, key: &K) -> Option<V> {
-        fn rightmost_child<K, V>(node: &mut Node<K, V>) -> (K, V, u64) {
+        fn rightmost_child<K, V>(node: &mut Node<K, V>) -> (K, V, Fingerprint) {
             if let Some(children) = node.children.as_mut() {
                 let (k, v, h) = rightmost_child(children.last_mut().unwrap());
                 node.tree_size -= 1;
-                node.tree_hash ^= h;
+                node.tree_hash -= h;
                 node.rebalance_after_deletion(node.keys.len());
                 (k, v, h)
             } else {
@@ -435,14 +433,14 @@ impl<K: Hash + Ord, V: Hash> HRTree<K, V> {
                 let v = node.values.pop().unwrap();
                 let h = node.hashes.pop().unwrap();
                 node.tree_size -= 1;
-                node.tree_hash ^= h;
+                node.tree_hash -= h;
                 (k, v, h)
             }
         }
         // return:
         // - the hash diff
         // - the value at the key that was removed, if there was one
-        fn aux<K: Ord, V>(node: &mut Node<K, V>, key: &K) -> (u64, Option<V>) {
+        fn aux<K: Ord, V>(node: &mut Node<K, V>, key: &K) -> (Fingerprint, Option<V>) {
             match node.keys.binary_search(key) {
                 Ok(index) => {
                     if let Some(children) = node.children.as_mut() {
@@ -454,7 +452,7 @@ impl<K: Hash + Ord, V: Hash> HRTree<K, V> {
                         let v = std::mem::replace(&mut node.values[index], prev_v);
                         let h = std::mem::replace(&mut node.hashes[index], prev_h);
                         node.tree_size -= 1;
-                        node.tree_hash ^= h;
+                        node.tree_hash -= h;
                         node.rebalance_after_deletion(index);
                         (h, Some(v))
                     } else {
@@ -463,7 +461,7 @@ impl<K: Hash + Ord, V: Hash> HRTree<K, V> {
                         let v = node.values.remove(index);
                         let h = node.hashes.remove(index);
                         node.tree_size -= 1;
-                        node.tree_hash ^= h;
+                        node.tree_hash -= h;
                         (h, Some(v))
                     }
                 }
@@ -474,12 +472,12 @@ impl<K: Hash + Ord, V: Hash> HRTree<K, V> {
                         if ret.is_some() {
                             node.tree_size -= 1;
                         }
-                        node.tree_hash ^= diff_hash;
+                        node.tree_hash -= diff_hash;
                         node.rebalance_after_deletion(index);
                         (diff_hash, ret)
                     } else {
                         // leaf node
-                        (0, None)
+                        (Fingerprint::ZERO, None)
                     }
                 }
             }
@@ -501,8 +499,8 @@ impl<K: Hash + Ord, V: Hash> HRTree<K, V> {
             node: &'a Node<K, V>,
             mut min: Option<&'a K>,
             max: Option<&K>,
-        ) -> (u64, usize, usize) {
-            let mut cum_hash = 0;
+        ) -> (Fingerprint, usize, usize) {
+            let mut cum_hash = Fingerprint::ZERO;
             let mut tot_size = 0;
             let mut max_height = 1;
             // check node size
@@ -528,7 +526,7 @@ impl<K: Hash + Ord, V: Hash> HRTree<K, V> {
                 if let Some(children) = node.children.as_ref() {
                     let next_max = Some(&node.keys[i]);
                     let (child_hash, child_size, child_height) = aux(&children[i], min, next_max);
-                    cum_hash ^= child_hash;
+                    cum_hash += child_hash;
                     tot_size += child_size;
                     if max_height != 1 {
                         assert_eq!(child_height, max_height, "height invariant violated");
@@ -539,14 +537,14 @@ impl<K: Hash + Ord, V: Hash> HRTree<K, V> {
                 // key
                 let hash = hash(&node.keys[i], &node.values[i]);
                 assert_eq!(hash, node.hashes[i], "hash cache invalid");
-                cum_hash ^= hash;
+                cum_hash += hash;
                 tot_size += 1;
             }
             // child after last key
             if let Some(children) = node.children.as_ref() {
                 let (child_hash, child_size, child_height) =
                     aux(children.last().unwrap(), min, max);
-                cum_hash ^= child_hash;
+                cum_hash += child_hash;
                 tot_size += child_size;
                 if max_height != 1 {
                     assert_eq!(child_height, max_height, "height invariant violated");
@@ -576,13 +574,13 @@ impl<K: std::fmt::Debug, V: std::fmt::Debug> std::fmt::Debug for HRTree<K, V> {
 
 impl<K: Hash + Ord, V: Hash> HashRangeQueryable for HRTree<K, V> {
     type Key = K;
-    fn hash<R: RangeBounds<K>>(&self, range: &R) -> u64 {
+    fn hash<R: RangeBounds<K>>(&self, range: &R) -> Fingerprint {
         fn aux<'a, K: Ord, V, R: RangeBounds<K>>(
             node: &'a Node<K, V>,
             range: &R,
             mut lower_bound: Option<&'a K>,
             upper_bound: Option<&K>,
-        ) -> u64 {
+        ) -> Fingerprint {
             // check if the lower-bound is included in the range
             let lower_bound_included = match range.start_bound() {
                 Bound::Unbounded => true,
@@ -611,7 +609,7 @@ impl<K: Hash + Ord, V: Hash> HashRangeQueryable for HRTree<K, V> {
             }
             // otherwise, recurse in the relevant sub-trees
 
-            let mut cum_hash = 0;
+            let mut cum_hash = Fingerprint::ZERO;
             let mut i = 0;
             while i < node.keys.len() && node.keys[i].range_cmp(range) == RangeOrdering::Below {
                 i += 1;
@@ -619,14 +617,14 @@ impl<K: Hash + Ord, V: Hash> HashRangeQueryable for HRTree<K, V> {
             while i < node.keys.len() && node.keys[i].range_cmp(range) == RangeOrdering::Inside {
                 let cur_bound = Some(&node.keys[i]);
                 if let Some(children) = node.children.as_ref() {
-                    cum_hash ^= aux(&children[i], range, lower_bound, cur_bound);
+                    cum_hash += aux(&children[i], range, lower_bound, cur_bound);
                 }
-                cum_hash ^= node.hashes[i];
+                cum_hash += node.hashes[i];
                 lower_bound = cur_bound;
                 i += 1;
             }
             if let Some(children) = node.children.as_ref() {
-                cum_hash ^= aux(&children[i], range, lower_bound, upper_bound);
+                cum_hash += aux(&children[i], range, lower_bound, upper_bound);
             }
             cum_hash
         }
@@ -775,6 +773,7 @@ mod tests {
     use rand::{seq::SliceRandom, Rng, SeedableRng};
 
     use crate::diff::{Diffable, HashRangeQueryable};
+    use crate::fingerprint::Fingerprint;
 
     use super::HRTree;
 
@@ -792,27 +791,27 @@ mod tests {
     fn test_hash() {
         // empty
         let mut tree = HRTree::new();
-        assert_eq!(tree.hash(&..), 0);
+        assert_eq!(tree.hash(&..), Fingerprint::ZERO);
         tree.check_invariants();
 
         // 1 value
         tree.insert(50, "Hello");
         tree.check_invariants();
         let hash1 = tree.hash(&..);
-        assert_ne!(hash1, 0);
+        assert_ne!(hash1, Fingerprint::ZERO);
 
         // 2 values
         tree.insert(25, "World!");
         tree.check_invariants();
         let hash2 = tree.hash(&..);
-        assert_ne!(hash2, 0);
+        assert_ne!(hash2, Fingerprint::ZERO);
         assert_ne!(hash2, hash1);
 
         // 3 values
         tree.insert(75, "Everyone!");
         tree.check_invariants();
         let hash3 = tree.hash(&..);
-        assert_ne!(hash3, 0);
+        assert_ne!(hash3, Fingerprint::ZERO);
         assert_ne!(hash3, hash1);
         assert_ne!(hash3, hash2);
 
@@ -829,7 +828,7 @@ mod tests {
         let mut tree1 = HRTree::new();
         let mut key_values = Vec::new();
 
-        let mut expected_hash = 0;
+        let mut expected_hash = Fingerprint::ZERO;
 
         // add some
         for _ in 0..1000 {
@@ -838,7 +837,7 @@ mod tests {
             let old = tree1.insert(key, value);
             assert!(old.is_none());
             tree1.check_invariants();
-            expected_hash ^= super::hash(&key, &value);
+            expected_hash += super::hash(&key, &value);
             assert_eq!(tree1.hash(&..), expected_hash);
             key_values.push((key, value));
         }
@@ -854,7 +853,7 @@ mod tests {
         tree1.insert(key, value1);
         tree1.with_mut(&key, |v| *v.unwrap() = value2);
         tree1.check_invariants();
-        expected_hash ^= super::hash(&key, &value2);
+        expected_hash += super::hash(&key, &value2);
         key_values.push((key, value2));
 
         // in the tree, the items should now be sorted
@@ -867,7 +866,7 @@ mod tests {
         let mid = key_values[key_values.len() / 2].0;
         assert_ne!(tree1.hash(&(mid..)), tree1.hash(&..));
         assert_ne!(tree1.hash(&..mid), tree1.hash(&..));
-        assert_eq!(tree1.hash(&..mid) ^ tree1.hash(&(mid..)), tree1.hash(&..));
+        assert_eq!(tree1.hash(&..mid) + tree1.hash(&(mid..)), tree1.hash(&..));
 
         for _ in 0..100 {
             let index = rng.gen::<usize>() % key_values.len();
@@ -944,7 +943,7 @@ mod tests {
             let value2 = tree1.remove(&key);
             tree1.check_invariants();
             assert_eq!(value2, Some(value));
-            expected_hash ^= super::hash(&key, &value);
+            expected_hash -= super::hash(&key, &value);
             assert_eq!(tree1.hash(&..), expected_hash);
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@
 //! threat model and scope.
 
 pub mod diff;
+pub mod fingerprint;
 pub mod gen_ip;
 pub mod hrtree;
 pub mod hrtree_iter;
@@ -38,5 +39,6 @@ pub(crate) mod reconcilable;
 pub(crate) mod reconcile_engine;
 pub(crate) mod timeout_wheel;
 
+pub use fingerprint::Fingerprint;
 pub use hrtree::HRTree;
 pub use reconcile_store::ReconcileStore;

--- a/src/reconcile_engine.rs
+++ b/src/reconcile_engine.rs
@@ -31,6 +31,7 @@ use tracing::{debug, trace, warn};
 use crate::auth;
 use crate::diff::HashRangeQueryable;
 use crate::diff::{Diffable, HashSegment};
+use crate::fingerprint::Fingerprint;
 use crate::gen_ip::gen_ip;
 use crate::reconcilable::{MaybeTombstone, Reconcilable};
 use crate::reconcile_store::Config;
@@ -158,7 +159,7 @@ impl<
         }
     }
 
-    pub fn fingerprint<R: RangeBounds<K>>(&self, range: R) -> u64 {
+    pub fn fingerprint<R: RangeBounds<K>>(&self, range: R) -> Fingerprint {
         self.map.read().hash(&range)
     }
 

--- a/src/reconcile_store.rs
+++ b/src/reconcile_store.rs
@@ -20,6 +20,7 @@ use ipnet::IpNet;
 use parking_lot::{MappedRwLockReadGuard, RwLockReadGuard};
 use serde::{de::DeserializeOwned, Serialize};
 
+use crate::fingerprint::Fingerprint;
 use crate::reconcile_engine::{version_hash, ReconcileEngine};
 use crate::timeout_wheel::TimeoutWheel;
 
@@ -116,7 +117,7 @@ impl<
         *self.engine.pre_insert.write() = Box::new(wrapped_pre_insert);
     }
 
-    pub fn fingerprint<R: RangeBounds<K>>(&self, range: R) -> u64 {
+    pub fn fingerprint<R: RangeBounds<K>>(&self, range: R) -> Fingerprint {
         self.engine.fingerprint(range)
     }
 

--- a/tests/diff.rs
+++ b/tests/diff.rs
@@ -2,6 +2,7 @@ use std::hash::Hash;
 use std::ops::{Bound, RangeBounds};
 
 use reconcile::diff::{DiffRange, Diffable, HashRangeQueryable, HashSegment};
+use reconcile::fingerprint::Fingerprint;
 use reconcile::hrtree::HRTree;
 
 pub fn diff<K, D: Diffable<ComparisonItem = HashSegment<K>, DifferenceItem = DiffRange<K>>>(
@@ -116,10 +117,17 @@ fn test_compare() {
 /// This lets us deterministically reproduce issue #106 (the `hash == 0` sentinel
 /// aliasing a non-empty range) without relying on a real, non-portable
 /// `DefaultHasher` collision.
-fn elem_hash(key: i32) -> u64 {
+fn elem_hash(key: i32) -> Fingerprint {
     match key {
-        1 | 2 => 7,
-        k => (k as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15) | 1,
+        // Keys 1 and 2 are crafted to cancel under the additive combiner:
+        // `elem_hash(1) + elem_hash(2) == ZERO (mod 2²⁵⁶)`, so the non-empty
+        // range {1, 2} fingerprints to ZERO — exactly the issue #106 hazard.
+        1 => Fingerprint([7, 0, 0, 0]),
+        2 => -Fingerprint([7, 0, 0, 0]),
+        k => {
+            let m = (k as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15) | 1;
+            Fingerprint([m, m ^ 0x5555_5555_5555_5555, m.rotate_left(17), m | 0x80])
+        }
     }
 }
 
@@ -155,11 +163,11 @@ impl MockStore {
 impl HashRangeQueryable for MockStore {
     type Key = i32;
 
-    fn hash<R: RangeBounds<i32>>(&self, range: &R) -> u64 {
+    fn hash<R: RangeBounds<i32>>(&self, range: &R) -> Fingerprint {
         self.keys
             .iter()
             .filter(|k| range.contains(k))
-            .fold(0, |acc, &k| acc ^ elem_hash(k))
+            .fold(Fingerprint::ZERO, |acc, &k| acc + elem_hash(k))
     }
 
     fn insertion_position(&self, key: &i32) -> usize {
@@ -188,8 +196,8 @@ fn nonempty_range_hashing_to_zero_vs_empty() {
     let b = MockStore::new(vec![]);
 
     // Sanity: the non-empty range really does hash to the empty sentinel value.
-    assert_eq!(a.hash(&..), 0);
-    assert_eq!(b.hash(&..), 0);
+    assert_eq!(a.hash(&..), Fingerprint::ZERO);
+    assert_eq!(b.hash(&..), Fingerprint::ZERO);
 
     let (local_diff_ranges, remote_diff_ranges) = diff(&a, &b);
 
@@ -211,8 +219,8 @@ fn nonempty_collision_vs_different_content() {
     let a = MockStore::new(vec![1, 2]);
     let b = MockStore::new(vec![1, 2, 5]);
 
-    assert_eq!(a.hash(&..), 0);
-    assert_ne!(b.hash(&..), 0);
+    assert_eq!(a.hash(&..), Fingerprint::ZERO);
+    assert_ne!(b.hash(&..), Fingerprint::ZERO);
 
     let (local_diff_ranges, remote_diff_ranges) = diff(&a, &b);
 

--- a/tests/service.rs
+++ b/tests/service.rs
@@ -5,7 +5,7 @@ use rand::{
     Rng, SeedableRng,
 };
 
-use reconcile::{reconcile_store::Config, ReconcileStore};
+use reconcile::{reconcile_store::Config, Fingerprint, ReconcileStore};
 
 /// Wait for a while until the provided predicate becomes true
 ///
@@ -56,7 +56,7 @@ async fn test() {
     let start_hash = store1.fingerprint(..);
     let store2 = ReconcileStore::new(cfg2).await.with_seed(addr1);
     let task2 = tokio::spawn(store2.clone().run());
-    assert_eq!(store2.fingerprint(..), 0);
+    assert_eq!(store2.fingerprint(..), Fingerprint::ZERO);
     let task1 = tokio::spawn(store1.clone().run());
     assert_eq!(store1.fingerprint(..), start_hash);
 


### PR DESCRIPTION
## Summary

Fixes the weak, non-portable range fingerprint described in #111. The fingerprint was a **64-bit XOR of per-element `DefaultHasher(key, value)`**, which had two independent defects:

1. **XOR is algebraically weak.** It is `GF(2)`-linear and self-inverse, so cancelling/repeated element hashes vanish and an adversary can *solve* (Gaussian elimination) for crafted elements that make a divergent range collide in fingerprint → silent missed differences. 64 bits also invites accidental birthday collisions (~2³²) across a cluster's lifetime.
2. **`DefaultHasher` is unstable** across Rust versions and platforms (per std docs). As the **wire reconciliation token**, two nodes on different toolchains / word sizes compute different hashes for identical data and never converge.

## Changes

- **New `Fingerprint`** (`src/fingerprint.rs`): a 256-bit value (four little-endian limbs) forming an abelian group under **addition modulo 2²⁵⁶** — combine is `+`, remove is `-`. Addition with carries is **not** `GF(2)`-linear (defeats offline collision crafting), and 256 bits pushes birthday collisions to ~2¹²⁸. This is the issue's suggested "hash-then-add mod 2²⁵⁶" combiner.
- **Element hash pinned to BLAKE3**, fed through a `Hasher` adapter that emits integers in **fixed little-endian width**, so 32-/64-bit and big-/little-endian nodes feed BLAKE3 identical bytes → a stable, portable wire token. (`blake3` was already a default dependency via the `mac-blake3` MAC backend; it is now non-optional.)
- **Golden-vector tests** freeze the element hash and a combined fingerprint, so any accidental change to the wire format fails CI — exactly as recommended in the issue.
- Mechanical conversion of the `HRTree`: every XOR combine became an add (`combine` / insert delta `new − old`) or a subtract (element/subtree removal). XOR was its own inverse; the additive group needs explicit direction, which was mapped at every accumulation site (`refresh_hash_size`, `insert`, `with_mut`, `remove`/`rightmost_child`, `rebalance_after_deletion`, the range query, and `check_invariants`).
- Drive-by: removed a stray `println!` debug leftover in `HRTree::with_mut`.
- Updated the public `fingerprint()`/`HashRangeQueryable::hash` return type and `HashSegment.hash` field to `Fingerprint`, plus the README description.

## Testing

- `cargo test --all` — all green (lib 37, doc/diff/service suites pass), including the existing `big_test` and `check_invariants` (which verify the cumulative fingerprint after every insert/update/remove against an independently-maintained reference) and the issue #106 regression tests (now using crafted elements that cancel to `ZERO` under the additive combiner).
- `cargo fmt --check`, `cargo clippy --all -- -D warnings`, `cargo doc` (with `-Dwarnings`), and `cargo bench --no-run` all pass.

## Out of scope / follow-up

`version_hash` (the tombstone-version token in `reconcile_engine.rs`) still uses `DefaultHasher`. It shares the cross-version stability smell but is **not** the range fingerprint targeted by #111 (XOR weakness does not apply to it), so it is intentionally left for a separate change.

Closes #111

https://claude.ai/code/session_01WSypeznLw9aDmgJYz7ce4x

---
_Generated by [Claude Code](https://claude.ai/code/session_01WSypeznLw9aDmgJYz7ce4x)_