### PR TITLE
Add CI code-coverage and explicit doc-tests (#97)

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -35,9 +35,34 @@ jobs:
       run: cargo build --all --verbose
     - name: Run tests
       run: cargo test --all --verbose
+    - name: Run doc-tests
+      run: cargo test --doc --all --verbose
     - name: Check that the benchmarks can still compile
       run: cargo bench --no-run
     - name: Generate the documentation
       run: cargo doc --all --verbose
     - name: Check that the crate is publishable
       run: cargo publish --allow-dirty --dry-run
+
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install llvm-tools-preview
+      run: rustup component add llvm-tools-preview
+    - uses: taiki-e/install-action@cargo-llvm-cov
+    - name: Enable caching
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+    - name: Generate code coverage
+      run: cargo llvm-cov --workspace --lcov --output-path lcov.info
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v4
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: lcov.info
+        fail_ci_if_error: false

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![MIT licensed][mit-badge]][mit-url]
 [![Apache licensed][apache-badge]][apache-url]
 [![Build Status][actions-badge]][actions-url]
+[![Coverage Status][codecov-badge]][codecov-url]
 [![Docs Status][docs-badge]][docs-url]
 
 [crates-badge]: https://img.shields.io/crates/v/reconcile.svg
@@ -14,8 +15,8 @@
 [apache-url]: https://github.com/Akvize/reconcile-rs/blob/master/LICENSE-APACHE
 [actions-badge]: https://github.com/Akvize/reconcile-rs/actions/workflows/master.yml/badge.svg
 [actions-url]: https://github.com/Akvize/reconcile-rs/actions/workflows/master.yml
-[actions-badge]: https://github.com/Akvize/reconcile-rs/actions/workflows/master.yml/badge.svg
-[actions-url]: https://github.com/Akvize/reconcile-rs/actions/workflows/master.yml
+[codecov-badge]: https://codecov.io/gh/Akvize/reconcile-rs/branch/master/graph/badge.svg
+[codecov-url]: https://codecov.io/gh/Akvize/reconcile-rs
 [docs-badge]: https://docs.rs/reconcile/badge.svg
 [docs-url]: https://docs.rs/reconcile/latest/reconcile/
 
@@ -235,3 +236,27 @@ changes from 10 to 1,000,000 elements.
 
 **Note:** These benchmarks are performed locally on the loop-back network
 interface. On a real network, transmission delays will make the values larger.
+
+## Testing and coverage
+
+The crate is covered by unit, integration, property-based and documentation
+tests. Run the whole suite with:
+
+```sh
+cargo test --all          # unit + integration + doc tests
+cargo test --doc          # documentation examples only
+```
+
+Code coverage is measured on every CI run with
+[`cargo-llvm-cov`](https://github.com/taiki-e/cargo-llvm-cov) and reported to
+[Codecov](https://codecov.io/gh/Akvize/reconcile-rs) (see the coverage badge at
+the top). To reproduce the coverage report locally:
+
+```sh
+cargo install cargo-llvm-cov
+cargo llvm-cov --workspace            # text summary in the terminal
+cargo llvm-cov --workspace --html     # browsable HTML report under target/llvm-cov/html
+```
+
+Coverage is collected with the crate's default features. The `mac-blake3` and
+`mac-hmac` backends are mutually exclusive, so do **not** pass `--all-features`.

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,11 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
+comment:
+  layout: "reach, diff, files"
+  require_changes: true


### PR DESCRIPTION
Closes #97.

## What

Adds code-coverage measurement/reporting to CI and makes doc-tests an explicit, visible CI step.

### CI (`.github/workflows/master.yml`)
- New `coverage` job using [`cargo-llvm-cov`](https://github.com/taiki-e/cargo-llvm-cov) (installed via `taiki-e/install-action`) to generate an lcov report and upload it to **Codecov**.
- Runs with **default features only** — `--all-features` would fail to compile because the `mac-blake3`/`mac-hmac` backends are mutually exclusive.
- New explicit `cargo test --doc --all` step in the `lint-and-test` job.

### Coverage gate (`codecov.yml`)
- Informational / **non-blocking** project + patch status ("measure first, soft gate"). Can be tightened into a hard `--fail-under-lines` threshold once the number proves stable.

### README
- Added a Codecov badge (and removed a pre-existing duplicated build-status link pair).
- New **"Testing and coverage"** section documenting how to run doc-tests and reproduce the coverage report locally.

## Measured baseline
Local run (`cargo llvm-cov --workspace`): **95.27% line** coverage, 95.33% regions, 90.37% functions — already above the issue's 90% aspiration. Doc-tests: 11 pass, no broken snippets.

## Action required before the badge works
A **`CODECOV_TOKEN`** repo secret must be added (Settings → Secrets and variables → Actions). Public-repo tokenless upload also works but is rate-limited/flaky, so the token is recommended.

## Out of scope
- Tightening the soft gate into a hard fail-under threshold.
- Doc-test coverage (`--doctests`) which requires nightly.

https://claude.ai/code/session_01Px31xFmiswLbAXdB3umfza

---
_Generated by [Claude Code](https://claude.ai/code/session_01Px31xFmiswLbAXdB3umfza)_