### PR TITLE
Fix LWW conflict resolution with a Hybrid Logical Clock

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,35 @@ The ReconcileStore exploits the properties of `HRTree` to conduct a binary-searc
 search in the collections of the two instances. Once difference are found, the
 corresponding key-value pairs are exchanged and conflicts are resolved.
 
+## Conflict resolution
+
+Conflicts are resolved with last-write-wins (LWW), but keyed on a **Hybrid Logical Clock**
+(`Hlc`, after Kulkarni et al. 2014) rather than a raw wall clock. Each value carries an
+`Hlc` timestamp, and the winner is the one with the greater timestamp under the **total
+order** `(wall_ms, counter, node_id)`.
+
+This matters for correctness. A naive physical-clock LWW is unsafe on two counts:
+
+* under clock skew, a node whose clock runs ahead always wins, **silently losing**
+  causally-newer writes from other nodes;
+* on *equal* timestamps a non-commutative tie-break lets two replicas each keep their own
+  value forever. Because the timestamp is part of the reconciliation hash, their
+  fingerprints never match and the protocol re-exchanges the pair eternally — **permanent
+  divergence and reconciliation livelock**.
+
+The HLC fixes both. On receiving a peer's value, a node advances its own clock past the
+remote timestamp, so a later local write is ordered strictly after everything it has seen
+(no lost update under bounded skew). The `node_id` makes the order total and deterministic,
+so every replica picks the *same* survivor — the merge is commutative, associative and
+idempotent, i.e. genuine Strong Eventual Consistency.
+
+Each node uses a random `node_id` by default; set an explicit one with
+`Config::with_node_id` for a stable, reproducible ordering (e.g. in tests). Each node in a
+cluster must use a distinct id.
+
+LWW still discards one of two *genuinely concurrent* writes by design; recovering both would
+require version vectors or a CRDT, which is out of scope.
+
 ![Graph of the time needed to send 1 insertion and 1 removal](img/perf-send.png)
 
 The graph above shows the amount of time **in microseconds** (abscissa, bottom

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -233,12 +233,14 @@ fn service_send(c: &mut Criterion) {
         listen_addr: addr1,
         peer_net,
         cluster_key: None,
+        node_id: None,
     };
     let cfg2 = Config {
         port,
         listen_addr: addr2,
         peer_net,
         cluster_key: None,
+        node_id: None,
     };
 
     let mut rng = rand::rngs::ThreadRng::default();

--- a/src/hlc.rs
+++ b/src/hlc.rs
@@ -1,0 +1,235 @@
+// Copyright 2023 Developers of the reconcile project.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Hybrid Logical Clock (HLC) used to timestamp values for conflict resolution.
+//!
+//! Conflict resolution in [`ReconcileStore`](crate::ReconcileStore) is last-write-wins (LWW).
+//! Keying LWW on a raw physical wall-clock (`DateTime<Utc>`) is unsafe:
+//!
+//! * under clock skew, a node whose clock runs ahead always wins, silently losing
+//!   causally-newer writes from other nodes;
+//! * on *equal* timestamps a naive tie-break is not commutative, so two replicas can each
+//!   keep their own value forever. Since the timestamp is part of the reconciliation hash,
+//!   their fingerprints never match and the protocol re-exchanges the pair eternally
+//!   (permanent divergence + livelock).
+//!
+//! A [`Hlc`] fixes both. It is a 64-bit-ish hybrid timestamp (Kulkarni et al., 2014) that:
+//!
+//! * stays close to physical time, yet is **locally monotonic** and **respects causality**:
+//!   on receiving a remote timestamp a node advances its own clock past it (the engine's
+//!   internal clock observes every inbound timestamp), so a subsequent local write is ordered
+//!   *after* everything it has seen — no lost update under bounded skew;
+//! * carries a `node_id`, giving a **globally deterministic total order**
+//!   `(wall_ms, counter, node_id)`. Every replica therefore picks the *same* survivor on a
+//!   conflict, which makes the merge commutative, associative and idempotent — i.e. genuine
+//!   Strong Eventual Consistency.
+//!
+//! LWW still discards one of two *genuinely concurrent* writes by design; recovering both
+//! would require version vectors or a CRDT and is out of scope (see issue #110).
+
+use chrono::Utc;
+use parking_lot::Mutex;
+use serde::{Deserialize, Serialize};
+
+/// A Hybrid Logical Clock timestamp.
+///
+/// The fields are compared in declaration order, so the derived [`Ord`] is exactly the
+/// total order `(wall_ms, counter, node_id)` used to resolve conflicts. See the
+/// [module documentation](crate::hlc) for the rationale.
+#[derive(
+    Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize, Default,
+)]
+pub struct Hlc {
+    /// Physical component: milliseconds since the Unix epoch, as last observed by the clock.
+    wall_ms: u64,
+    /// Logical component: disambiguates events sharing the same `wall_ms`.
+    counter: u32,
+    /// Identity of the node that minted this timestamp; provides the deterministic tie-break.
+    node_id: u64,
+}
+
+impl Hlc {
+    /// Build an `Hlc` from its raw components.
+    ///
+    /// Mostly useful in tests and when reconstructing a timestamp from external storage;
+    /// normal code obtains timestamps from the store's internal clock.
+    pub fn new(wall_ms: u64, counter: u32, node_id: u64) -> Hlc {
+        Hlc {
+            wall_ms,
+            counter,
+            node_id,
+        }
+    }
+
+    /// Physical component (milliseconds since the Unix epoch).
+    pub fn wall_ms(&self) -> u64 {
+        self.wall_ms
+    }
+
+    /// Logical counter component.
+    pub fn counter(&self) -> u32 {
+        self.counter
+    }
+
+    /// Identity of the node that minted this timestamp.
+    pub fn node_id(&self) -> u64 {
+        self.node_id
+    }
+}
+
+/// Read physical time as milliseconds since the Unix epoch.
+fn phys_now_ms() -> u64 {
+    Utc::now().timestamp_millis().max(0) as u64
+}
+
+/// A per-node Hybrid Logical Clock.
+///
+/// Generates locally-monotonic [`Hlc`] timestamps with [`now`](HlcClock::now) and advances
+/// past timestamps received from peers with [`observe`](HlcClock::observe). The clock is
+/// internally synchronized, so a single instance is shared (cloned) across all tasks of a
+/// node.
+#[derive(Debug)]
+pub(crate) struct HlcClock {
+    node_id: u64,
+    /// Last timestamp produced or observed; the wall/counter pair is updated atomically
+    /// under the mutex so that [`now`](HlcClock::now) stays strictly monotonic.
+    last: Mutex<Hlc>,
+}
+
+impl HlcClock {
+    /// Create a clock for the node identified by `node_id`.
+    pub fn new(node_id: u64) -> HlcClock {
+        HlcClock {
+            node_id,
+            last: Mutex::new(Hlc {
+                wall_ms: 0,
+                counter: 0,
+                node_id,
+            }),
+        }
+    }
+
+    /// Mint a fresh timestamp for a local event (a write or an outgoing message).
+    ///
+    /// The returned timestamp is strictly greater than every timestamp previously produced
+    /// or observed by this clock, ensuring local monotonicity.
+    pub fn now(&self) -> Hlc {
+        let pt = phys_now_ms();
+        let mut last = self.last.lock();
+        let next = if pt > last.wall_ms {
+            Hlc {
+                wall_ms: pt,
+                counter: 0,
+                node_id: self.node_id,
+            }
+        } else {
+            Hlc {
+                wall_ms: last.wall_ms,
+                counter: last.counter + 1,
+                node_id: self.node_id,
+            }
+        };
+        *last = next;
+        next
+    }
+
+    /// Advance the clock to account for a timestamp received from a peer.
+    ///
+    /// After observing `remote`, a subsequent [`now`](HlcClock::now) is guaranteed to be
+    /// greater than `remote`, so a local write following the receipt of a remote value is
+    /// ordered after it. This is what prevents lost updates under clock skew.
+    pub fn observe(&self, remote: Hlc) {
+        let pt = phys_now_ms();
+        let mut last = self.last.lock();
+        let max_wall = pt.max(last.wall_ms).max(remote.wall_ms);
+        let counter = if max_wall == last.wall_ms && max_wall == remote.wall_ms {
+            last.counter.max(remote.counter) + 1
+        } else if max_wall == last.wall_ms {
+            last.counter + 1
+        } else if max_wall == remote.wall_ms {
+            remote.counter + 1
+        } else {
+            0
+        };
+        *last = Hlc {
+            wall_ms: max_wall,
+            counter,
+            node_id: self.node_id,
+        };
+    }
+}
+
+/// A value that carries an [`Hlc`] timestamp.
+///
+/// Lets the reconciliation engine read the timestamp of a stored value (to advance its
+/// clock on receipt) without knowing the concrete value type.
+pub trait Timestamped {
+    /// The Hybrid Logical Clock timestamp attached to this value.
+    fn timestamp(&self) -> Hlc;
+}
+
+impl<V> Timestamped for (Hlc, V) {
+    fn timestamp(&self) -> Hlc {
+        self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn now_is_strictly_monotonic() {
+        let clock = HlcClock::new(1);
+        let mut prev = clock.now();
+        for _ in 0..10_000 {
+            let next = clock.now();
+            assert!(next > prev, "{next:?} !> {prev:?}");
+            prev = next;
+        }
+    }
+
+    #[test]
+    fn counter_increments_when_wall_does_not_advance() {
+        let clock = HlcClock::new(1);
+        // Force the clock far into the future so physical time cannot advance past it for
+        // the duration of the test: every `now()` must then bump the counter.
+        clock.observe(Hlc::new(u64::MAX - 100, 0, 9));
+        let a = clock.now();
+        let b = clock.now();
+        assert_eq!(a.wall_ms(), b.wall_ms());
+        assert_eq!(b.counter(), a.counter() + 1);
+    }
+
+    #[test]
+    fn observe_advances_past_a_future_timestamp() {
+        // Reproduces defect (a): a peer with a clock running ahead. After observing its
+        // timestamp, our next local write must be ordered *after* it, not lost.
+        let clock = HlcClock::new(1);
+        let future = Hlc::new(phys_now_ms() + 10_000_000, 5, 2);
+        clock.observe(future);
+        let local = clock.now();
+        assert!(
+            local > future,
+            "local write {local:?} was not ordered after observed future timestamp {future:?}"
+        );
+    }
+
+    #[test]
+    fn total_order_breaks_ties_on_node_id() {
+        // Equal wall and counter: the node_id decides, deterministically and identically on
+        // every replica.
+        let a = Hlc::new(100, 0, 1);
+        let b = Hlc::new(100, 0, 2);
+        assert!(a < b);
+        assert!(b > a);
+        // And it is consistent with the field priority: wall dominates counter dominates id.
+        assert!(Hlc::new(100, 1, 1) > Hlc::new(100, 0, 2));
+        assert!(Hlc::new(101, 0, 1) > Hlc::new(100, 9, 9));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@
 
 pub mod diff;
 pub mod gen_ip;
+pub mod hlc;
 pub mod hrtree;
 pub mod hrtree_iter;
 pub mod reconcile_store;
@@ -38,5 +39,6 @@ pub(crate) mod reconcilable;
 pub(crate) mod reconcile_engine;
 pub(crate) mod timeout_wheel;
 
+pub use hlc::Hlc;
 pub use hrtree::HRTree;
 pub use reconcile_store::ReconcileStore;

--- a/src/reconcilable.rs
+++ b/src/reconcilable.rs
@@ -8,7 +8,7 @@
 
 //! Provides the [`Reconcilable`] trait.
 
-use chrono::{DateTime, Utc};
+use crate::hlc::Hlc;
 
 /// Values stored in a map to be synced by the [`ReconcileStore`](crate::reconcile_store::ReconcileStore)
 /// have to be [`Reconcilable`] to ensure safe conflict handling.
@@ -16,7 +16,15 @@ pub trait Reconcilable {
     fn reconcile(&self, other: &Self) -> Self;
 }
 
-impl<V: Clone> Reconcilable for (DateTime<Utc>, V) {
+/// Last-write-wins keyed on a [`Hlc`] timestamp.
+///
+/// Because [`Hlc`] is a **total order** `(wall_ms, counter, node_id)`, `reconcile` is `max`
+/// over that order: it is commutative, associative and idempotent, so every replica
+/// converges to the same value (Strong Eventual Consistency). Two *distinct* writes can
+/// never share an `Hlc` (the same node bumps the counter, different nodes differ on
+/// `node_id`), so the equal-timestamp branch only fires for identical values. See the
+/// [`hlc`](crate::hlc) module for why the previous physical-clock scheme was unsafe.
+impl<V: Clone> Reconcilable for (Hlc, V) {
     fn reconcile(&self, other: &Self) -> Self {
         if other.0 > self.0 {
             other.clone()
@@ -37,8 +45,39 @@ pub trait MaybeTombstone {
     fn is_tombstone(&self) -> bool;
 }
 
-impl<V> MaybeTombstone for (DateTime<Utc>, Option<V>) {
+impl<V> MaybeTombstone for (Hlc, Option<V>) {
     fn is_tombstone(&self) -> bool {
         self.1.is_none()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reconcile_is_commutative_on_equal_wall_and_counter() {
+        // Distinct node_ids with the same wall+counter: the old physical-clock tie-break
+        // kept the local value, so the two replicas diverged forever (defect (b)). The
+        // total order makes the survivor deterministic regardless of argument order.
+        let a = (Hlc::new(100, 0, 1), "a");
+        let b = (Hlc::new(100, 0, 2), "b");
+        assert_eq!(a.reconcile(&b), b.reconcile(&a));
+        // The higher node_id wins consistently.
+        assert_eq!(a.reconcile(&b).1, "b");
+    }
+
+    #[test]
+    fn reconcile_is_idempotent() {
+        let a = (Hlc::new(7, 3, 42), "x");
+        assert_eq!(a.reconcile(&a), a);
+    }
+
+    #[test]
+    fn reconcile_picks_the_greater_timestamp() {
+        let older = (Hlc::new(10, 0, 5), "old");
+        let newer = (Hlc::new(11, 0, 1), "new");
+        assert_eq!(older.reconcile(&newer).1, "new");
+        assert_eq!(newer.reconcile(&older).1, "new");
     }
 }

--- a/src/reconcile_engine.rs
+++ b/src/reconcile_engine.rs
@@ -32,6 +32,7 @@ use crate::auth;
 use crate::diff::HashRangeQueryable;
 use crate::diff::{Diffable, HashSegment};
 use crate::gen_ip::gen_ip;
+use crate::hlc::{Hlc, HlcClock, Timestamped};
 use crate::reconcilable::{MaybeTombstone, Reconcilable};
 use crate::reconcile_store::Config;
 use crate::HRTree;
@@ -79,6 +80,9 @@ pub(crate) struct ReconcileEngine<K, V> {
     pub(crate) members: Arc<RwLock<HashSet<IpAddr>>>,
     /// Per-tombstone acknowledgments: `key -> (peer -> version token of the tombstone it holds)`.
     pub(crate) tombstone_acks: Arc<RwLock<HashMap<K, HashMap<IpAddr, u64>>>>,
+    /// This node's Hybrid Logical Clock, shared across all clones so that every write and
+    /// every received timestamp advances the same clock.
+    clock: Arc<HlcClock>,
 }
 
 impl<K, V> Clone for ReconcileEngine<K, V> {
@@ -94,6 +98,7 @@ impl<K, V> Clone for ReconcileEngine<K, V> {
             authenticator: self.authenticator.clone(),
             members: self.members.clone(),
             tombstone_acks: self.tombstone_acks.clone(),
+            clock: self.clock.clone(),
         }
     }
 }
@@ -124,6 +129,7 @@ impl<
             + Send
             + Serialize
             + Sync
+            + Timestamped
             + 'static,
     > ReconcileEngine<K, V>
 {
@@ -144,6 +150,7 @@ impl<
             );
         }
         let map = HRTree::<K, V>::new();
+        let node_id = config.node_id.unwrap_or_else(rand::random);
         ReconcileEngine {
             map: Arc::new(RwLock::new(map)),
             port: config.port,
@@ -155,11 +162,17 @@ impl<
             authenticator,
             members: Arc::new(RwLock::new(HashSet::new())),
             tombstone_acks: Arc::new(RwLock::new(HashMap::new())),
+            clock: Arc::new(HlcClock::new(node_id)),
         }
     }
 
     pub fn fingerprint<R: RangeBounds<K>>(&self, range: R) -> u64 {
         self.map.read().hash(&range)
+    }
+
+    /// Mint a fresh Hybrid Logical Clock timestamp for a local write.
+    pub fn clock_now(&self) -> Hlc {
+        self.clock.now()
     }
 
     fn get_peers(&self) -> Vec<IpAddr> {
@@ -340,7 +353,7 @@ impl<
         let payload = payload.as_bytes();
         trace!("received {} bytes from {peer}", payload.len());
         let mut in_comparison = Vec::new();
-        let mut updates = Vec::new();
+        let mut updates: Vec<(K, V)> = Vec::new();
         let mut acks: Vec<(K, u64)> = Vec::new();
         let mut deserializer = Deserializer::from_slice(payload, DefaultOptions::new());
         // read messages in buffer
@@ -446,6 +459,10 @@ impl<
             {
                 let mut guard = self.map.write();
                 for (k, remote_v) in updates {
+                    // Advance our clock past the timestamp carried by the remote value, so a
+                    // later local write is ordered after everything we have seen. This is
+                    // what prevents lost updates under clock skew (issue #110).
+                    self.clock.observe(remote_v.timestamp());
                     let tombstone_version = match guard.get(&k) {
                         Some(local_v) => {
                             let merged_v = local_v.reconcile(&remote_v);
@@ -623,18 +640,18 @@ mod auth_attack {
     use std::time::Duration;
 
     use bincode::{DefaultOptions, Serializer};
-    use chrono::{DateTime, TimeZone, Utc};
     use serde::Serialize;
     use tokio::net::UdpSocket;
 
     use super::Message;
+    use crate::hlc::Hlc;
     use crate::{auth, reconcile_store::Config, ReconcileStore};
 
-    /// Serialize the F3 attack payload: an `Update` with a year-9999 timestamp that, if merged,
+    /// Serialize the F3 attack payload: an `Update` with a far-future timestamp that, if merged,
     /// would win against every legitimate write forever.
     fn forged_update() -> Vec<u8> {
-        let far_future = Utc.with_ymd_and_hms(9999, 1, 1, 0, 0, 0).unwrap();
-        let message = Message::Update::<i32, (DateTime<Utc>, Option<String>)>((
+        let far_future = Hlc::new(u64::MAX, 0, 0);
+        let message = Message::Update::<i32, (Hlc, Option<String>)>((
             0,
             (far_future, Some("evil".to_string())),
         ));
@@ -686,12 +703,11 @@ mod auth_attack {
 mod causal_stability {
     use std::net::IpAddr;
 
-    use chrono::{DateTime, Utc};
-
+    use crate::hlc::Hlc;
     use crate::reconcile_engine::{version_hash, ReconcileEngine};
     use crate::reconcile_store::Config;
 
-    type Tombstoned = (DateTime<Utc>, Option<i32>);
+    type Tombstoned = (Hlc, Option<i32>);
 
     async fn engine(addr: &str) -> ReconcileEngine<i32, Tombstoned> {
         let config = Config::default()
@@ -706,7 +722,7 @@ mod causal_stability {
         let peer_a: IpAddr = "127.0.0.61".parse().unwrap();
         let peer_b: IpAddr = "127.0.0.62".parse().unwrap();
         let key = 7;
-        let tombstone: Tombstoned = (Utc::now(), None);
+        let tombstone: Tombstoned = (Hlc::new(1, 0, 0), None);
         let version = version_hash(&tombstone);
 
         // No member known yet: nothing could resurrect the value, so GC is allowed.
@@ -748,7 +764,7 @@ mod causal_stability {
         let live: IpAddr = "127.0.0.64".parse().unwrap();
         let gone: IpAddr = "127.0.0.65".parse().unwrap();
         let key = 9;
-        let tombstone: Tombstoned = (Utc::now(), None);
+        let tombstone: Tombstoned = (Hlc::new(1, 0, 0), None);
         let version = version_hash(&tombstone);
 
         eng.members.write().insert(live);

--- a/src/reconcile_store.rs
+++ b/src/reconcile_store.rs
@@ -20,6 +20,7 @@ use ipnet::IpNet;
 use parking_lot::{MappedRwLockReadGuard, RwLockReadGuard};
 use serde::{de::DeserializeOwned, Serialize};
 
+use crate::hlc::Hlc;
 use crate::reconcile_engine::{version_hash, ReconcileEngine};
 use crate::timeout_wheel::TimeoutWheel;
 
@@ -41,7 +42,7 @@ where
     K: Clone + Hash + std::cmp::Eq + Send + Sync,
 {
     /// Internal map and hooks container.
-    engine: ReconcileEngine<K, (DateTime<Utc>, Option<V>)>,
+    engine: ReconcileEngine<K, (Hlc, Option<V>)>,
     /// Tombstone timestamps for deleted entries.
     tombstones: TimeoutWheel<K>,
 }
@@ -67,7 +68,7 @@ impl<
     /// Create a new `ReconcileStore`, set up network and tombstones.
     pub async fn new(config: Config) -> Self {
         let svc = ReconcileStore {
-            engine: ReconcileEngine::<K, (DateTime<Utc>, Option<V>)>::new(config).await,
+            engine: ReconcileEngine::<K, (Hlc, Option<V>)>::new(config).await,
             tombstones: TimeoutWheel::new(),
         };
         svc.add_pre_insert(|_, _| {});
@@ -99,17 +100,22 @@ impl<
     ///
     /// Hooks are executed outside of the map’s write lock, so calling back into any insert
     /// method from within a hook will not block or deadlock.
-    pub fn add_pre_insert<F: Send + Sync + Fn(&K, &(DateTime<Utc>, Option<V>)) + 'static>(
+    pub fn add_pre_insert<F: Send + Sync + Fn(&K, &(Hlc, Option<V>)) + 'static>(
         &self,
         pre_insert: F,
     ) {
         let tombstones = self.tombstones.clone();
-        let wrapped_pre_insert = move |k: &K, v: &(DateTime<Utc>, Option<V>)| {
+        let wrapped_pre_insert = move |k: &K, v: &(Hlc, Option<V>)| {
             pre_insert(k, v);
             if v.1.is_some() {
                 tombstones.remove(k);
             } else {
-                tombstones.insert(k.clone(), v.0);
+                // The timeout wheel ages tombstones by wall-clock time; use the HLC's
+                // physical component so all replicas expire a tombstone at the same logical
+                // wall time. GC is in any case gated on causal stability.
+                let when =
+                    DateTime::from_timestamp_millis(v.0.wall_ms() as i64).unwrap_or_else(Utc::now);
+                tombstones.insert(k.clone(), when);
             }
         };
         // Swap in the new hook
@@ -137,13 +143,17 @@ impl<
     ///
     /// Returns the overwritten value if the key already existed.
     pub fn just_insert(&self, key: K, value: V) -> Option<V> {
-        let ret = self.engine.just_insert(key, (Utc::now(), Some(value)));
+        let ret = self
+            .engine
+            .just_insert(key, (self.engine.clock_now(), Some(value)));
         ret.and_then(|t| t.1)
     }
 
     /// Fully-qualified insert: just_insert + async broadcast.
     pub fn insert(&self, key: K, value: V) -> Option<V> {
-        let ret = self.engine.insert(key, (Utc::now(), Some(value)));
+        let ret = self
+            .engine
+            .insert(key, (self.engine.clock_now(), Some(value)));
         ret.and_then(|t| t.1)
     }
 
@@ -157,7 +167,7 @@ impl<
         self.engine.just_insert_bulk(
             &key_values
                 .iter()
-                .map(|(k, v)| (k.clone(), (Utc::now(), Some(v.clone()))))
+                .map(|(k, v)| (k.clone(), (self.engine.clock_now(), Some(v.clone()))))
                 .collect::<Vec<_>>(),
         );
     }
@@ -167,18 +177,22 @@ impl<
         self.engine.insert_bulk(
             &key_values
                 .iter()
-                .map(|(k, v)| (k.clone(), (Utc::now(), Some(v.clone()))))
+                .map(|(k, v)| (k.clone(), (self.engine.clock_now(), Some(v.clone()))))
                 .collect::<Vec<_>>(),
         );
     }
 
     pub fn just_remove(&self, key: &K) -> Option<V> {
-        let ret = self.engine.just_insert(key.clone(), (Utc::now(), None));
+        let ret = self
+            .engine
+            .just_insert(key.clone(), (self.engine.clock_now(), None));
         ret.and_then(|t| t.1)
     }
 
     pub fn remove(&self, key: &K) -> Option<V> {
-        let ret = self.engine.insert(key.clone(), (Utc::now(), None));
+        let ret = self
+            .engine
+            .insert(key.clone(), (self.engine.clock_now(), None));
         ret.and_then(|t| t.1)
     }
 
@@ -186,16 +200,22 @@ impl<
         self.engine.just_insert_bulk(
             &keys
                 .iter()
-                .map(|k| (k.clone(), (Utc::now(), None)))
+                .map(|k| (k.clone(), (self.engine.clock_now(), None)))
                 .collect::<Vec<_>>(),
         );
     }
 
-    pub fn remove_bulk(&self, keys: &[(K, DateTime<Utc>)]) {
+    /// Bulk-remove: stamps a fresh Hybrid Logical Clock timestamp for each key and
+    /// broadcasts the resulting tombstones.
+    ///
+    /// Unlike the previous physical-clock API, callers no longer supply timestamps: a
+    /// caller-chosen `DateTime` could collide with another replica's and trigger the
+    /// non-commutative tie-break that caused permanent divergence (issue #110).
+    pub fn remove_bulk(&self, keys: &[K]) {
         self.engine.insert_bulk(
             &keys
                 .iter()
-                .map(|(k, t)| (k.clone(), (*t, None)))
+                .map(|k| (k.clone(), (self.engine.clock_now(), None)))
                 .collect::<Vec<_>>(),
         );
     }
@@ -282,6 +302,14 @@ pub struct Config {
     /// the cluster must use the **same** 32-byte key (and the same MAC backend feature). See
     /// [`Config::with_cluster_key`].
     pub cluster_key: Option<[u8; 32]>,
+    /// Identity of this node, used as the deterministic tie-break in the Hybrid Logical
+    /// Clock total order. When `None` (the default), a random id is generated at startup.
+    ///
+    /// Two nodes must not share the same id, or conflicts between equal `(wall, counter)`
+    /// timestamps would no longer be resolved deterministically. A random 64-bit id makes
+    /// collisions negligible; set an explicit id only when you need a stable, reproducible
+    /// ordering (e.g. in tests).
+    pub node_id: Option<u64>,
     // may include other options in the future: use_tls, tombstone_ttl, metrics, etc.
 }
 impl Default for Config {
@@ -291,6 +319,7 @@ impl Default for Config {
             listen_addr: "127.0.0.1".parse().unwrap(),
             peer_net: "127.0.0.1/8".parse().unwrap(),
             cluster_key: None,
+            node_id: None,
         }
     }
 }
@@ -322,6 +351,15 @@ impl Config {
         self.cluster_key = Some(key);
         self
     }
+
+    /// Set an explicit node identity for the Hybrid Logical Clock tie-break.
+    ///
+    /// Each node in a cluster must use a distinct id. Leave unset to use a random id (the
+    /// default); set it for a stable, reproducible conflict ordering.
+    pub fn with_node_id(mut self, node_id: u64) -> Self {
+        self.node_id = Some(node_id);
+        self
+    }
 }
 
 #[cfg(test)]
@@ -333,16 +371,23 @@ mod reconcile_store_tests {
     #[tokio::test]
     async fn tombstones_expiration() {
         let config = Config {
-            port: 8080,
+            // A dedicated port (and a singleton peer net) isolates this test from the
+            // integration tests: peer discovery probes random addresses in the peer net on
+            // this port, so an overlapping port lets a concurrently-running test's node inject
+            // updates here.
+            port: 8090,
             listen_addr: "127.0.0.45".parse().unwrap(),
-            peer_net: "127.0.0.1/8".parse().unwrap(),
+            peer_net: "127.0.0.45/32".parse().unwrap(),
             cluster_key: None,
+            node_id: None,
         };
         let store = ReconcileStore::<i32, i32>::new(config)
             .await
             .with_tombstone_timeout(Duration::from_millis(1));
 
-        let task = tokio::spawn(store.clone().run());
+        // This test exercises the tombstone TimeoutWheel directly; it deliberately does *not*
+        // spawn `run()`, whose periodic causal-stability-gated GC would itself remove the
+        // expired tombstone and race these assertions.
 
         // insert a tombstone
         store.remove(&0);
@@ -351,7 +396,5 @@ mod reconcile_store_tests {
         assert_eq!(store.tombstones.expired(), vec![0]);
         assert_eq!(store.tombstones.remove(&0), Some(0));
         assert_eq!(store.tombstones.remove(&0), None);
-
-        task.abort();
     }
 }

--- a/tests/service.rs
+++ b/tests/service.rs
@@ -55,10 +55,13 @@ async fn test() {
     store1.insert_bulk(&key_values);
     let start_hash = store1.fingerprint(..);
     let store2 = ReconcileStore::new(cfg2).await.with_seed(addr1);
-    let task2 = tokio::spawn(store2.clone().run());
+    // Check the initial state *before* spawning the run loops: store1's `insert_bulk` already
+    // spawned a background broadcast to its seeded peer (store2), so once store2 starts
+    // receiving these asserts would race with reconciliation.
     assert_eq!(store2.fingerprint(..), 0);
-    let task1 = tokio::spawn(store1.clone().run());
     assert_eq!(store1.fingerprint(..), start_hash);
+    let task2 = tokio::spawn(store2.clone().run());
+    let task1 = tokio::spawn(store1.clone().run());
 
     // check that tree2 is filled with the values from tree1
     assert_until!(store2.fingerprint(..) == start_hash);
@@ -76,35 +79,50 @@ async fn test() {
     store1.remove(&key);
     assert_until!(store2.get(&key).is_none());
 
-    // check that the more recent value always wins
-    for _ in 0..20 {
-        let key = "42".to_string();
-        let value1 = "Hello, World!".to_string();
-        let value2 = "Good bye, World!".to_string();
+    // Check that a *causally later* write always wins. The conflict order is established by
+    // making the second writer observe the first write before acting (we wait for the first
+    // value to propagate). Under the Hybrid Logical Clock this means the second writer's clock
+    // has advanced past the first timestamp, so its write is ordered strictly after — the
+    // deterministic, causality-respecting LWW contract. (We deliberately do *not* rely on
+    // wall-clock real-time order across the two independent node clocks: two writes in the same
+    // millisecond on different nodes are genuinely concurrent and resolved by node id, which is
+    // exactly the ambiguity issue #110 is about.)
+    let key = "42".to_string();
+    for i in 0..20 {
+        // Unique values per iteration so each `assert_until` observes *this* write, not a value
+        // left over from a previous iteration.
+        let first = format!("first-{i}");
+        let second = format!("second-{i}");
         if rng.gen() {
-            // value1 vs value2
-            store1.insert(key.clone(), value1.clone());
-            store2.insert(key.clone(), value2.clone());
-            assert_until!(store1.get(&key).as_deref() == Some(&value2));
-            assert_until!(store2.get(&key).as_deref() == Some(&value2));
+            // store1 writes, store2 observes it, then store2 overwrites: store2's value wins.
+            store1.insert(key.clone(), first.clone());
+            assert_until!(store2.get(&key).as_deref() == Some(&first));
+            store2.insert(key.clone(), second.clone());
+            assert_until!(store1.get(&key).as_deref() == Some(&second));
+            assert_until!(store2.get(&key).as_deref() == Some(&second));
         } else if rng.gen() {
-            // value2 vs value1
-            store1.insert(key.clone(), value2.clone());
-            store2.insert(key.clone(), value1.clone());
-            assert_until!(store1.get(&key).as_deref() == Some(&value1));
-            assert_until!(store2.get(&key).as_deref() == Some(&value1));
+            // Symmetric: store2 writes first, store1 observes, then store1 wins.
+            store2.insert(key.clone(), first.clone());
+            assert_until!(store1.get(&key).as_deref() == Some(&first));
+            store1.insert(key.clone(), second.clone());
+            assert_until!(store1.get(&key).as_deref() == Some(&second));
+            assert_until!(store2.get(&key).as_deref() == Some(&second));
         } else if rng.gen() {
-            // value1 vs tombstone
-            store1.insert(key.clone(), value1);
+            // value then tombstone: the deletion observes the value and wins.
+            store1.insert(key.clone(), first.clone());
+            assert_until!(store2.get(&key).as_deref() == Some(&first));
             store2.remove(&key);
             assert_until!(store1.get(&key).is_none());
             assert_until!(store2.get(&key).is_none());
         } else {
-            // tombstone vs value1
+            // tombstone then value: the insert observes the tombstone and wins.
+            store1.insert(key.clone(), first.clone());
+            assert_until!(store2.get(&key).as_deref() == Some(&first));
             store1.remove(&key);
-            store2.insert(key.clone(), value1.clone());
-            assert_until!(store1.get(&key).as_deref() == Some(&value1));
-            assert_until!(store2.get(&key).as_deref() == Some(&value1));
+            assert_until!(store2.get(&key).is_none());
+            store2.insert(key.clone(), second.clone());
+            assert_until!(store1.get(&key).as_deref() == Some(&second));
+            assert_until!(store2.get(&key).as_deref() == Some(&second));
         }
     }
 
@@ -176,12 +194,74 @@ async fn authenticated_nodes_converge() {
     task1.abort();
 }
 
+/// Regression test for issue #110: two replicas that concurrently write *different* values to
+/// the same key must converge to a single agreed value, with matching fingerprints.
+///
+/// Before the Hybrid Logical Clock fix, conflict resolution keyed on the physical wall clock
+/// with a non-commutative tie-break: on equal timestamps each replica kept its own value, and
+/// because the timestamp is part of the reconciliation hash the fingerprints never matched, so
+/// the protocol re-exchanged the pair forever (permanent divergence + livelock). With the
+/// total-order HLC the survivor is deterministic, so both replicas agree and the fingerprints
+/// equalize. If the regression returned, the convergence assertions below would time out.
+#[tokio::test(flavor = "multi_thread")]
+async fn concurrent_writes_converge() {
+    let port = 8083;
+    let peer_net = "127.0.0.1/8".parse().unwrap();
+    let addr1 = "127.0.0.80".parse().unwrap();
+    let addr2 = "127.0.0.81".parse().unwrap();
+    // Fixed, distinct node ids give a deterministic conflict winner (the higher id).
+    let cfg1 = Config::default()
+        .with_port(port)
+        .with_listen_addr(addr1)
+        .with_peer_net(peer_net)
+        .with_node_id(1);
+    let cfg2 = Config::default()
+        .with_port(port)
+        .with_listen_addr(addr2)
+        .with_peer_net(peer_net)
+        .with_node_id(2);
+
+    let store1 = ReconcileStore::<String, String>::new(cfg1)
+        .await
+        .with_seed(addr2);
+    let store2 = ReconcileStore::<String, String>::new(cfg2)
+        .await
+        .with_seed(addr1);
+    let task1 = tokio::spawn(store1.clone().run());
+    let task2 = tokio::spawn(store2.clone().run());
+
+    // Hammer the same key from both nodes with different values, back to back, so that some
+    // writes race closely in time.
+    let key = "contended".to_string();
+    for i in 0..50 {
+        store1.insert(key.clone(), format!("from-1-{i}"));
+        store2.insert(key.clone(), format!("from-2-{i}"));
+    }
+
+    // Both replicas must converge: identical fingerprints over the whole range, and the same
+    // value for the contended key. (A surviving divergence/livelock would never equalize.)
+    assert_until!(store1.fingerprint(..) == store2.fingerprint(..));
+    let v1 = store1.get(&key).map(|g| g.clone());
+    let v2 = store2.get(&key).map(|g| g.clone());
+    assert_eq!(
+        v1, v2,
+        "replicas disagree on the contended key: {v1:?} vs {v2:?}"
+    );
+    assert!(v1.is_some(), "the contended key vanished entirely");
+
+    task1.abort();
+    task2.abort();
+}
+
 /// Regression test for issue #109: a tombstone must not be garbage-collected while a replica
 /// that has not acknowledged it is still a member (causal stability), and decommissioning that
 /// replica must release the tombstone for GC.
 #[tokio::test(flavor = "multi_thread")]
 async fn tombstone_is_retained_until_peer_acknowledges() {
-    let port = 8080;
+    // A dedicated port isolates this test from the others: peer discovery probes a random
+    // address in 127.0.0.0/8 on this port, so sharing a port lets concurrently-running tests
+    // cross-talk and pollute each other's stores.
+    let port = 8084;
     let peer_net = "127.0.0.1/8".parse().unwrap();
     let addr1 = "127.0.0.72".parse().unwrap();
     let addr2 = "127.0.0.73".parse().unwrap();
@@ -247,7 +327,8 @@ async fn tombstone_is_retained_until_peer_acknowledges() {
 /// resurrected when that replica returns with the stale value.
 #[tokio::test(flavor = "multi_thread")]
 async fn deleted_value_is_not_resurrected_by_returning_peer() {
-    let port = 8080;
+    // Dedicated port for test isolation (see `tombstone_is_retained_until_peer_acknowledges`).
+    let port = 8085;
     let peer_net = "127.0.0.1/8".parse().unwrap();
     let addr1 = "127.0.0.70".parse().unwrap();
     let addr2 = "127.0.0.71".parse().unwrap();


### PR DESCRIPTION
Closes #110.

## Problem

Conflict resolution was last-write-wins (LWW) keyed on the **physical wall clock** (`DateTime<Utc>`) with a strict-`>` tie-break that kept the local value on equal timestamps. As reported in #110, this violated Strong Eventual Consistency in two ways:

- **(a) Lost updates under clock skew** — a node whose clock ran ahead always won, silently discarding causally-newer writes from other nodes.
- **(b) Non-commutative tie-break → permanent divergence + livelock** — on equal timestamps each replica kept its own value. Because the timestamp is part of the reconciliation hash, the two fingerprints never matched and `diff_round` re-exchanged the pair forever.

## Fix

Replace the physical timestamp with a **Hybrid Logical Clock** (`Hlc`, after Kulkarni et al. 2014):

- **New `hlc` module**: `Hlc { wall_ms, counter, node_id }` whose derived `Ord` is exactly the total order `(wall_ms, counter, node_id)`; the per-node `HlcClock` (`now` / `observe`); and a `Timestamped` trait so the generic engine can read a value's timestamp.
- **Deterministic merge** — `reconcile` becomes `max` over a total order: commutative, associative, idempotent, so every replica picks the same survivor. Fixes **(b)**.
- **Causality on receipt** — when the engine applies a remote update it calls `clock.observe(remote.timestamp())`, so a later local write is ordered strictly after everything the node has seen. Fixes **(a)**.
- **Store wiring** — all writes are stamped from the shared clock; `Config::with_node_id` lets callers pin a deterministic identity (random `u64` by default; each node must be distinct).

LWW still drops one of two *genuinely concurrent* writes by design; recovering both would need version vectors / a CRDT and is out of scope (noted in #110).

## API change

`remove_bulk` now takes `&[K]` and stamps fresh HLC timestamps, instead of accepting caller-supplied `&[(K, DateTime<Utc>)]` — caller-chosen timestamps were one of the sources of defect (b). The crate is pre-1.0.

## Tests

- Unit tests for the clock (strict monotonicity, counter bump at constant wall, `observe` ordering a local write past a "future" remote timestamp — the proof for (a), total-order tie-break on `node_id`) and for the merge (commutativity on equal `wall`+`counter`, idempotence, greater-timestamp wins).
- New integration test `concurrent_writes_converge`: two replicas hammer the same key with different values; both fingerprints must equalize and agree on the surviving value. A returning divergence/livelock would time out.
- Fixed pre-existing test-isolation / ordering races that the added load surfaced: unique UDP port per integration test, check initial fingerprints **before** spawning the run loops, and drop the unnecessary `run()` spawn from the tombstone-expiry unit test (its periodic GC raced the assertions).

## Verification

`cargo build`, `cargo test` (incl. doctests), `cargo clippy --all-targets`, `cargo fmt --check`, and `cargo doc --no-deps` all pass; the full suite was run repeatedly to confirm the timing flakiness is gone.

https://claude.ai/code/session_01R5norcungFo39kPhQQRrke

---
_Generated by [Claude Code](https://claude.ai/code/session_01R5norcungFo39kPhQQRrke)_