### PR TITLE
Add pluggable persistence so restarts recover state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -408,6 +408,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -426,6 +442,18 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
 ]
 
 [[package]]
@@ -548,6 +576,12 @@ name = "libc"
 version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "lock_api"
@@ -722,6 +756,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -748,7 +788,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.16",
 ]
 
 [[package]]
@@ -795,6 +835,7 @@ dependencies = [
  "range-cmp",
  "serde",
  "sha2",
+ "tempfile",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -844,6 +885,19 @@ name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+
+[[package]]
+name = "rustix"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "rustversion"
@@ -967,6 +1021,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.4",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1117,6 +1184,15 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -1357,6 +1433,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,5 +48,6 @@ zeroize = { version = "1.7", optional = true, features = ["derive"] }
 clap = { version = "4.4.6", features = ["derive"] }
 criterion = "0.5.1"
 rand = "0.8.5"
+tempfile = "3"
 tokio = { version = "1.33.0", features = ["macros", "rt-multi-thread"] }
 tracing-subscriber = "0.3.17"

--- a/README.md
+++ b/README.md
@@ -30,9 +30,12 @@ The protocol allows finding a difference over millions of elements with a limite
 number of round-trips. It should also work well to populate an instance from
 scratch from other instances.
 
-The intended use case is a scalable Web service with a non-persistent and
-eventually consistent key-value store. The design enable high performance by
-avoiding any latency related to using an external store such as Redis.
+The intended use case is a scalable Web service with an in-memory, eventually
+consistent key-value store. The design enable high performance by avoiding any
+latency related to using an external store such as Redis. Durability is
+optional and pluggable — see [Persistence](#persistence) — so a node can
+recover its state (including tombstones) across a restart instead of rejoining
+the cluster as an empty replica.
 
 ![Architecture diagram of a scalable Web service using reconcile-rs](img/illustration.png)
 
@@ -74,6 +77,38 @@ it is dropped (defense in depth).
 confidentiality (the payload is not encrypted — see issue #96), replay protection (replaying a
 captured datagram is benign for idempotent last-write-wins reconciliation), or a peer allow-list.
 For confidentiality, run the protocol over a trusted/encrypted underlay.
+
+## Persistence
+
+By default a `ReconcileStore` is held purely in memory: a process restart loses the entire dataset,
+**including tombstones**. Losing tombstones is not just a durability problem — it is a correctness
+hazard. A node that restarts empty behaves like a brand-new replica, re-learns already-deleted
+values from peers, and can resurrect them (the tombstone-resurrection problem of issue #109).
+
+Every store therefore always owns a persistence backend (the `Persistence` trait is mandatory).
+What varies is *which* backend is plugged in:
+
+- `InMemoryPersistence` (the default) keeps the latest snapshot in RAM and loses it on restart —
+  i.e. the historical behaviour.
+- `FileSnapshot` durably stores a single atomically-written snapshot on disk.
+
+Plug in a durable backend between `new()` and `run()`. The previous state — live values,
+tombstones, and the issue-#109 causal-stability bookkeeping (membership and per-tombstone
+acknowledgments) — is reloaded **before** the node rejoins the gossip protocol, so a restart does
+not look like a fresh, empty replica:
+
+```rust
+use std::sync::Arc;
+use reconcile::{reconcile_store::Config, FileSnapshot, ReconcileStore};
+
+let store = ReconcileStore::new(Config::default())
+    .await
+    .with_persistence(Arc::new(FileSnapshot::new("/var/lib/myapp/reconcile.snapshot")));
+tokio::spawn(store.clone().run()); // periodically snapshots in the background
+```
+
+The backend is pluggable: implement the `Persistence` trait to store snapshots in `redb`, `sled`,
+S3, or any other medium.
 
 ## HRTree
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,7 @@ pub mod diff;
 pub mod gen_ip;
 pub mod hrtree;
 pub mod hrtree_iter;
+pub mod persistence;
 pub mod reconcile_store;
 
 pub(crate) mod auth;
@@ -39,4 +40,5 @@ pub(crate) mod reconcile_engine;
 pub(crate) mod timeout_wheel;
 
 pub use hrtree::HRTree;
+pub use persistence::{FileSnapshot, InMemoryPersistence, PersistedState, Persistence};
 pub use reconcile_store::ReconcileStore;

--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -1,0 +1,281 @@
+// Copyright 2023 Developers of the reconcile project.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Durability for a [`ReconcileStore`](crate::ReconcileStore).
+//!
+//! A [`ReconcileStore`](crate::ReconcileStore) **always** owns a persistence backend: the
+//! [`Persistence`] trait is mandatory, not opt-in. What varies is *which* backend is plugged in.
+//! The default is [`InMemoryPersistence`], which keeps the latest snapshot in RAM and therefore
+//! **loses everything when the process restarts** — i.e. the historical, pre-persistence behaviour.
+//! Swapping in a durable backend such as [`FileSnapshot`] via
+//! [`ReconcileStore::with_persistence`](crate::ReconcileStore::with_persistence) makes a restart
+//! recover the previous state instead of looking like a brand-new replica.
+//!
+//! Why this matters: a node that restarts with an empty map loses its **tombstones** too. Losing
+//! tombstones is not just a durability problem — it is a correctness multiplier for tombstone
+//! resurrection (see issue #109): the restarted node behaves like a fresh replica, re-learns
+//! already-deleted values from peers, and can re-propagate them. A durable backend recovers the
+//! tombstones (and the #109 causal-stability state) before the node rejoins the gossip protocol.
+//!
+//! # What is persisted
+//!
+//! - **All map entries**, live values *and* tombstones (the map stores `(timestamp, Option<V>)`,
+//!   and tombstones are `(timestamp, None)` retained until causal-stability-gated GC).
+//! - The **causal-stability state** from issue #109: the membership set and the per-tombstone
+//!   acknowledgments, so a restarted node still holds back GC until every replica has seen a
+//!   deletion.
+//!
+//! The tombstone-expiry timeout wheel is **not** persisted separately: replaying the entries
+//! through the store's pre-insert hook rebuilds it, preserving each tombstone's original deletion
+//! timestamp.
+
+use std::collections::{HashMap, HashSet};
+use std::fs;
+use std::io;
+use std::net::IpAddr;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+use chrono::{DateTime, Utc};
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+
+/// The store's keyed entries in their internal dated, tombstone-aware form: each key maps to a
+/// `(timestamp, Option<V>)`, where a `None` payload is a tombstone.
+pub type DatedEntries<K, V> = Vec<(K, (DateTime<Utc>, Option<V>))>;
+
+/// A snapshot of everything a [`ReconcileStore`](crate::ReconcileStore) needs to durably survive a
+/// restart without behaving like a fresh replica.
+///
+/// `V` is the user value type; entries store the internal dated, tombstone-aware representation
+/// `(DateTime<Utc>, Option<V>)`.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(bound(
+    serialize = "K: Serialize, V: Serialize",
+    deserialize = "K: Deserialize<'de> + Eq + std::hash::Hash, V: Deserialize<'de>"
+))]
+pub struct PersistedState<K, V> {
+    /// Every key with its dated value. A `None` payload is a tombstone.
+    pub entries: DatedEntries<K, V>,
+    /// Every peer this node has ever communicated with (causal-stability membership, #109).
+    pub members: HashSet<IpAddr>,
+    /// Per-tombstone acknowledgments: `key -> (peer -> version token of the tombstone it holds)`.
+    pub tombstone_acks: HashMap<K, HashMap<IpAddr, u64>>,
+}
+
+/// A pluggable durable backend for a [`ReconcileStore`](crate::ReconcileStore).
+///
+/// Every store owns one (the trait is mandatory); [`InMemoryPersistence`] is the non-durable
+/// default. Implementations must be cheap to share across tasks (`Send + Sync + 'static`) since the
+/// store holds the backend behind an [`Arc`](std::sync::Arc) and snapshots from a background task.
+pub trait Persistence<K, V>: Send + Sync + 'static {
+    /// Load the previously saved state, or `Ok(None)` if nothing was ever saved.
+    fn load(&self) -> io::Result<Option<PersistedState<K, V>>>;
+    /// Durably save the given state, atomically replacing any previous snapshot.
+    fn save(&self, state: &PersistedState<K, V>) -> io::Result<()>;
+}
+
+/// The **default** persistence backend: keeps the latest snapshot in RAM.
+///
+/// Within a running process a save followed by a load round-trips faithfully, but the snapshot
+/// lives only in memory, so **a process restart loses everything** — exactly the historical
+/// behaviour of a store with no on-disk durability. Use [`FileSnapshot`] (or another durable
+/// backend) when a restart must recover the previous state.
+pub struct InMemoryPersistence<K, V> {
+    state: Mutex<Option<PersistedState<K, V>>>,
+}
+
+impl<K, V> Default for InMemoryPersistence<K, V> {
+    fn default() -> Self {
+        InMemoryPersistence {
+            state: Mutex::new(None),
+        }
+    }
+}
+
+impl<K, V> InMemoryPersistence<K, V> {
+    /// Create an empty in-memory backend.
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl<K, V> Persistence<K, V> for InMemoryPersistence<K, V>
+where
+    K: Clone + Send + Sync + 'static,
+    V: Clone + Send + Sync + 'static,
+{
+    fn load(&self) -> io::Result<Option<PersistedState<K, V>>> {
+        Ok(self.state.lock().unwrap().clone())
+    }
+
+    fn save(&self, state: &PersistedState<K, V>) -> io::Result<()> {
+        *self.state.lock().unwrap() = Some(state.clone());
+        Ok(())
+    }
+}
+
+/// A durable, file-based [`Persistence`] backend storing a single bincode-encoded snapshot.
+///
+/// Saves are **atomic**: the snapshot is written to a sibling `*.tmp` file, flushed, then renamed
+/// over the target path, so a crash mid-write never corrupts a previously good snapshot.
+#[derive(Clone, Debug)]
+pub struct FileSnapshot {
+    path: PathBuf,
+}
+
+impl FileSnapshot {
+    /// Create a backend that reads from and writes to `path`.
+    pub fn new(path: impl AsRef<Path>) -> Self {
+        FileSnapshot {
+            path: path.as_ref().to_path_buf(),
+        }
+    }
+
+    fn tmp_path(&self) -> PathBuf {
+        let mut tmp = self.path.clone().into_os_string();
+        tmp.push(".tmp");
+        PathBuf::from(tmp)
+    }
+}
+
+impl<K, V> Persistence<K, V> for FileSnapshot
+where
+    K: Serialize + DeserializeOwned + Eq + std::hash::Hash + Send + Sync + 'static,
+    V: Serialize + DeserializeOwned + Send + Sync + 'static,
+{
+    fn load(&self) -> io::Result<Option<PersistedState<K, V>>> {
+        let bytes = match fs::read(&self.path) {
+            Ok(bytes) => bytes,
+            Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(None),
+            Err(err) => return Err(err),
+        };
+        let state = bincode::deserialize(&bytes)
+            .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
+        Ok(Some(state))
+    }
+
+    fn save(&self, state: &PersistedState<K, V>) -> io::Result<()> {
+        let bytes = bincode::serialize(state)
+            .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
+        let tmp = self.tmp_path();
+        // Write to a temporary file, flush it, then atomically rename over the target so a crash
+        // mid-write cannot corrupt a previously good snapshot.
+        {
+            use std::io::Write;
+            let mut file = fs::File::create(&tmp)?;
+            file.write_all(&bytes)?;
+            file.sync_all()?;
+        }
+        fs::rename(&tmp, &self.path)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_state() -> PersistedState<i32, String> {
+        let mut members = HashSet::new();
+        members.insert("127.0.0.1".parse().unwrap());
+        members.insert("127.0.0.2".parse().unwrap());
+
+        let mut acks = HashMap::new();
+        let mut key_acks = HashMap::new();
+        key_acks.insert("127.0.0.1".parse().unwrap(), 42u64);
+        acks.insert(7, key_acks);
+
+        PersistedState {
+            entries: vec![
+                (1, (Utc::now(), Some("alive".to_string()))),
+                (2, (Utc::now(), None)), // tombstone
+            ],
+            members,
+            tombstone_acks: acks,
+        }
+    }
+
+    fn assert_states_eq(a: &PersistedState<i32, String>, b: &PersistedState<i32, String>) {
+        assert_eq!(a.entries, b.entries);
+        assert_eq!(a.members, b.members);
+        assert_eq!(a.tombstone_acks, b.tombstone_acks);
+    }
+
+    #[test]
+    fn persisted_state_bincode_roundtrip() {
+        let state = sample_state();
+        let bytes = bincode::serialize(&state).unwrap();
+        let back: PersistedState<i32, String> = bincode::deserialize(&bytes).unwrap();
+        assert_states_eq(&back, &state);
+    }
+
+    #[test]
+    fn in_memory_roundtrips_within_process() {
+        let backend = InMemoryPersistence::<i32, String>::new();
+        assert!(backend.load().unwrap().is_none());
+
+        let state = sample_state();
+        backend.save(&state).unwrap();
+        assert_states_eq(&backend.load().unwrap().unwrap(), &state);
+    }
+
+    #[test]
+    fn in_memory_save_replaces_previous() {
+        let backend = InMemoryPersistence::<i32, String>::new();
+
+        let mut first = sample_state();
+        first.entries = vec![(1, (Utc::now(), Some("first".to_string())))];
+        backend.save(&first).unwrap();
+
+        let mut second = sample_state();
+        second.entries = vec![(1, (Utc::now(), Some("second".to_string())))];
+        backend.save(&second).unwrap();
+
+        let loaded = backend.load().unwrap().unwrap();
+        assert_eq!(loaded.entries[0].1 .1, Some("second".to_string()));
+    }
+
+    #[test]
+    fn file_snapshot_save_then_load() {
+        let dir = tempfile::tempdir().unwrap();
+        let backend = FileSnapshot::new(dir.path().join("snapshot.bin"));
+
+        // Nothing saved yet.
+        assert!(Persistence::<i32, String>::load(&backend)
+            .unwrap()
+            .is_none());
+
+        let state = sample_state();
+        Persistence::<i32, String>::save(&backend, &state).unwrap();
+
+        let loaded = Persistence::<i32, String>::load(&backend)
+            .unwrap()
+            .expect("a snapshot was saved");
+        assert_states_eq(&loaded, &state);
+    }
+
+    #[test]
+    fn file_snapshot_save_is_atomic_replace() {
+        let dir = tempfile::tempdir().unwrap();
+        let backend = FileSnapshot::new(dir.path().join("snapshot.bin"));
+
+        let mut first = sample_state();
+        first.entries = vec![(1, (Utc::now(), Some("first".to_string())))];
+        Persistence::<i32, String>::save(&backend, &first).unwrap();
+
+        let mut second = sample_state();
+        second.entries = vec![(1, (Utc::now(), Some("second".to_string())))];
+        Persistence::<i32, String>::save(&backend, &second).unwrap();
+
+        // No leftover temporary file, and the latest snapshot wins.
+        assert!(!dir.path().join("snapshot.bin.tmp").exists());
+        let loaded = Persistence::<i32, String>::load(&backend).unwrap().unwrap();
+        assert_eq!(loaded.entries[0].1 .1, Some("second".to_string()));
+    }
+}

--- a/src/reconcile_store.rs
+++ b/src/reconcile_store.rs
@@ -13,17 +13,23 @@ use std::fmt::Debug;
 use std::hash::Hash;
 use std::net::IpAddr;
 use std::ops::RangeBounds;
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use chrono::{DateTime, Utc};
 use ipnet::IpNet;
 use parking_lot::{MappedRwLockReadGuard, RwLockReadGuard};
 use serde::{de::DeserializeOwned, Serialize};
+use tracing::warn;
 
+use crate::persistence::{DatedEntries, InMemoryPersistence, PersistedState, Persistence};
 use crate::reconcile_engine::{version_hash, ReconcileEngine};
 use crate::timeout_wheel::TimeoutWheel;
 
 const TOMBSTONE_CLEARING: Duration = Duration::from_secs(1);
+
+/// How often the background task writes a full snapshot to the persistence backend.
+const SNAPSHOT_INTERVAL: Duration = Duration::from_secs(5);
 
 /// Core service wrapping a key-value map to enable reconciliation between different instances over a network.
 ///
@@ -44,6 +50,9 @@ where
     engine: ReconcileEngine<K, (DateTime<Utc>, Option<V>)>,
     /// Tombstone timestamps for deleted entries.
     tombstones: TimeoutWheel<K>,
+    /// Durable backend. Always present (the trait is mandatory); defaults to the non-durable
+    /// [`InMemoryPersistence`], swapped out via [`with_persistence`](ReconcileStore::with_persistence).
+    persistence: Arc<dyn Persistence<K, V>>,
 }
 
 impl<K, V> Clone for ReconcileStore<K, V>
@@ -55,6 +64,7 @@ where
         ReconcileStore {
             engine: self.engine.clone(),
             tombstones: self.tombstones.clone(),
+            persistence: self.persistence.clone(),
         }
     }
 }
@@ -69,9 +79,66 @@ impl<
         let svc = ReconcileStore {
             engine: ReconcileEngine::<K, (DateTime<Utc>, Option<V>)>::new(config).await,
             tombstones: TimeoutWheel::new(),
+            persistence: Arc::new(InMemoryPersistence::default()),
         };
         svc.add_pre_insert(|_, _| {});
         svc
+    }
+
+    /// Plug in a durable persistence backend, **loading any previously saved state first**.
+    ///
+    /// Every store always owns a backend; by default that is the non-durable
+    /// [`InMemoryPersistence`], so a process restart starts empty. Call this with a durable
+    /// backend (e.g. [`FileSnapshot`](crate::FileSnapshot)) between
+    /// [`new`](ReconcileStore::new) and [`run`](ReconcileStore::run) to recover the previous
+    /// state — entries, tombstones, and the causal-stability membership/acks — **before** the
+    /// node rejoins the gossip protocol, so a restart does not look like a fresh, empty replica.
+    ///
+    /// Loaded entries are replayed through the pre-insert hook, which preserves each tombstone's
+    /// original deletion timestamp and rebuilds the tombstone-expiry wheel.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the backend fails to load (e.g. a corrupt snapshot file): recovering from a
+    /// damaged durable state is a deliberate, explicit decision rather than a silent fresh start.
+    pub fn with_persistence(mut self, backend: Arc<dyn Persistence<K, V>>) -> Self {
+        if let Some(state) = backend.load().expect("failed to load persisted state") {
+            *self.engine.members.write() = state.members;
+            *self.engine.tombstone_acks.write() = state.tombstone_acks;
+            // Replay through the wrapped pre-insert hook so the tombstone wheel is rebuilt with the
+            // original deletion timestamps (do NOT route through the public insert helpers, which
+            // would overwrite timestamps with `Utc::now()`).
+            self.engine.just_insert_bulk(&state.entries);
+        }
+        self.persistence = backend;
+        self
+    }
+
+    /// Capture the full store state and hand it to the persistence backend.
+    fn snapshot(&self) {
+        let entries: DatedEntries<K, V> = self
+            .engine
+            .map
+            .read()
+            .iter()
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect();
+        let state = PersistedState {
+            entries,
+            members: self.engine.members.read().clone(),
+            tombstone_acks: self.engine.tombstone_acks.read().clone(),
+        };
+        if let Err(err) = self.persistence.save(&state) {
+            warn!("failed to persist reconcile store snapshot: {err}");
+        }
+    }
+
+    /// Periodically snapshot the full store state to the persistence backend.
+    async fn snapshot_periodically(&self) {
+        loop {
+            tokio::time::sleep(SNAPSHOT_INTERVAL).await;
+            self.snapshot();
+        }
     }
 
     /// Provides the address of a known peer to the store
@@ -248,8 +315,13 @@ impl<
     }
 
     pub async fn run(self) {
-        let clone = self.clone();
-        tokio::join!(self.engine.run(), clone.clear_expired_tombstones());
+        let tombstones = self.clone();
+        let snapshots = self.clone();
+        tokio::join!(
+            self.engine.run(),
+            tombstones.clear_expired_tombstones(),
+            snapshots.snapshot_periodically(),
+        );
     }
 }
 
@@ -326,9 +398,23 @@ impl Config {
 
 #[cfg(test)]
 mod reconcile_store_tests {
+    use std::net::IpAddr;
+    use std::sync::Arc;
     use std::time::Duration;
 
-    use crate::{reconcile_store::Config, ReconcileStore};
+    use crate::reconcile_engine::version_hash;
+    use crate::{reconcile_store::Config, FileSnapshot, ReconcileStore};
+
+    /// A config bound to an ephemeral UDP port on loopback, so persistence tests can construct
+    /// stores without colliding on a fixed port.
+    fn ephemeral_config() -> Config {
+        Config {
+            port: 0,
+            listen_addr: "127.0.0.1".parse().unwrap(),
+            peer_net: "127.0.0.1/8".parse().unwrap(),
+            cluster_key: None,
+        }
+    }
 
     #[tokio::test]
     async fn tombstones_expiration() {
@@ -353,5 +439,131 @@ mod reconcile_store_tests {
         assert_eq!(store.tombstones.remove(&0), None);
 
         task.abort();
+    }
+
+    /// A durable backend must let a restarted store recover both live values and tombstones, with
+    /// identical timestamps (hence an identical fingerprint).
+    #[tokio::test]
+    async fn persistence_roundtrip_recovers_entries_and_tombstones() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("snapshot.bin");
+
+        let store = ReconcileStore::<i32, i32>::new(ephemeral_config())
+            .await
+            .with_persistence(Arc::new(FileSnapshot::new(&path)));
+        store.insert(1, 11); // live value
+        store.insert(2, 22);
+        store.remove(&2); // tombstone
+        let expected = store.fingerprint(..);
+        store.snapshot(); // force a durable write
+
+        // A brand-new store recovers the previous state from the same file.
+        let restarted = ReconcileStore::<i32, i32>::new(ephemeral_config())
+            .await
+            .with_persistence(Arc::new(FileSnapshot::new(&path)));
+        assert_eq!(restarted.get(&1).as_deref(), Some(&11));
+        assert!(restarted.get(&2).is_none(), "tombstone was not recovered");
+        assert_eq!(
+            restarted.fingerprint(..),
+            expected,
+            "recovered state must hash identically (timestamps preserved)"
+        );
+        // The recovered tombstone is back in the expiry wheel (replayed through the hook).
+        assert!(restarted.tombstones.remove(&2).is_some());
+    }
+
+    /// The causal-stability state from issue #109 (membership + per-tombstone acks) must survive a
+    /// restart, otherwise GC gating is lost.
+    #[tokio::test]
+    async fn restart_preserves_membership_and_acks() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("snapshot.bin");
+        let peer: IpAddr = "127.0.0.99".parse().unwrap();
+
+        let store = ReconcileStore::<i32, i32>::new(ephemeral_config())
+            .await
+            .with_persistence(Arc::new(FileSnapshot::new(&path)));
+        store.engine.members.write().insert(peer);
+        store.insert(5, 55);
+        store.remove(&5); // tombstone
+        store
+            .engine
+            .tombstone_acks
+            .write()
+            .entry(5)
+            .or_default()
+            .insert(peer, 123);
+        store.snapshot();
+
+        let restarted = ReconcileStore::<i32, i32>::new(ephemeral_config())
+            .await
+            .with_persistence(Arc::new(FileSnapshot::new(&path)));
+        assert!(
+            restarted.engine.members.read().contains(&peer),
+            "membership set was not restored"
+        );
+        assert_eq!(
+            restarted
+                .engine
+                .tombstone_acks
+                .read()
+                .get(&5)
+                .and_then(|acks| acks.get(&peer)),
+            Some(&123),
+            "tombstone acknowledgments were not restored"
+        );
+    }
+
+    /// Regression for issue #122 ↔ #109: a restart must not turn a held-back tombstone into a
+    /// collectable (and thus resurrectable) one. A fresh, empty store would treat the tombstone as
+    /// causally stable (no members ⇒ GC allowed); a store that recovered its membership must still
+    /// gate GC because the unacknowledged peer is restored too.
+    #[tokio::test]
+    async fn restart_keeps_tombstone_gc_gated() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("snapshot.bin");
+        let peer: IpAddr = "127.0.0.98".parse().unwrap();
+
+        let store = ReconcileStore::<i32, i32>::new(ephemeral_config())
+            .await
+            .with_persistence(Arc::new(FileSnapshot::new(&path)));
+        store.engine.members.write().insert(peer);
+        store.insert(1, 11);
+        store.remove(&1); // tombstone, never acknowledged by `peer`
+
+        let version = store.engine.map.read().get(&1).map(version_hash).unwrap();
+        assert!(
+            !store.engine.is_tombstone_stable(&1, version),
+            "precondition: tombstone is gated before restart"
+        );
+        store.snapshot();
+
+        // Sanity check the hazard: a *fresh* store (no recovered membership) would consider the
+        // same tombstone stable and collect it.
+        let fresh = ReconcileStore::<i32, i32>::new(ephemeral_config()).await;
+        fresh.insert(1, 11);
+        fresh.remove(&1);
+        let fresh_version = fresh.engine.map.read().get(&1).map(version_hash).unwrap();
+        assert!(
+            fresh.engine.is_tombstone_stable(&1, fresh_version),
+            "a fresh restart with no membership would (wrongly) GC the tombstone — the hazard #122 describes"
+        );
+
+        // The recovered store keeps the tombstone gated, preventing resurrection.
+        let restarted = ReconcileStore::<i32, i32>::new(ephemeral_config())
+            .await
+            .with_persistence(Arc::new(FileSnapshot::new(&path)));
+        assert!(restarted.get(&1).is_none(), "tombstone was not recovered");
+        let version = restarted
+            .engine
+            .map
+            .read()
+            .get(&1)
+            .map(version_hash)
+            .unwrap();
+        assert!(
+            !restarted.engine.is_tombstone_stable(&1, version),
+            "restart dropped causal-stability state: tombstone would be GC'd and could resurrect"
+        );
     }
 }


### PR DESCRIPTION
Closes #122.

## Problem

A `ReconcileStore` was held purely in memory: a process restart lost the entire dataset, **including tombstones**. Losing tombstones is not just a durability problem — it is a correctness hazard. A node that restarts empty behaves like a brand-new replica, re-learns already-deleted values from peers, and can **resurrect** them (the tombstone-resurrection problem of #109).

## Approach

Introduce a **mandatory, pluggable `Persistence` trait**. Every store always owns a backend; what varies is which one:

- **`InMemoryPersistence`** (the default) keeps the latest snapshot in RAM and loses it on restart — identical to the previous behaviour, so **existing code is unaffected**.
- **`FileSnapshot`** durably stores a single, atomically-written (`*.tmp` → `fsync` → `rename`) bincode snapshot on disk.

`ReconcileStore::with_persistence(...)`, called between `new()` and `run()`, **loads any saved state before the node rejoins the gossip protocol** (pull-then-quiesce), so a restart no longer looks like a fresh, empty replica. What is recovered:

- all map **entries** — live values *and* tombstones;
- the **#109 causal-stability bookkeeping**: the membership set and per-tombstone acknowledgments, so GC stays gated after a restart.

Entries are replayed through the existing pre-insert hook, which preserves each tombstone's original deletion timestamp and rebuilds the expiry wheel — so the timeout wheel needs no separate persistence. `run()` snapshots periodically in the background.

The trait is the extension point: implementing it for `redb`, `sled`, S3, etc. is straightforward.

## Tests

- Unit: file/in-memory backends, bincode round-trip, atomic replacement.
- Integration: full save/reload round-trip (entries + tombstones, identical fingerprint), membership/ack restoration, and a regression that a recovered store keeps a tombstone **GC-gated** where a fresh restart would wrongly collect it (the #122 ↔ #109 hazard).

`cargo fmt --check`, `cargo clippy --all -- -D warnings`, `cargo test`, and `cargo doc --no-deps` all pass. No new runtime dependency (`tempfile` is dev-only).

https://claude.ai/code/session_0151XjVzMsMFJGpZt4XNtqXo

---
_Generated by [Claude Code](https://claude.ai/code/session_0151XjVzMsMFJGpZt4XNtqXo)_