### PR TITLE
Architecture refonte roadmap — hexagonal ports & adapters (docs only)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,508 +1,312 @@
-# Architecture review & refonte foundations — `reconcile-rs` (crate `reconcile`)
+# Architecture review & refonte — hexagonal target (`reconcile-rs`)
 
-> Forward-looking **architecture** document: a critical review of the current layering and
-> contracts, a concrete target architecture (layers, module tree, trait signatures), and a
-> phased, test-green migration path.
+> Forward-looking **architecture** document. Organizing principle: **hexagonal architecture
+> (ports & adapters)**. The goal is not to add or remove traits for their own sake, but to put
+> *well-designed* traits where they belong — at the boundary between the domain and the
+> infrastructure — and to stop exposing internal mechanism as public API.
 >
-> - **Date:** 2026-06-01
-> - **Manifest version:** `0.0.0-git` (unpublished under this shape — no backward-compatibility
->   contract yet, so the API and the on-wire/on-disk formats may be broken freely).
-> - **Scope:** architecture, contracts and abstraction. This is **not** a defect review — for the
->   correctness/security peer-review see [`REVIEW.md`](./REVIEW.md). Most of its critical findings
->   (F1–F8: `hash==0` sentinel, packet-panic DoS, missing auth, tombstone resurrection,
->   physical-clock LWW, weak XOR fingerprint, reachable `unimplemented!()`, unstable
->   `DefaultHasher`) are **already fixed** in the current code (256-bit BLAKE3 fingerprint, HLC,
->   per-datagram MAC, causal-stability gate, `checked_sub` hardening). This document assumes that
->   corrected baseline and asks a different question: *is the architecture clean?*
-> - **Method:** static reading of `src/`, `tests/`, `Cargo.toml`. No source file modified by this
->   document. Every claim carries a `file:line` proof against the audited tree.
+> - **Date:** 2026-06-02 · **Manifest:** `0.0.0-git` (unpublished; API and on-wire/on-disk formats
+>   may be broken freely).
+> - **Scope:** architecture, contracts, coupling. Not a defect review — for correctness/security
+>   see [`REVIEW.md`](./REVIEW.md), whose critical findings are already fixed in the current tree
+>   (256-bit BLAKE3 fingerprint, HLC, per-datagram MAC, causal-stability tombstone gate,
+>   `checked_sub` hardening). This document assumes that corrected baseline.
+> - **Method:** static reading of `src/`, `tests/`, `Cargo.toml`. Every claim carries a `file:line`
+>   proof. No source file is modified by this document.
 
 ---
 
-## 1. Diagnosis in one sentence
+## 1. Reframing: the problem is not *how many* traits, it's *which* traits and *where*
 
-The code is **correct and well-tested but layer-collapsed**: a data structure, a wire protocol, a
-replication-semantics policy (HLC + LWW + tombstone GC), a transport (UDP/bincode/MAC) and a user
-facade all live in one flat module set **with no contract boundaries** — and the one place where
-abstraction was attempted (the associated types of `Diffable`) adds ceremony without flexibility.
+A trait is only worth its weight when it is a **port** — a domain-revealing boundary that inverts a
+dependency on infrastructure. The current codebase has the two failure modes that make a trait set
+feel like an "usine à gaz", and they are *opposite* problems:
 
-The fix is to introduce **named seams** — traits at the layer boundaries — and to make the
-value/tombstone/clock/transport models **pluggable**, *without touching the handful of things that
-are correctness- or compatibility-load-bearing* (§5).
+1. **Internal mechanism exposed as public API.** `HashRangeQueryable`, `Diffable` and
+   `MaybeTombstone` describe *how the engine computes a diff* or *the shape of a stored tuple*.
+   They are plumbing — **not "screaming", not domain-revealing** — yet they are published
+   (`lib.rs:30` `pub mod diff`) and carry ceremony (vacuous associated types). Exposing them is the
+   defect: they leak the mechanism and pin the public surface to it.
+2. **Missing ports.** The domain has *no* boundary against infrastructure. The reconciliation
+   engine depends **directly** on `tokio::net::UdpSocket`, `bincode`, `rand::StdRng`, `ipnet`, and
+   the HLC reads `chrono::Utc` itself. There is no dependency inversion, so the domain cannot be
+   exercised without real sockets and real wall-clock time, and the transport/codec/clock cannot be
+   swapped.
+
+The refonte fixes both: **hide and dissolve the plumbing traits**, and **introduce the handful of
+ports the domain actually needs** (`Clock`, `Transport`, `Codec`, `Persistence`).
 
 ---
 
-## 2. Critical review of the current architecture
+## 2. Critical review
 
-### 2.1 The five layers, and where they leak
+### 2.1 The coupling map — where infrastructure leaks into the domain
 
-The crate naturally decomposes into five layers, but the modules do not reflect them:
+`grep` of infrastructure imports across the modules (audited tree):
 
-| Layer | Responsibility | Today's files |
+| Module | Infra it imports directly | Verdict |
 |---|---|---|
-| **L1 — Data structure** | Ordered map with O(log n) range fingerprints | `hrtree.rs`, `hrtree_iter.rs`, `fingerprint.rs` |
-| **L2 — Reconciliation protocol** | Range-subdivision set-difference algorithm over fingerprints; pure, transport-agnostic, no I/O | `diff.rs` |
-| **L3 — Replication semantics** | What a *version* is (clock), how conflicts *merge*, what a *tombstone* is, when a tombstone is GC-safe (causal stability) | `hlc.rs`, `reconcilable.rs`, `timeout_wheel.rs` + ack logic **buried inside** `reconcile_engine.rs` |
-| **L4 — Transport + codec + membership** | UDP socket I/O, bincode framing, MAC auth, peer discovery/sampling, the async protocol *driver* | `reconcile_engine.rs`, `auth.rs`, `gen_ip.rs` |
-| **L5 — Service facade** | The single public type users hold; wiring, persistence, builder config | `reconcile_store.rs`, `persistence.rs` |
+| `hrtree.rs`, `hrtree_iter.rs`, `fingerprint.rs`, `diff.rs`, `reconcilable.rs` | none (only `rand` inside `#[cfg(test)]`) | **already infra-free** — this is the hexagon interior, it exists today |
+| `hlc.rs` | `chrono::Utc` (`hlc.rs:35`) — physical time read inside the domain | one small leak: the *time source* |
+| `reconcile_engine.rs` | `tokio::net::UdpSocket`, `tokio::time`, `bincode::{Serializer,Deserializer,DefaultOptions}`, `rand::StdRng`, `ipnet` (`reconcile_engine.rs:21-28,67`) | **infrastructure-soaked** — transport + codec + discovery all hard-wired |
+| `reconcile_store.rs` | `chrono`, `ipnet` (`reconcile_store.rs:19-20`) | facade, leaks time + addressing |
 
-**Two clean layering violations** stand out:
+The domain mechanism (HRTree, fingerprint, diff algorithm) is **already clean**. The whole infra
+dependency is concentrated in one god-module, `reconcile_engine.rs`, plus the wall-clock read in
+`hlc.rs`. That is precisely the surface a port extraction targets.
 
-1. **L3 logic is embedded in L4.** Clock advancement (`clock.observe`), per-value tombstone
-   version-hashing (`version_hash`, `reconcile_engine.rs:55`) and ack tracking
-   (`tombstone_acks`, `reconcile_engine.rs:83`) live inside the engine's message loop rather than
-   in a semantics layer. The *policy* (when is a deletion safe to forget?) is tangled with the
-   *mechanism* (UDP datagrams).
-2. **L2 is reached by a blanket impl that hardwires L1's key type.** `diff.rs:78`,
-   `impl<K: Clone, T: HashRangeQueryable<Key = K>> Diffable for T`, means nobody ever implements
-   `Diffable` directly; the protocol is welded onto the data-structure trait.
+### 2.2 Trait-by-trait classification
 
-### 2.2 Seven hard-coded couplings that block abstraction
+Three distinct categories, three distinct fixes — *not* "delete all single-impl traits".
 
-| # | Coupling | Proof | Why it hurts |
+| Trait | `file:line` | What it really is | Fix |
 |---|---|---|---|
-| C1 | **Clock hardwired to HLC** | `reconcile_engine.rs:86` (`clock: Arc<HlcClock>`), `hlc.rs` | No `Clock`/`Timestamp` seam; a different versioning scheme (vector clocks, externally-supplied stamps) cannot be plugged in. |
-| C2 | **Conflict resolution hardwired to LWW-on-Hlc** | `reconcilable.rs:27` (`impl Reconcilable for (Hlc, V)`) | Merge policy is fixed; no way to override per value type without re-implementing the engine. |
-| C3 | **Value model hardwired to `(Hlc, Option<V>)`** | `reconcile_store.rs:52`, `persistence.rs:51` (`DatedEntries = Vec<(K,(Hlc,Option<V>))>`) | The timestamp+tombstone tuple is structural, not a named type. |
-| C4 | **Tombstone leaks into the public API** | `reconcile_store.rs:171` — `add_pre_insert<F: … Fn(&K, &(Hlc, Option<V>)) …>` | Users of the *public* hook must know the internal wrapping `(Hlc, Option<V>)`; the abstraction boundary is broken at the surface. |
-| C5 | **Tombstone logic fragmented** | `reconcilable.rs:43` (`MaybeTombstone`), `Option<V>`, `timeout_wheel.rs`, `tombstone_acks` (`reconcile_engine.rs:83`), store GC loop | One concept (a deletion and its safe lifetime) is smeared across five places. |
-| C6 | **Transport=UDP & codec=bincode hardwired** | `reconcile_engine.rs:67` (`socket: Arc<UdpSocket>`), `:21` (`use bincode::…`) | No `Transport`/`Codec` seam; cannot swap UDP→QUIC or bincode→protobuf, and cannot unit-test the driver without real sockets. |
-| C7 | **Public surface leaks internals** | `lib.rs:30-37` exposes `pub mod diff, fingerprint, hrtree_iter, hlc, gen_ip` next to `reconcile_store` | A user cannot tell the stable external contract (`ReconcileStore`) from low-level plumbing (`HashSegment`, `Fingerprint` internals, iterators, `HlcClock`). |
+| `Diffable` | `diff.rs:58` | **Plumbing**, wrongly public. Blanket impl, associated types always `HashSegment<K>`/`DiffRange<K>` — vacuous. Never hand-implemented. | **Delete the trait.** `start_diff`/`diff_round` become `pub(crate)` free functions over the concrete `HRTree`. |
+| `HashRangeQueryable` | `diff.rs:30` | **Plumbing**, wrongly public. One real impl (`HRTree`); the only other is a test `MockStore`. Describes the data structure's internal capability, not a domain boundary. | **Delete the trait.** Inherent methods on `HRTree`; the diff test exercises `HRTree` directly. |
+| `MaybeTombstone` | `reconcilable.rs:43` | **Value-shape plumbing.** One impl on `(Hlc, Option<V>)`. Not a port. | Dissolve into a **domain type** `Entry`/`State` with `is_tombstone()` inherent. |
+| `Reconcilable` | `reconcilable.rs:27` | **Domain policy** (LWW), but mis-shaped as a tuple trait. | Inherent `Entry::merge` (default LWW); optional `Resolve` *domain* seam only if multiple policies become a real goal (§3.5). |
+| `Timestamped` | `hlc.rs:171` | **Value-shape plumbing.** One impl on `(Hlc, V)`. | Field access on `Entry` (`entry.stamp`). |
+| `Mac` | `auth.rs:92` | Compile-time-selected backend (`mac-blake3`/`mac-hmac`), never both at once. | Borderline. Keep as a small `pub(crate)` contract *or* collapse to a `cfg`-selected concrete `ClusterMac`. Not a public port. |
+| **`Persistence`** | `persistence.rs:77` | **A real port.** Two adapters (`InMemory`, `FileSnapshot`) + genuine external extension need. Domain-revealing. | **Keep — this is the model every other port should follow.** |
 
-### 2.3 The verbosity: bounds and the vacuous two-trait split
+So the existing trait set has exactly **one well-formed port** (`Persistence`) and a pile of
+exposed mechanism. The refonte keeps `Persistence`, **adds the missing ports** (`Clock`,
+`Transport`, `Codec`), and **hides/dissolves the rest**.
 
-The owner's "verbose, unreadable traits" complaint has two concrete causes.
+### 2.3 Verbosity and leaks (orthogonal, still real)
 
-**(a) Giant `where` blocks, repeated.** The same nine-bound key constraint and eleven-bound value
-constraint are spelled out at every impl site:
-
-```rust
-// reconcile_engine.rs:122-135
-impl<
-        K: Clone + Debug + DeserializeOwned + Hash + Ord + Send + Serialize + Sync + 'static,
-        V: Clone + DeserializeOwned + Hash + MaybeTombstone + PartialEq + Reconcilable
-            + Send + Serialize + Sync + Timestamped + 'static,
-    > ReconcileEngine<K, V>
-```
-
-The identical key bound reappears at `reconcile_store.rs:75` and in the `get_mut` impl. There is no
-trait-alias/bundle, so every reader re-parses the same wall of bounds. Worse, `MaybeTombstone +
-Reconcilable + Timestamped` are mixed into a *value* bound — but those are **semantics of the entry
-type**, not properties any plain value has. They belong to the entry model (§3.4), not to `V`.
-
-**(b) A two-trait split whose associated types are vacuous.** `HashRangeQueryable` (`diff.rs:30`)
-plus `Diffable` (`diff.rs:58`), where `Diffable::ComparisonItem` is *always* `HashSegment<K>` and
-`Diffable::DifferenceItem` is *always* `DiffRange<K>` (`diff.rs:78-80`). The associated types
-suggest flexibility that does not exist; the blanket impl means `Diffable` is never implemented by
-hand. Two traits and two associated types pay for zero generality.
+- The 9-bound key constraint and 11-bound value constraint are spelled out at every impl site
+  (`reconcile_engine.rs:122-135`, `reconcile_store.rs:75`, the `get_mut` impl). No bound bundle.
+- `MaybeTombstone + Reconcilable + Timestamped` sit inside a *value* bound, although they are
+  properties of the **entry**, not of any plain value.
+- The internal wrapper `(Hlc, Option<V>)` leaks into the **public** hook
+  `add_pre_insert<F: … Fn(&K, &(Hlc, Option<V>)) …>` (`reconcile_store.rs:171`) and into
+  `PersistedState`/`DatedEntries` (`persistence.rs:51`). The mechanism is on the public surface.
 
 ---
 
-## 3. Target architecture
-
-### 3.1 Structural decision: single crate now, **workspace-ready** module tree
-
-The owner's stated target is a **multi-crate workspace**. The recommendation here is to **reach it
-in two moves, not one**: first reorganize into a layered *module* tree inside the single crate, with
-explicit `pub` / `pub(crate)` contracts and module names chosen so that "promote each `mod` to a
-crate" is mechanical; then split into a workspace once the layers have stabilized (and ideally once
-a sub-crate has an external consumer).
-
-**Why module-first, crate-second:**
-
-- *Pre-1.0, unpublished.* A workspace's main payoff — independent versioning and compile-time
-  isolation of sub-crates — has near-zero value before any external consumer exists.
-- *Risk isolation.* The hard part of this refonte is the **trait design** (§3.3) and the
-  **god-object split** (§3.5). Doing that *and* fighting cross-crate visibility, `Cargo.toml`
-  plumbing and feature-flag propagation simultaneously multiplies risk for no behavioural gain.
-- *Tests stay honest.* `tests/service.rs` and `tests/proptest_hrtree.rs` reach across all layers;
-  one crate lets them stay green through every phase without being rewritten against several crates.
-
-**The single downside, and its mitigation.** Module-level `pub(crate)` is a softer wall than a crate
-boundary: a lazy cross-layer reach still compiles. Mitigation: the explicit re-export facade
-(§3.2), code review, and — later — a `clippy.toml`/`cargo-deny`-style disallowed-path lint in CI.
-
-**Bascule criteria (when to actually split into the workspace):** when `hrtree/`+`proto/` gains an
-external consumer, or when `no_std`/alternative-transport feature isolation is wanted. The module
-tree below names each layer after its eventual crate so the split is a move, not a redesign.
+## 3. Target architecture: the hexagon
 
 ```
-hrtree/    → reconcile-hrtree   (L1)
-proto/     → reconcile-proto    (L2)
-semantics/ → reconcile-core     (L3)
-net/       → reconcile-net      (L4)
-store/     → reconcile          (L5, the umbrella crate)
+                         ┌─────────────────────── adapters (infra) ───────────────────────┐
+   driving side          │                                                                │
+   (application)         │   HlcClock        UdpTransport      BincodeCodec    FileSnapshot│
+        │                │  (chrono/time)   (tokio/UDP)        (bincode)     / InMemory     │
+        ▼                │       │               │                 │              │         │
+  ┌───────────┐  impl    └───────┼───────────────┼─────────────────┼──────────────┼─────────┘
+  │  Store    │           ports: │ Clock         │ Transport       │ Codec        │ Persistence
+  │  (facade) │◀──────────────── ▼ ───────────── ▼ ─────────────── ▼ ──────────── ▼ ────────
+  └───────────┘                 ┌──────────────────────────────────────────────────────────┐
+        ▲                       │                    DOMAIN  (hexagon)                       │
+        │  inbound/driving port │  reconciliation algorithm · conflict policy (LWW)          │
+        └───────────────────────│  tombstone lifecycle · HRTree + Fingerprint (mechanism)    │
+                                │  Hlc (value) · Entry/State (value)  —  NO tokio/bincode    │
+                                └──────────────────────────────────────────────────────────┘
 ```
 
-### 3.2 Target module tree (single crate, workspace-ready)
+- **Domain (interior):** the reconciliation diff algorithm, the conflict-resolution policy, the
+  tombstone lifecycle + causal-stability rule, the `HRTree` and `Fingerprint` (internal mechanism),
+  and the value types `Hlc`, `Entry`, `State`. **Depends on no infrastructure crate.** The grep in
+  §2.1 shows this is *almost already true* — only the wall-clock read needs to move out.
+- **Outbound (driven) ports** — the well-designed traits the domain depends on:
+  `Clock`, `Transport`, `Codec`, `Persistence`.
+- **Adapters** implement the ports: `HlcClock` (system time), `UdpTransport` (tokio), `BincodeCodec`
+  (bincode), `FileSnapshot`/`InMemory` (durability).
+- **Inbound (driving) port:** the `Store` API the application calls (insert/remove/get/run).
 
-```
-src/
-  lib.rs                 // THE public facade: re-exports L5 + the few L1/L3 extension points
-  prelude.rs             // optional `pub use` bundle for downstream users
-  bounds.rs              // pub: Key, Value supertrait bundles (used everywhere)
+The hexagonal payoff is concrete and testable: an in-memory `Transport` adapter makes the
+convergence proptest deterministic (no real sockets); a fixed `Clock` makes HLC behaviour
+reproducible.
 
-  hrtree/                // L1  (future crate: reconcile-hrtree)
-    mod.rs               //   pub: HRTree, Fingerprint, RangeHashMap (the merged L1/L2 contract)
-    node.rs
-    iter.rs
-    fingerprint.rs
-
-  proto/                 // L2  (future crate: reconcile-proto)  — pub(crate)
-    mod.rs               //   start_diff / diff_round as free fns over RangeHashMap
-    segment.rs           //   HashSegment, DiffRange  (wire types)
-
-  semantics/             // L3  (future crate: reconcile-core)
-    mod.rs
-    clock.rs             //   pub: Clock, Timestamp, Versioned
-    merge.rs             //   pub: Merge (was Reconcilable)
-    entry.rs             //   pub: Entry<T,V>, State<V>  (replaces (Hlc, Option<V>))
-    hlc.rs               //   pub: Hlc (impl Timestamp) + pub(crate) HlcClock (impl Clock)
-    stability.rs         //   pub(crate): TombstoneTracker (was tombstone_acks + timeout_wheel)
-
-  net/                   // L4  (future crate: reconcile-net)
-    mod.rs
-    transport.rs         //   pub: Transport trait; pub(crate) UdpTransport
-    codec.rs             //   pub: Codec trait;     pub(crate) BincodeCodec
-    auth.rs              //   pub(crate): Mac, Authenticator, ClusterKey, Payload
-    membership.rs        //   pub(crate): PeerTable, discovery (gen_ip)
-    driver.rs            //   pub(crate): ProtocolDriver (the slimmed-down engine)
-
-  store/                 // L5  (this crate's reason to exist)
-    mod.rs               //   pub: ReconcileStore, Config
-    persistence.rs       //   pub: Persistence, FileSnapshot, InMemoryPersistence, PersistedState
-```
-
-### 3.3 External vs internal contract, per layer
-
-- **L1 (`hrtree/`) — external:** `HRTree`, `Fingerprint`, and the merged range-hash trait
-  `RangeHashMap` (§3.6). Legitimately reusable on their own. Everything else (`node`, cached-hash
-  internals) is `pub(crate)`.
-- **L2 (`proto/`) — internal only.** The protocol is an implementation detail of replication.
-  `HashSegment`/`DiffRange` are **wire types**: `pub(crate)`, never in the public API. (Today
-  `diff.rs` is `pub mod` at `lib.rs:30` — coupling **C7**; demote it.)
-- **L3 (`semantics/`) — external:** `Clock`, `Timestamp`, `Versioned`, `Merge`, `Entry`, `State`,
-  `Hlc` — the **extension points** users plug into to change clock or conflict policy. `HlcClock`,
-  `TombstoneTracker` are `pub(crate)`.
-- **L4 (`net/`) — external:** the `Transport` and `Codec` *traits* (so an embedder can swap UDP for
-  QUIC, or bincode for protobuf). Concrete `UdpTransport`/`BincodeCodec`, `Authenticator`,
-  `PeerTable`, `ProtocolDriver` are `pub(crate)`.
-- **L5 (`store/`) — external:** `ReconcileStore`, `Config`, the `Persistence` family. ~90% of the
-  surface users actually touch.
-
-`lib.rs` shrinks from eight `pub mod` (`lib.rs:30-37`) to a tight facade:
+### 3.2 The ports (well-designed, domain-revealing, the only public traits)
 
 ```rust
-pub mod store;        // ReconcileStore, Config
-pub mod persistence;  // Persistence family (or re-exported from store)
-pub mod semantics;    // Clock / Merge / Entry / Hlc — extension points
-pub mod hrtree;       // L1 reusable data structure
-pub mod net;          // Transport / Codec traits (concretes stay pub(crate))
-
-pub(crate) mod proto;
-pub(crate) mod bounds;
-
-pub use store::{Config, ReconcileStore};
-pub use hrtree::{Fingerprint, HRTree};
-pub use semantics::{Clock, Entry, Hlc, Merge, State, Timestamp, Versioned};
-pub use persistence::{FileSnapshot, InMemoryPersistence, PersistedState, Persistence};
-```
-
-The key change: `diff`, `fingerprint` internals, `hrtree_iter`, `gen_ip`, `hlc::HlcClock` and
-`auth` stop being top-level `pub`. Users can no longer mistake plumbing for the stable contract.
-
-### 3.4 Bound bundles — kill the repeated `where` clauses
-
-`#![feature(trait_alias)]` is unstable. Use the **stable supertrait + blanket-impl** pattern: a
-marker supertrait bundles the bounds, a blanket impl makes every qualifying type satisfy it
-automatically, and downstream users never implement it by hand.
-
-```rust
-// src/bounds.rs
-use std::fmt::Debug;
-use std::hash::Hash;
-use serde::{de::DeserializeOwned, Serialize};
-
-/// Everything a key must satisfy across the stack. Implemented automatically.
-pub trait Key:
-    Clone + Debug + Hash + Ord + Send + Sync + Serialize + DeserializeOwned + 'static {}
-impl<T> Key for T where
-    T: Clone + Debug + Hash + Ord + Send + Sync + Serialize + DeserializeOwned + 'static {}
-
-/// Everything a *stored* value must satisfy: serializable, hashable (for the
-/// fingerprint), comparable (to detect a no-op merge), thread-safe.
-pub trait Value:
-    Clone + Debug + Hash + PartialEq + Send + Sync + Serialize + DeserializeOwned + 'static {}
-impl<T> Value for T where
-    T: Clone + Debug + Hash + PartialEq + Send + Sync + Serialize + DeserializeOwned + 'static {}
-```
-
-The twelve-line bound block at `reconcile_engine.rs:122-135` collapses to `impl<K: Key, V: Value>`
-(plus the entry-model bounds, which now travel with `Entry`, §3.5). Note the *conceptual* cleanup,
-not just cosmetics: `MaybeTombstone + Reconcilable + Timestamped` move **out** of the value bound and
-**into** the entry model where they belong.
-
-### 3.5 Clock / Version abstraction (generalizes HLC)
-
-Split HLC's two roles: the *timestamp* (a value type with a total order) and the *clock* (a stateful
-minter/observer).
-
-```rust
-// src/semantics/clock.rs
-
-/// A version stamp with a globally-deterministic total order. `Ord` MUST be a genuine
-/// total order shared by all replicas (the conflict survivor is `max` over it), and it
-/// MUST be part of the value's `Hash` so the fingerprint reflects version changes.
-pub trait Timestamp:
-    Clone + Copy + Ord + std::hash::Hash + Send + Sync
-    + serde::Serialize + serde::de::DeserializeOwned + 'static {}
-
-/// A per-node clock that mints monotonic timestamps and advances on observation.
+// ── Clock ─────────────────────────────────────────────────────────────────────
+// Removes the domain's dependency on chrono::Utc (hlc.rs:35). The HLC algorithm
+// stays domain logic; only the physical-time source crosses the boundary.
 pub trait Clock: Send + Sync + 'static {
-    type Timestamp: Timestamp;
-    /// Mint a fresh timestamp, strictly greater than every timestamp previously produced
-    /// or observed by this clock (local monotonicity).
+    type Timestamp: Copy + Ord + Hash + Serialize + DeserializeOwned + Send + Sync + 'static;
+    /// Mint a fresh, strictly-monotonic local timestamp.
     fn now(&self) -> Self::Timestamp;
-    /// Advance to account for a timestamp received from a peer, so a subsequent `now()` is
-    /// ordered after `remote` (causality; prevents lost updates under skew).
+    /// Advance past a timestamp received from a peer (causality).
     fn observe(&self, remote: Self::Timestamp);
 }
 
-/// A value carrying a version stamp: lets the engine read a stored value's timestamp
-/// (to advance the clock) without knowing the concrete value type. Replaces `Timestamped`.
-pub trait Versioned {
-    type Timestamp: Timestamp;
-    fn timestamp(&self) -> Self::Timestamp;
+// ── Transport ───────────────────────────────────────────────────────────────────
+// Removes the dependency on tokio::net::UdpSocket. Datagram in / datagram out.
+#[async_trait::async_trait]
+pub trait Transport: Send + Sync + 'static {
+    type Addr: Clone + Eq + Hash + Send + Sync;
+    async fn recv_from(&self, buf: &mut [u8]) -> io::Result<(usize, Self::Addr)>;
+    async fn send_to(&self, buf: &[u8], dst: &Self::Addr) -> io::Result<usize>;
+    fn local_addr(&self) -> io::Result<Self::Addr>;
+}
+
+// ── Codec ─────────────────────────────────────────────────────────────────────
+// Removes the dependency on bincode. Encodes/decodes protocol messages; auth wraps it.
+pub trait Codec: Send + Sync + 'static {
+    type Error: std::error::Error + Send + Sync + 'static;
+    fn encode<T: Serialize>(&self, value: &T, out: &mut Vec<u8>) -> Result<(), Self::Error>;
+    fn decode_stream<T: DeserializeOwned>(&self, bytes: &[u8]) -> Result<Vec<T>, Self::Error>;
+}
+
+// ── Persistence (already exists, persistence.rs:77 — the model port) ────────────
+pub trait Persistence<K, V>: Send + Sync + 'static {
+    fn load(&self) -> io::Result<Option<PersistedState<K, V>>>;
+    fn save(&self, state: &PersistedState<K, V>) -> io::Result<()>;
 }
 ```
 
-`Hlc: Timestamp` — the derived `Ord` already *is* the `(wall_ms, counter, node_id)` total order
-(`hlc.rs:44-54`); **do not change it** (§5.2). `HlcClock: Clock<Timestamp = Hlc>` — its `now`/
-`observe` (`hlc.rs:121`, `:146`) already match the trait exactly, so this is pure renaming.
-`Timestamped` (`hlc.rs:171`) becomes `Versioned`.
+Default adapters: `HlcClock: Clock<Timestamp = Hlc>` (its `now`/`observe`, `hlc.rs:121,146`, already
+match the port exactly), `UdpTransport(Arc<UdpSocket>)`, `BincodeCodec(DefaultOptions)`,
+`FileSnapshot`/`InMemoryPersistence`. The `Authenticator`/MAC stays a `pub(crate)` wrapper
+**outside and ahead of** the `Codec` — auth-before-deserialize is a security property (issue #108,
+§6.5), never folded into the codec.
 
-### 3.6 First-class tombstones — replace `(Hlc, Option<V>)`
-
-The deepest fix, addressing **C3/C4/C5**. The value model is currently the tuple `(Hlc, Option<V>)`
-with tombstone = `None`, and that tuple leaks into the public `add_pre_insert` (`reconcile_store.rs:171`)
-and into `PersistedState` (`persistence.rs:51`). Make it an explicit, named type with one trait.
+### 3.3 Domain types that replace the value-shape plumbing traits
 
 ```rust
-// src/semantics/entry.rs
-
-/// One stored, replicated cell: a version stamp plus either a live value or a tombstone.
-/// Replaces the leaky `(Hlc, Option<V>)`.
-#[derive(Clone, Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+// One stored, replicated cell — replaces (Hlc, Option<V>) and dissolves
+// MaybeTombstone / Reconcilable / Timestamped into a concrete, screaming domain type.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct Entry<T, V> { pub stamp: T, pub state: State<V> }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum State<V> { Present(V), Tombstone }
 
-impl<T: Timestamp, V> Versioned for Entry<T, V> {
-    type Timestamp = T;
-    fn timestamp(&self) -> T { self.stamp }
-}
-
-impl<T, V> Entry<T, V> {
+impl<T: Ord + Copy, V: Clone> Entry<T, V> {
     pub fn is_tombstone(&self) -> bool { matches!(self.state, State::Tombstone) }
-    pub fn value(&self) -> Option<&V> {
-        match &self.state { State::Present(v) => Some(v), State::Tombstone => None }
-    }
-}
-```
-
-This dissolves the fragmented `MaybeTombstone` trait (`reconcilable.rs:43`) into an inherent method,
-removes the `Option` wrapper from the public hook signature, and gives `PersistedState` a named field
-type. `version_hash` (`reconcile_engine.rs:55`) keeps working because `Entry` derives `Hash`.
-
-> **Wire/disk format note.** The bincode encoding of `Entry<Hlc, V>` differs from
-> `(Hlc, Option<V>)`. This is a **breaking on-disk/on-wire change** — acceptable because the crate
-> is unpublished (`0.0.0`) and has no compatibility contract. Sequence it (Phase 4, §4) so the
-> proptest oracle re-runs against the new shape.
-
-### 3.7 Merge abstraction (generalizes LWW)
-
-```rust
-// src/semantics/merge.rs
-
-/// Conflict resolution. MUST be commutative, associative and idempotent so all replicas
-/// converge (Strong Eventual Consistency). Returns the winner of two concurrently-held
-/// values for the same key.
-pub trait Merge { fn merge(&self, other: &Self) -> Self; }
-
-/// Last-write-wins over any total-order timestamp. Generalizes `Reconcilable for (Hlc, V)`.
-impl<T: Timestamp, V: Clone> Merge for Entry<T, V> {
-    fn merge(&self, other: &Self) -> Self {
+    pub fn value(&self) -> Option<&V> { /* … */ }
+    /// Default conflict policy: last-write-wins over the timestamp's total order.
+    pub fn merge(&self, other: &Self) -> Self {
         if other.stamp > self.stamp { other.clone() } else { self.clone() }
     }
 }
 ```
 
-**Recommendation: keep `Merge` as a trait on the entry type** (mirroring today's
-`Reconcilable for (Hlc, V)`, `reconcilable.rs:27`) with LWW supplied by the blanket impl above —
-**do not** introduce a separate `Lww<C>` strategy object. The engine already calls
-`local.reconcile(&remote)` with no policy parameter; a free-standing strategy would force a policy
-generic through the entire stack (driver, store, config) for a generalization nobody has requested.
-The trait keeps the call site identical and still lets a user override merge by newtyping their value.
+This removes `(Hlc, Option<V>)` from the public `add_pre_insert` signature and gives
+`PersistedState` a named field type. `version_hash` (`reconcile_engine.rs:55`) keeps working since
+`Entry` derives `Hash`. **On-wire/on-disk change** (acceptable, unpublished); sequence it where the
+proptest oracle re-runs (Phase 4, §5).
 
-Do **not** weaken the strict `>` (§5.2): "equal stamp ⇒ keep self" is what makes merge commutative,
-pinned by `reconcile_is_commutative_on_equal_wall_and_counter` (`reconcilable.rs:59`).
+### 3.4 The internal mechanism stays internal
 
-### 3.8 Merge the `HashRangeQueryable` + `Diffable` pair into one trait
+`HashRangeQueryable` + `Diffable` are deleted as *traits*. The range-hash capability becomes
+inherent methods on the concrete `HRTree`; `start_diff`/`diff_round` become `pub(crate)` free
+functions over it, living in a `proto` module. **None of this is public.** The wire types
+`HashSegment`/`DiffRange` are `pub(crate)`. This is the "popote interne" — it must not appear in the
+crate's external contract. Move `diff_round` **verbatim**: it carries the #106/#111 size-not-hash
+rule and the #112 malformed-bound hardening (§6.3, §6.4).
 
-Kill the vacuous two-trait split (§2.3b). Keep **one** trait `RangeHashMap` (the renamed
-`HashRangeQueryable`), **delete** the `Diffable` trait, and turn `start_diff`/`diff_round` into
-**free functions** in `proto/` parameterized by `RangeHashMap`. This removes the redundant trait
-*and* its vacuous associated types in one move, and relocates the protocol (L2) out of the
-data-structure contract (L1).
+### 3.5 Conflict resolution: domain policy, not an infra port
 
-```rust
-// src/hrtree/mod.rs  — the L1 contract, the only thing the protocol needs
-pub trait RangeHashMap {
-    type Key: Ord + Clone;
-    fn range_hash<R: RangeBounds<Self::Key>>(&self, range: &R) -> Fingerprint;
-    fn insertion_position(&self, key: &Self::Key) -> usize;
-    fn key_at(&self, index: usize) -> &Self::Key;
-    fn len(&self) -> usize;
-    fn is_empty(&self) -> bool { self.len() == 0 }
-}
+LWW-on-`Hlc` is **domain logic**, so it lives in the domain as the concrete default (`Entry::merge`
+above). It is *not* an outbound port. Expose a `Resolve` seam **only if** swapping LWW for another
+strategy (e.g. a CRDT) is a real roadmap item; otherwise a trait here would be the same speculative
+ceremony we are removing. Recommendation: ship the concrete LWW default; add the seam when a second
+policy actually exists.
 
-// src/proto/mod.rs  — L2, pure, no I/O, pub(crate)
-pub(crate) fn start_diff<M: RangeHashMap>(map: &M) -> Vec<HashSegment<M::Key>> { /* moved verbatim */ }
-pub(crate) fn diff_round<M: RangeHashMap>(
-    map: &M,
-    in_comparison: Vec<HashSegment<M::Key>>,
-    out_comparison: &mut Vec<HashSegment<M::Key>>,
-    differences: &mut Vec<DiffRange<M::Key>>,
-) { /* moved verbatim, including the #106/#111/#112 hardening */ }
-```
-
-> **Move `diff_round` verbatim.** Its body (`diff.rs:90-200`) contains the size-not-hash
-> emptiness/equality decision (issues #106/#111, `diff.rs:135-141`) and the malformed-bound /
-> inverted-range hardening (issue #112, `diff.rs:100-134`). It is correctness-critical; this is a
-> **relocation, not a rewrite** (§5.3, §5.4).
-
-### 3.9 Transport and Codec abstractions
-
-Decouple UDP and bincode (**C6**). Keep the async surface minimal so `UdpTransport` is a thin
-wrapper and `tests/fuzz_packets.rs` can still drive raw bytes.
+### 3.6 Bound bundles to de-verbose (stable supertrait + blanket impl)
 
 ```rust
-// src/net/transport.rs
-#[async_trait::async_trait]   // hand-rolled `impl Future` also fine; async-trait is simplest here
-pub trait Transport: Send + Sync + 'static {
-    type Addr: Clone + Send + Sync;
-    async fn recv_from(&self, buf: &mut [u8]) -> std::io::Result<(usize, Self::Addr)>;
-    async fn send_to(&self, buf: &[u8], dst: &Self::Addr) -> std::io::Result<usize>;
-    fn local_addr(&self) -> std::io::Result<Self::Addr>;
-}
+pub trait Key:
+    Clone + Debug + Hash + Ord + Send + Sync + Serialize + DeserializeOwned + 'static {}
+impl<T> Key for T where T: /* same */ {}
 
-// src/net/codec.rs
-/// Frames protocol messages to/from bytes. The MAC/auth layer wraps the codec output; the
-/// codec itself is auth-agnostic. Streaming decode (multiple messages per datagram) is
-/// preserved by decoding from a cursor.
-pub trait Codec: Send + Sync + 'static {
-    type Error: std::error::Error + Send + Sync + 'static;
-    fn encode<T: serde::Serialize>(&self, value: &T, out: &mut Vec<u8>) -> Result<(), Self::Error>;
-    fn decode_stream<T: serde::de::DeserializeOwned>(&self, bytes: &[u8]) -> Result<Vec<T>, Self::Error>;
-}
+pub trait Value:
+    Clone + Debug + Hash + PartialEq + Send + Sync + Serialize + DeserializeOwned + 'static {}
+impl<T> Value for T where T: /* same */ {}
 ```
 
-`UdpTransport(Arc<UdpSocket>)` and `BincodeCodec(DefaultOptions)` are the `pub(crate)` defaults
-wired by `Config`. **Keep `BincodeCodec` on the exact same `DefaultOptions` and the same `Message`
-enum tag order** (`reconcile_engine.rs:108-120`) — the on-wire representation of
-`ComparisonItem/Update/Ack`, `HashSegment` and `Fingerprint` must not change beyond the `Entry`
-re-encoding of §3.6 (§5.1). The MAC/`Authenticator` stays a **separate `pub(crate)` wrapper outside
-and ahead of** the codec — auth-before-deserialize is a security property (issue #108, §5.5), never
-folded into the codec.
+The 11-line `where` block at `reconcile_engine.rs:122-135` collapses to `impl<K: Key, V: Value>`;
+the entry semantics travel with `Entry`, not with `V`.
 
-### 3.10 Decomposing the god object `ReconcileEngine`
+### 3.7 Workspace = compiler-enforced dependency inversion
 
-`ReconcileEngine` (`reconcile_engine.rs:64-87`, 789 lines) currently fuses: map ownership, the UDP
-socket, bincode ser/de, MAC framing, peer expiry, member tracking, the clock, tombstone-ack state,
-the `Message` enum, the recv/dispatch loop, broadcast-on-write, and the pre-insert hook. Split into
-single-responsibility components owned by a thin driver:
+This is where the **multi-crate workspace you asked for earns its keep** (and supersedes the
+"single-crate-first" hedge from the previous draft): a crate boundary is the only thing that
+*mechanically prevents* the domain from importing tokio/bincode. The hexagon becomes:
 
-| New component | Owns / does | Carved from |
+```
+reconcile-core     // DOMAIN + PORTS. Defines Clock, Transport, Codec, Persistence (traits),
+                   //   Entry/State, Hlc, Fingerprint, HRTree, the diff algorithm, LWW.
+                   //   deps: serde, blake3 only. NO tokio, NO bincode, NO chrono-IO, NO ipnet.
+reconcile-net      // ADAPTERS: UdpTransport (tokio), BincodeCodec (bincode), Authenticator,
+                   //   peer discovery (ipnet/rand).            deps: reconcile-core + infra.
+reconcile-store    // ADAPTERS: FileSnapshot / InMemory persistence.  deps: reconcile-core + infra.
+reconcile          // WIRING + driving API: ReconcileStore, Config.   deps: all of the above.
+```
+
+The dependency arrow points **only inward** (adapters → core, never the reverse). If someone writes
+`use tokio::…` in `reconcile-core`, it fails to compile — that is the guarantee a single crate
+cannot give. Ports are defined **in `reconcile-core`** (hexagonal "dependency inversion": the domain
+owns the interface, the adapter depends on it).
+
+---
+
+## 4. Iso-functional cleanups (orthogonal to the ports work, ~450 lines)
+
+Mechanical, behaviour-preserving simplifications, valid under any philosophy. Verified by the
+existing test suite (a clean compile + green tests *is* the proof).
+
+| Cleanup | `file:line` | Win |
 |---|---|---|
-| `Transport` + `UdpTransport` (`net/`) | socket bind, `recv_from`/`send_to`, retries | `socket`, `send_to_retry`, `MAX_SENDTO_RETRIES` |
-| `Codec` + `BincodeCodec` (`net/`) | `Message` encode / decode-stream | `Serializer`/`Deserializer`, `BUFFER_SIZE` framing |
-| `Authenticator` (`net/auth.rs`) | MAC open/seal, `Payload` gate | `auth.rs` (already isolated) |
-| `PeerTable` (`net/membership.rs`) | `peers` (expiring) + `members` (monotonic) + `gen_ip` sampling | `peers`, `members`, `get_peers`, `PEER_EXPIRATION`, `gen_ip` |
-| `TombstoneTracker` (`semantics/stability.rs`) | `tombstone_acks` + reciprocal-ack + `TimeoutWheel` + `is_gc_ready` predicate | `tombstone_acks`, ack logic in `handle_messages`, `timeout_wheel.rs` |
-| `Arc<dyn Clock>` (or `Arc<HlcClock>`) | mint/observe | `clock` field, `clock_now`, the `observe` call |
-| `ProtocolDriver` (`net/driver.rs`) | the slim coordinator: `run()` loop, dispatch, broadcast-on-write | what remains after the extractions |
+| **8 iterator types → one shared cursor + projection.** `IntoIter/Iter/IterMut/Values/ValuesMut/Keys/IntoKeys/IntoValues` recopy the same descent; 3 twin `*Layer` enums. | `hrtree_iter.rs:63-530` | **~250 lines** |
+| **7 flat `Arc<RwLock<…>>` + 11-field manual `Clone` → one `Arc<Inner>` + `#[derive(Clone)]`.** One lock-discipline story instead of eight. | `reconcile_engine.rs:64-105` | **~50 lines** |
+| **Broadcast copy-pasted 3× (insert / insert_bulk / acks) → one `broadcast_messages` helper.** | `reconcile_engine.rs:194-254,407-502` | **~30 lines** |
+| **Nested `fn aux(...)` re-declaring bounds** already fixed by the `impl` block. | `hrtree.rs` `get/insert/remove/position/…` | **~30 lines** |
+| **Manual `Clone` on `ReconcileStore`/`TimeoutWheel` → derive** once `Arc<Inner>` lands; dual-index wheel behind one lock. | `reconcile_store.rs:60-72`, `timeout_wheel.rs:11-25` | **~20 lines** |
+| **steal-left/steal-right rebalance dup; silent `.unwrap()` on network serialize → `.expect()`.** | `hrtree.rs:142-259`, `reconcile_engine.rs:320,579+` | clarity |
 
-**Wiring.** `ProtocolDriver` holds `Arc<RwLock<HRTree>>`, a `Transport`, a `Codec`, an
-`Authenticator`, a `PeerTable`, a `TombstoneTracker`, and a `Clock`. Its `run()` loop becomes:
-`transport.recv_from` → `authenticator.open` → `codec.decode_stream` → classify into
-comparisons/updates/acks → delegate (comparisons → `proto::diff_round`; updates → `apply_updates`,
-which calls `clock.observe`, `entry.merge`, `tombstone_tracker.record`; acks → `tombstone_tracker`)
-→ each delegate returns outbound messages, which the driver encodes + auths + sends. This turns
-`handle_messages` (today ~150 lines mixing five concerns) into a ~30-line dispatcher.
-
-**Causal-stability invariant survives the split intact** (§5.6): a tombstone is GC-eligible only
-when *every* member in `PeerTable.members` has acked the *exact* `version_hash` currently held.
-Concentrate that logic in `TombstoneTracker::is_gc_ready(key, version, &members)`, byte-for-byte.
+The **core algorithm is not over-engineered** (HLC, causal-stability gate, fingerprint caching are
+tight and necessary). The bloat is in **scaffolding**, not logic.
 
 ---
 
-## 4. Phased migration (ordered, each independently committable, test-green)
+## 5. Migration phases (each independently committable, test-green)
 
-Every phase ends with `cargo test` green against the **existing** suite (the behavioural oracle).
-No big-bang.
+| Phase | What | Risk | Oracle |
+|---|---|---|---|
+| **0 — Iso-functional cleanups** (§4) | Iterator cursor, `Arc<Inner>` + derive `Clone`, broadcast helper, drop redundant bounds. Pure refactor, no contract change. | low | whole suite compiles + passes unchanged. |
+| **1 — Bound bundles + hide the plumbing** | Add `Key`/`Value`; demote `diff`, `fingerprint` internals, `hrtree_iter`, `gen_ip`, `hlc::HlcClock`, `auth` from `pub` to `pub(crate)` in `lib.rs`. | low | suite green; check `tests/diff.rs` imports of demoted paths. |
+| **2 — Dissolve plumbing traits** | Delete `Diffable`/`HashRangeQueryable`; `diff_round`/`start_diff` → `pub(crate)` free fns over `HRTree` (**verbatim**). | low | `tests/diff.rs` (#106/#111/#112), `proptest_hrtree.rs`. |
+| **3 — `Clock` port** | Extract `Clock`; `HlcClock` becomes its adapter; move the `chrono::Utc` read into the adapter so the domain is time-source-free. `Timestamped` → field access. | low | `hlc.rs` unit tests (monotonicity, observe, tie-break). |
+| **4 — `Entry`/`State` domain type** | Replace `(Hlc,Option<V>)`; dissolve `MaybeTombstone`; `Reconcilable` → `Entry::merge`; fix public `add_pre_insert`; update `PersistedState`. **Changes encoding.** | **highest** | `tests/service.rs` (resurrection, conflicts, convergence), `proptest_hrtree.rs`, `FileSnapshot` round-trips. |
+| **5 — `Transport` + `Codec` ports** | Extract both; `UdpTransport`/`BincodeCodec` adapters; rewrite the engine loop as a thin driver delegating to ports; keep `Authenticator` ahead of the codec; freeze `DefaultOptions`/`Message` tag order. **Unlocks in-memory transport for deterministic tests.** | medium | `tests/service.rs` convergence, `fuzz_packets.rs`, lossy-transport proptest. |
+| **6 — Workspace split** | Promote modules to `reconcile-core` / `reconcile-net` / `reconcile-store` / `reconcile`; ports defined in `-core`; verify `-core` has no infra deps. | medium | full suite green; `cargo tree` shows no tokio/bincode under `reconcile-core`. |
 
-| Phase | What | Files | Risk | Oracle |
-|---|---|---|---|---|
-| **1 — Bound bundles + facade** *(cheapest, highest visible value)* | Add `bounds.rs` (`Key`/`Value`), replace the repeated `where` blocks; demote `diff`, `fingerprint` internals, `hrtree_iter`, `gen_ip`, `hlc::HlcClock` to `pub(crate)` in `lib.rs`. (`MaybeTombstone+Reconcilable+Timestamped` stay explicit until Phase 4.) | `lib.rs`, `bounds.rs` (new), `reconcile_engine.rs`, `reconcile_store.rs` | very low | whole suite compiles+passes unchanged; a successful compile *proves* the bundles are equivalent. Check `tests/diff.rs` for direct imports of demoted paths and keep them reachable (`#[cfg(test)] pub use`). |
-| **2 — Merge L1/L2, relocate protocol** | Rename `HashRangeQueryable`→`RangeHashMap` into `hrtree/`; delete `Diffable`; move `start_diff`/`diff_round` **verbatim** into `proto/`; update the two engine call sites. | `diff.rs`→`hrtree/`+`proto/`, `hrtree.rs`, engine, `tests/diff.rs` (import-only) | low | `tests/diff.rs` (#106/#111/#112) + `proptest_hrtree.rs` convergence catch any accidental edit to moved code. |
-| **3 — Clock/Timestamp/Versioned** | Introduce the three traits; `impl Timestamp for Hlc`, `impl Clock for HlcClock`; rename `Timestamped`→`Versioned`. Engine still holds `Arc<HlcClock>`, called through the trait. | `hlc.rs`→`semantics/{clock,hlc}.rs`, `reconcilable.rs`, engine | low | `hlc.rs` unit tests (monotonicity, observe-advances, total-order tie-break) move with the type, stay green. |
-| **4 — First-class `Entry`** *(highest risk: changes encoding)* | `Entry`/`State` replace `(Hlc,Option<V>)`; `Reconcilable`→`Merge`; delete `MaybeTombstone`; fix the public `add_pre_insert` signature; update `PersistedState`/`DatedEntries`. | `entry.rs`+`merge.rs` (new), engine, `reconcile_store.rs:171`, `persistence.rs:51` | **highest** | `tests/service.rs` (resurrection, conflicts, two-node convergence), `proptest_hrtree.rs` (lossy-transport convergence = strongest round-trip check), `FileSnapshot` round-trips (`reconcile_store.rs` persistence tests). |
-| **5 — Extract `TombstoneTracker` + `PeerTable`** | Pull acks+reciprocal+`TimeoutWheel` into `semantics/stability.rs` with `is_gc_ready`; pull `peers`/`members`/`gen_ip` into `net/membership.rs`. | `timeout_wheel.rs`→`stability.rs`, `gen_ip.rs`→`membership.rs`, engine, store GC loop | medium | resurrection + authenticated-node tests in `tests/service.rs`; `fuzz_packets.rs` for ack robustness. |
-| **6 — Extract `Transport`/`Codec`, slim the driver** | Introduce the traits + `UdpTransport`/`BincodeCodec`; rewrite `handle_messages`/`run` as `ProtocolDriver` delegating to Phase-5 components; keep `Authenticator` ahead of the codec; freeze `DefaultOptions`/`Message` tag order. | `net/{transport,codec,driver}.rs`, `reconcile_engine.rs`→`driver.rs`, `auth.rs`→`net/auth.rs` | medium | `tests/service.rs` two-node convergence + `fuzz_packets.rs` (malformed datagram never panics) + `proptest_hrtree.rs` lossy convergence. |
-| **7 — Final facade + module move + docs** | Physically move files into `hrtree/ proto/ semantics/ net/ store/`; finalize `lib.rs` + optional `prelude`; update README/module docs to name the layers and extension points; materialize crate boundaries for the eventual workspace split. | tree move, `lib.rs`, README | low | everything compiles, full suite green, `cargo doc` builds. |
-
-**Ordering rationale.** Each phase depends only on its predecessors. Phase 1 delivers visible value
-immediately. The highest-risk encoding change (Phase 4) sits in the middle, where the test oracle is
-richest, not at the end where regressions are expensive to localize.
+Phase 0 delivers immediate, risk-free value. The encoding change (Phase 4) sits in the middle where
+the oracle is richest. The workspace split is last, once layers are stable — but it is now a
+*goal*, not a hedge, because it enforces the hexagon's dependency direction.
 
 ---
 
-## 5. What must NOT change (correctness / compatibility load-bearing)
+## 6. What must NOT change (load-bearing)
 
-1. **`Fingerprint` wire format and arithmetic** — the `[u64;4]` 256-bit abelian group (add/sub mod
-   2²⁵⁶, per-element BLAKE3), its `combine`/`remove`, and the golden vectors in `fingerprint.rs`.
-   The whole protocol's correctness rests on `combine` being a commutative group so range
-   fingerprints compose; the golden vectors pin the exact bytes. Relocate the file only.
-2. **HLC total order `(wall_ms, counter, node_id)`** (`hlc.rs:44-54`) — the derived `Ord` field
-   order *is* the conflict-resolution order. Generalizing to a `Timestamp` trait must preserve
-   `Hlc`'s exact `Ord`/`Hash`. Do not reorder fields; do not weaken `>` to `>=` in merge.
-3. **The size-not-hash emptiness/equality decision in `diff_round`** (issues #106/#111,
-   `diff.rs:135-141`) — decisions on `size`/`local_size`, never on `hash == ZERO`, because a
-   non-empty range can legitimately fingerprint to zero. Move verbatim.
-4. **Malformed-bound / inverted-range hardening in `diff_round`** (issue #112, `diff.rs:100-134`) —
-   dropping unsupported bound shapes and `checked_sub` instead of `unimplemented!()`/underflow. A
-   remote-DoS fix; preserve every branch. Pinned by `tests/diff.rs`.
-5. **Auth-before-deserialize ordering** (issue #108) — `Authenticator::open` runs on raw bytes
-   *before* any `Codec::decode`, and only accepted senders are recorded as peers/members. The
-   `Codec`/`Transport` split keeps the MAC gate outside and ahead of the codec, never folded in.
-6. **Causal-stability tombstone gate** — GC only after every `members` entry has acked the exact
-   `version_hash` held; `members` is monotonic (never auto-expired) precisely so a long-partitioned
-   peer cannot resurrect a deletion. `TombstoneTracker` must reproduce this exactly. Pinned by the
-   resurrection test in `tests/service.rs`.
-7. **`version_hash` determinism** (`reconcile_engine.rs:55`) — `DefaultHasher`'s fixed keys make the
-   token identical across nodes. Do **not** swap to a randomized/seeded hasher when `Entry` gains
-   its derived `Hash`.
+1. **`Fingerprint` wire format & arithmetic** (`[u64;4]`, add/sub mod 2²⁵⁶, per-element BLAKE3) +
+   golden vectors in `fingerprint.rs`. Relocate only.
+2. **HLC total order `(wall_ms, counter, node_id)`** (`hlc.rs:44-54`) — the derived `Ord` *is* the
+   conflict order. `Clock::Timestamp = Hlc` must preserve it; do not weaken `>` to `>=` in merge.
+3. **Size-not-hash emptiness/equality in `diff_round`** (#106/#111, `diff.rs:135-141`).
+4. **Malformed-bound / inverted-range hardening in `diff_round`** (#112, `diff.rs:100-134`).
+5. **Auth-before-deserialize** (#108): MAC verified on raw bytes *before* `Codec::decode`; the
+   `Codec` port never absorbs auth.
+6. **Causal-stability tombstone gate:** GC only after every monotonic `members` entry acked the
+   exact `version_hash`. Pinned by the resurrection test in `tests/service.rs`.
+7. **`version_hash` determinism** (`reconcile_engine.rs:55`, `DefaultHasher` fixed keys) — keep it
+   when `Entry` derives `Hash`.
 
 ---
 
-## 6. Summary
+## 7. Summary
 
-The refonte is not a rewrite. It is the introduction of five **named seams** —
-`RangeHashMap` (L1/L2), `Clock`/`Timestamp`/`Versioned` + `Merge` + `Entry` (L3), `Transport`/`Codec`
-(L4) — plus a `Key`/`Value` bound bundle to kill the verbosity, plus the decomposition of one
-god-object into single-responsibility components. The seven load-bearing invariants of §5 are held
-fixed throughout, and the existing test suite (`service`, `proptest_hrtree`, `diff`, `fuzz_packets`)
-is the oracle that keeps every one of the seven migration phases honest. The module tree is named so
-that the owner's ultimate target — a multi-crate workspace — becomes a mechanical move once the
-layers have proven stable.
+The crate already has a clean, infra-free domain mechanism (HRTree/fingerprint/diff) and exactly one
+well-formed port (`Persistence`). The "usine à gaz" is (a) internal mechanism — `Diffable`,
+`HashRangeQueryable`, `MaybeTombstone` — *published* as if it were the contract, and (b) the absence
+of ports, leaving the domain welded to tokio/UDP/bincode/chrono inside one god-module. The refonte
+is therefore not "fewer traits" nor "more traits" — it is **the right traits as ports** (`Clock`,
+`Transport`, `Codec`, `Persistence`) defined by the domain, **the plumbing hidden** (`diff`,
+range-hash) or **dissolved into screaming domain types** (`Entry`/`State` for the tombstone/version
+model), **bound bundles** to kill the verbosity, and a **workspace** whose crate boundaries enforce
+the inward-only dependency direction the hexagon requires. The seven load-bearing invariants of §6
+are held fixed, and the existing test suite keeps every phase honest.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -263,21 +263,130 @@ tight and necessary). The bloat is in **scaffolding**, not logic.
 
 ---
 
-## 5. Migration phases (each independently committable, test-green)
+## 5. Migration phases — one issue per phase
 
-| Phase | What | Risk | Oracle |
-|---|---|---|---|
-| **0 — Iso-functional cleanups** (§4) | Iterator cursor, `Arc<Inner>` + derive `Clone`, broadcast helper, drop redundant bounds. Pure refactor, no contract change. | low | whole suite compiles + passes unchanged. |
-| **1 — Bound bundles + hide the plumbing** | Add `Key`/`Value`; demote `diff`, `fingerprint` internals, `hrtree_iter`, `gen_ip`, `hlc::HlcClock`, `auth` from `pub` to `pub(crate)` in `lib.rs`. | low | suite green; check `tests/diff.rs` imports of demoted paths. |
-| **2 — Dissolve plumbing traits** | Delete `Diffable`/`HashRangeQueryable`; `diff_round`/`start_diff` → `pub(crate)` free fns over `HRTree` (**verbatim**). | low | `tests/diff.rs` (#106/#111/#112), `proptest_hrtree.rs`. |
-| **3 — `Clock` port** | Extract `Clock`; `HlcClock` becomes its adapter; move the `chrono::Utc` read into the adapter so the domain is time-source-free. `Timestamped` → field access. | low | `hlc.rs` unit tests (monotonicity, observe, tie-break). |
-| **4 — `Entry`/`State` domain type** | Replace `(Hlc,Option<V>)`; dissolve `MaybeTombstone`; `Reconcilable` → `Entry::merge`; fix public `add_pre_insert`; update `PersistedState`. **Changes encoding.** | **highest** | `tests/service.rs` (resurrection, conflicts, convergence), `proptest_hrtree.rs`, `FileSnapshot` round-trips. |
-| **5 — `Transport` + `Codec` ports** | Extract both; `UdpTransport`/`BincodeCodec` adapters; rewrite the engine loop as a thin driver delegating to ports; keep `Authenticator` ahead of the codec; freeze `DefaultOptions`/`Message` tag order. **Unlocks in-memory transport for deterministic tests.** | medium | `tests/service.rs` convergence, `fuzz_packets.rs`, lossy-transport proptest. |
-| **6 — Workspace split** | Promote modules to `reconcile-core` / `reconcile-net` / `reconcile-store` / `reconcile`; ports defined in `-core`; verify `-core` has no infra deps. | medium | full suite green; `cargo tree` shows no tokio/bincode under `reconcile-core`. |
+> **How to use this section.** After this PR merges, open **one GitHub issue per phase** (or one
+> Project item) by copying its block verbatim — each is written to stand alone: goal, dependency,
+> files, a `- [ ]` task list, and acceptance criteria that double as the issue's *definition of
+> done*. Phases are strictly ordered by the **Depends on** field; the dependency graph is linear
+> (`0 → 1 → 2 → 3 → 4 → 5 → 6`) except that **Phase 0 is independent** and can ship immediately.
+> Suggested labels are given per phase. "Oracle" = the existing test(s) that must stay green and
+> therefore prove the change is behaviour-preserving (except Phase 4, which changes encoding).
 
-Phase 0 delivers immediate, risk-free value. The encoding change (Phase 4) sits in the middle where
-the oracle is richest. The workspace split is last, once layers are stable — but it is now a
-*goal*, not a hedge, because it enforces the hexagon's dependency direction.
+| # | Phase | Depends on | Risk | Net LoC | Contract change? |
+|---|---|---|---|---|---|
+| 0 | Iso-functional cleanups | — | low | **−450** | none |
+| 1 | Bound bundles + hide the plumbing | 0 | low | −40 | public surface shrinks |
+| 2 | Dissolve `Diffable`/`HashRangeQueryable` | 1 | low | −60 | none (internals) |
+| 3 | `Clock` port | 1 | low | +30 | none |
+| 4 | `Entry`/`State` domain type | 2, 3 | **high** | ~0 | **wire + on-disk** |
+| 5 | `Transport` + `Codec` ports | 4 | medium | ~0 | wire frozen, not changed |
+| 6 | Workspace split | 5 | medium | ~0 | none |
+
+---
+
+### Phase 0 — Iso-functional cleanups
+**Goal:** remove ~450 lines of scaffolding with zero behaviour change, to shrink the surface every
+later phase touches. · **Depends on:** nothing (ship first). · **Risk:** low. ·
+**Labels:** `refactor`, `good-first-issue`.
+
+**Tasks**
+- [ ] Collapse the 8 iterator types + 3 twin `*Layer` enums into one shared cursor + projection (`hrtree_iter.rs:63-530`).
+- [ ] Fold the 7 flat `Arc<RwLock<…>>` fields into one `Arc<Inner>`; replace the 11-field manual `Clone` with `#[derive(Clone)]` (`reconcile_engine.rs:64-105`).
+- [ ] Extract the broadcast logic duplicated 3× into one `broadcast_messages` helper (`reconcile_engine.rs:194-254,407-502`).
+- [ ] Drop the nested `fn aux(...)` bound re-declarations now covered by the `impl` block (`hrtree.rs` `get/insert/remove/position`).
+- [ ] Derive `Clone` on `ReconcileStore`/`TimeoutWheel` once `Arc<Inner>` lands; put the dual index behind one lock (`reconcile_store.rs:60-72`, `timeout_wheel.rs:11-25`).
+- [ ] Deduplicate steal-left/steal-right rebalance (`hrtree.rs:142-259`); turn silent `.unwrap()` on network serialize into `.expect("…")` (`reconcile_engine.rs:320,579+`).
+
+**Acceptance** — `cargo test` passes unchanged; `cargo clippy` clean; net diff is negative; **no
+public signature changes** (`cargo public-api diff` empty).
+
+---
+
+### Phase 1 — Bound bundles + hide the plumbing
+**Goal:** introduce `Key`/`Value` supertrait bundles and demote internal mechanism out of the
+public surface. · **Depends on:** Phase 0. · **Risk:** low. · **Labels:** `refactor`, `api`.
+
+**Tasks**
+- [ ] Add `pub trait Key: …` and `pub trait Value: …` with blanket impls (§3.6).
+- [ ] Replace the 11-line `where` block at `reconcile_engine.rs:122-135` (and the `reconcile_store.rs:75` / `get_mut` sites) with `impl<K: Key, V: Value>`.
+- [ ] In `lib.rs`, demote from `pub` to `pub(crate)`: `mod diff` internals, `fingerprint` internals, `hrtree_iter`, `gen_ip`, `hlc::HlcClock` internals, `auth` (keep `Persistence` and the `Store` facade public).
+- [ ] Audit `tests/` for imports of newly-demoted paths; move those tests into `#[cfg(test)]` units inside the crate where needed.
+
+**Acceptance** — suite green; `cargo public-api diff` shows **only removals** (surface shrinks, nothing added yet); no `tests/diff.rs` import resolves to a demoted public path.
+
+---
+
+### Phase 2 — Dissolve `Diffable` / `HashRangeQueryable`
+**Goal:** delete the two exposed-mechanism traits; the diff algorithm becomes `pub(crate)` functions
+over the concrete `HRTree`. · **Depends on:** Phase 1. · **Risk:** low. · **Labels:** `refactor`.
+
+**Tasks**
+- [ ] Move `start_diff`/`diff_round` **verbatim** into a `pub(crate) mod proto` as free functions taking `&HRTree` (preserve invariants §6.3, §6.4 byte-for-byte).
+- [ ] Turn `HashRangeQueryable`'s methods into inherent methods on `HRTree`; delete the trait.
+- [ ] Delete `Diffable`; make `HashSegment`/`DiffRange` `pub(crate)`.
+- [ ] Drop the test-only `MockStore`; point the diff test at `HRTree` directly.
+
+**Acceptance** — `tests/diff.rs` (regression cases #106/#111/#112) and `proptest_hrtree.rs` green; `grep -r 'Diffable\|HashRangeQueryable' src/` empty; nothing diff-related is `pub`.
+
+---
+
+### Phase 3 — `Clock` port
+**Goal:** make the domain time-source-free; the HLC algorithm stays, only the physical-time read
+moves to an adapter. · **Depends on:** Phase 1. · **Risk:** low. · **Labels:** `feature`, `api`.
+
+**Tasks**
+- [ ] Define `pub trait Clock { type Timestamp; fn now(); fn observe(); }` (§3.2) in the domain.
+- [ ] Make `HlcClock` the default adapter implementing `Clock<Timestamp = Hlc>`; move the `chrono::Utc::now()` read (`hlc.rs:35`) inside it.
+- [ ] Thread `C: Clock` through the engine; replace `Timestamped` tuple access with `entry.stamp` field access.
+- [ ] Add a `FixedClock`/`ManualClock` test adapter.
+
+**Acceptance** — `hlc.rs` unit tests (monotonicity, `observe`, `(wall,counter,node)` tie-break, §6.2) green; domain modules import no `chrono`; a test using `FixedClock` produces deterministic stamps.
+
+---
+
+### Phase 4 — `Entry` / `State` domain type ⚠️ encoding change
+**Goal:** replace the leaky `(Hlc, Option<V>)` tuple with a screaming domain type and dissolve the
+value-shape traits. · **Depends on:** Phases 2 and 3. · **Risk:** HIGH (changes wire + on-disk
+format — acceptable while unpublished). · **Labels:** `feature`, `breaking`, `api`.
+
+**Tasks**
+- [ ] Add `Entry<T, V>` + `enum State<V> { Present(V), Tombstone }` with inherent `is_tombstone`/`value`/`merge` (default LWW, §3.3); derive `Hash`/`Serialize`.
+- [ ] Replace every `(Hlc, Option<V>)` with `Entry<Hlc, V>`; delete `MaybeTombstone` and `Timestamped`; fold `Reconcilable` into `Entry::merge`.
+- [ ] Fix the public hook signature `add_pre_insert` (`reconcile_store.rs:171`) to take `&Entry<…>` instead of the tuple.
+- [ ] Update `PersistedState`/`DatedEntries` (`persistence.rs:51`) to the named type; bump any on-disk version marker.
+- [ ] Confirm `version_hash` (`reconcile_engine.rs:55`) still hashes deterministically over `Entry` (§6.7).
+
+**Acceptance** — `tests/service.rs` (resurrection, conflict, convergence), `proptest_hrtree.rs`, and a `FileSnapshot` save→load round-trip all green; **`add_pre_insert` no longer mentions `(Hlc, Option<V>)`** anywhere public; LWW `>` (not `>=`) preserved (§6.2).
+
+---
+
+### Phase 5 — `Transport` + `Codec` ports
+**Goal:** lift the last infrastructure (tokio/UDP, bincode) out of the domain; the engine becomes a
+thin driver over ports. · **Depends on:** Phase 4. · **Risk:** medium. ·
+**Labels:** `feature`, `api`.
+
+**Tasks**
+- [ ] Define `Transport` and `Codec` ports (§3.2); keep `Authenticator`/MAC **ahead of** the codec (verify-then-decode, §6.5).
+- [ ] Implement `UdpTransport(Arc<UdpSocket>)` and `BincodeCodec(DefaultOptions)` adapters; freeze the bincode `DefaultOptions` config and the `Message` enum tag order.
+- [ ] Rewrite the engine recv/send loop (`reconcile_engine.rs`) to delegate to the ports; remove direct `tokio::net`/`bincode` imports from the engine.
+- [ ] Add an in-memory (optionally lossy/reordering) `Transport` test adapter.
+
+**Acceptance** — `tests/service.rs` convergence and `fuzz_packets.rs` green; a **deterministic** convergence proptest runs over the in-memory transport with no real sockets; engine module imports neither `tokio::net` nor `bincode`.
+
+---
+
+### Phase 6 — Workspace split
+**Goal:** promote the layers to crates so the compiler enforces the inward-only dependency
+direction. · **Depends on:** Phase 5. · **Risk:** medium. · **Labels:** `build`, `refactor`.
+
+**Tasks**
+- [ ] Create the workspace: `reconcile-core` (domain + ports), `reconcile-net` (Transport/Codec/auth/discovery), `reconcile-store` (persistence adapters), `reconcile` (wiring + driving API).
+- [ ] Move modules accordingly; ports are **defined in `reconcile-core`**.
+- [ ] Pin dependencies so `reconcile-core` lists only `serde` + `blake3` (no tokio/bincode/chrono-IO/ipnet/rand-runtime).
+- [ ] Re-export the public API from the top-level `reconcile` crate so downstream `use` paths are unchanged where possible.
+
+**Acceptance** — full suite green from the workspace root; `cargo tree -p reconcile-core` shows **no** tokio/bincode/chrono/ipnet; adding `use tokio::…;` to `reconcile-core` fails to compile (the guarantee a single crate cannot give).
 
 ---
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,139 +1,167 @@
-# Architecture review & refonte — hexagonal target (`reconcile-rs`)
+# reconcile-rs — Architecture
 
-> Forward-looking **architecture** document. Organizing principle: **hexagonal architecture
-> (ports & adapters)**. The goal is not to add or remove traits for their own sake, but to put
-> *well-designed* traits where they belong — at the boundary between the domain and the
-> infrastructure — and to stop exposing internal mechanism as public API.
->
-> - **Date:** 2026-06-02 · **Manifest:** `0.0.0-git` (unpublished; API and on-wire/on-disk formats
->   may be broken freely).
-> - **Scope:** architecture, contracts, coupling. Not a defect review — for correctness/security
->   see [`REVIEW.md`](./REVIEW.md), whose critical findings are already fixed in the current tree
->   (256-bit BLAKE3 fingerprint, HLC, per-datagram MAC, causal-stability tombstone gate,
->   `checked_sub` hardening). This document assumes that corrected baseline.
-> - **Method:** static reading of `src/`, `tests/`, `Cargo.toml`. Every claim carries a `file:line`
->   proof. No source file is modified by this document.
+## Status & scope
+
+`reconcile-rs` is a reconciliation service that keeps a key-value map synchronised across several
+instances. This document describes the **current architecture** and the **target architecture**
+(hexagonal — ports & adapters). Correctness and security properties are specified in
+[`REVIEW.md`](./REVIEW.md) and are assumed here as the baseline.
+
+The crate is unpublished (`0.0.0-git`); the public API and the on-wire / on-disk formats are not yet
+stable and may change. Code locations are given as `file:line` against the current tree.
 
 ---
 
-## 1. Reframing: the problem is not *how many* traits, it's *which* traits and *where*
+## 1. System overview
 
-A trait is only worth its weight when it is a **port** — a domain-revealing boundary that inverts a
-dependency on infrastructure. The current codebase has the two failure modes that make a trait set
-feel like an "usine à gaz", and they are *opposite* problems:
+A node holds an ordered key-value map and gossips changes to its peers so that all replicas
+converge. The design rests on five mechanisms:
 
-1. **Internal mechanism exposed as public API.** `HashRangeQueryable`, `Diffable` and
-   `MaybeTombstone` describe *how the engine computes a diff* or *the shape of a stored tuple*.
-   They are plumbing — **not "screaming", not domain-revealing** — yet they are published
-   (`lib.rs:30` `pub mod diff`) and carry ceremony (vacuous associated types). Exposing them is the
-   defect: they leak the mechanism and pin the public surface to it.
-2. **Missing ports.** The domain has *no* boundary against infrastructure. The reconciliation
-   engine depends **directly** on `tokio::net::UdpSocket`, `bincode`, `rand::StdRng`, `ipnet`, and
-   the HLC reads `chrono::Utc` itself. There is no dependency inversion, so the domain cannot be
-   exercised without real sockets and real wall-clock time, and the transport/codec/clock cannot be
-   swapped.
-
-The refonte fixes both: **hide and dissolve the plumbing traits**, and **introduce the handful of
-ports the domain actually needs** (`Clock`, `Transport`, `Codec`, `Persistence`).
+- **Storage** — a Hash-Range Tree (`HRTree`): an ordered map that also maintains, for every subtree,
+  a **range fingerprint** so the hash of any key interval is available in `O(log n)`.
+- **Anti-entropy protocol** — two peers compare fingerprints over shrinking key ranges (`diff`) and
+  exchange only the divergent entries. Equality and emptiness are decided by interval **size**, not
+  by hash, to stay collision-safe.
+- **Causality & conflict resolution** — each value is stamped with a Hybrid Logical Clock (`Hlc`);
+  conflicts resolve by **last-write-wins** over the HLC total order `(wall_ms, counter, node_id)`.
+- **Deletion** — removals are **tombstones**; they are garbage-collected only once causally stable
+  (every monotonic cluster member has acknowledged the exact version), which prevents resurrection.
+- **Transport & security** — messages travel as authenticated UDP datagrams (per-datagram MAC,
+  verified before deserialisation). Persistence to disk is optional.
 
 ---
 
-## 2. Critical review
+## 2. Current architecture
 
-### 2.1 The coupling map — where infrastructure leaks into the domain
+### 2.1 Modules
 
-`grep` of infrastructure imports across the modules (audited tree):
+| Module | Responsibility |
+|---|---|
+| `hrtree.rs`, `hrtree_iter.rs` | Ordered map + range-fingerprint data structure and its iterators. |
+| `fingerprint.rs` | 256-bit additive fingerprint (`[u64; 4]`, per-element BLAKE3, add/sub mod 2²⁵⁶). |
+| `diff.rs` | Anti-entropy algorithm (`start_diff`, `diff_round`) and its wire types. |
+| `reconcilable.rs` | Value/tombstone semantics and the conflict-resolution policy. |
+| `hlc.rs` | Hybrid Logical Clock: timestamp type, ordering, and the clock that mints/observes stamps. |
+| `auth.rs` | Per-datagram message authentication (MAC). |
+| `persistence.rs` | Durability boundary: load/save a snapshot of the dated map. |
+| `reconcile_engine.rs` | Network orchestration: UDP socket, (de)serialisation, peer discovery, gossip. |
+| `reconcile_store.rs` | Public facade tying the engine, the map, and timeouts together. |
+| `timeout_wheel.rs` | Acknowledgement timeout tracking. |
 
-| Module | Infra it imports directly | Verdict |
+### 2.2 The domain mechanism is already infrastructure-free
+
+The data structure and the protocol algorithm carry **no infrastructure dependency** — they import
+no async runtime, no socket, no codec, no wall clock (outside `#[cfg(test)]`):
+
+| Module | Infrastructure imported |
+|---|---|
+| `hrtree.rs`, `hrtree_iter.rs`, `fingerprint.rs`, `diff.rs`, `reconcilable.rs` | none |
+
+This is, in effect, the interior of the hexagon and it exists today.
+
+### 2.3 Infrastructure coupling
+
+The infrastructure dependencies are concentrated in two places:
+
+| Module | Infrastructure imported directly | `file:line` |
 |---|---|---|
-| `hrtree.rs`, `hrtree_iter.rs`, `fingerprint.rs`, `diff.rs`, `reconcilable.rs` | none (only `rand` inside `#[cfg(test)]`) | **already infra-free** — this is the hexagon interior, it exists today |
-| `hlc.rs` | `chrono::Utc` (`hlc.rs:35`) — physical time read inside the domain | one small leak: the *time source* |
-| `reconcile_engine.rs` | `tokio::net::UdpSocket`, `tokio::time`, `bincode::{Serializer,Deserializer,DefaultOptions}`, `rand::StdRng`, `ipnet` (`reconcile_engine.rs:21-28,67`) | **infrastructure-soaked** — transport + codec + discovery all hard-wired |
-| `reconcile_store.rs` | `chrono`, `ipnet` (`reconcile_store.rs:19-20`) | facade, leaks time + addressing |
+| `hlc.rs` | `chrono::Utc` — physical time read inside the domain | `hlc.rs:35` |
+| `reconcile_engine.rs` | `tokio::net::UdpSocket`, `tokio::time`, `bincode`, `rand::StdRng`, `ipnet` | `reconcile_engine.rs:21-28,67` |
+| `reconcile_store.rs` | `chrono`, `ipnet` | `reconcile_store.rs:19-20` |
 
-The domain mechanism (HRTree, fingerprint, diff algorithm) is **already clean**. The whole infra
-dependency is concentrated in one god-module, `reconcile_engine.rs`, plus the wall-clock read in
-`hlc.rs`. That is precisely the surface a port extraction targets.
+The reconciliation engine therefore mixes three concerns — transport (UDP), encoding (bincode), and
+the gossip orchestration — in a single module, with the data structure and protocol reached
+underneath. There is no abstraction boundary between the domain and the transport, the codec, or the
+time source: the domain cannot be exercised without real sockets and real wall-clock time, and none
+of the three can be substituted.
 
-### 2.2 Trait-by-trait classification
+### 2.4 Trait landscape
 
-Three distinct categories, three distinct fixes — *not* "delete all single-impl traits".
+Seven traits exist. They fall into three groups:
 
-| Trait | `file:line` | What it really is | Fix |
-|---|---|---|---|
-| `Diffable` | `diff.rs:58` | **Plumbing**, wrongly public. Blanket impl, associated types always `HashSegment<K>`/`DiffRange<K>` — vacuous. Never hand-implemented. | **Delete the trait.** `start_diff`/`diff_round` become `pub(crate)` free functions over the concrete `HRTree`. |
-| `HashRangeQueryable` | `diff.rs:30` | **Plumbing**, wrongly public. One real impl (`HRTree`); the only other is a test `MockStore`. Describes the data structure's internal capability, not a domain boundary. | **Delete the trait.** Inherent methods on `HRTree`; the diff test exercises `HRTree` directly. |
-| `MaybeTombstone` | `reconcilable.rs:43` | **Value-shape plumbing.** One impl on `(Hlc, Option<V>)`. Not a port. | Dissolve into a **domain type** `Entry`/`State` with `is_tombstone()` inherent. |
-| `Reconcilable` | `reconcilable.rs:27` | **Domain policy** (LWW), but mis-shaped as a tuple trait. | Inherent `Entry::merge` (default LWW); optional `Resolve` *domain* seam only if multiple policies become a real goal (§3.5). |
-| `Timestamped` | `hlc.rs:171` | **Value-shape plumbing.** One impl on `(Hlc, V)`. | Field access on `Entry` (`entry.stamp`). |
-| `Mac` | `auth.rs:92` | Compile-time-selected backend (`mac-blake3`/`mac-hmac`), never both at once. | Borderline. Keep as a small `pub(crate)` contract *or* collapse to a `cfg`-selected concrete `ClusterMac`. Not a public port. |
-| **`Persistence`** | `persistence.rs:77` | **A real port.** Two adapters (`InMemory`, `FileSnapshot`) + genuine external extension need. Domain-revealing. | **Keep — this is the model every other port should follow.** |
+- **Boundary abstraction (1).** `Persistence` (`persistence.rs:77`) is a genuine port: it has two
+  implementations (in-memory and file snapshot) and abstracts durability behind a small,
+  intention-revealing contract.
+- **Internal mechanism, currently public (2).** `HashRangeQueryable` (`diff.rs:30`) and `Diffable`
+  (`diff.rs:58`) describe *how* the diff is computed over the tree. `Diffable` is a blanket impl
+  whose associated types are always the same concrete types; `HashRangeQueryable` has a single
+  real implementation (`HRTree`). They are exposed through `pub mod diff` (`lib.rs:30`), placing the
+  protocol mechanism on the crate's public surface.
+- **Value-shape helpers (4).** `MaybeTombstone` (`reconcilable.rs:43`), `Reconcilable`
+  (`reconcilable.rs:27`) and `Timestamped` (`hlc.rs:171`) each carry a single implementation over a
+  tuple — the stored cell is represented as `(Hlc, Option<V>)`. `Mac` (`auth.rs:92`) selects a MAC
+  backend chosen at compile time.
 
-So the existing trait set has exactly **one well-formed port** (`Persistence`) and a pile of
-exposed mechanism. The refonte keeps `Persistence`, **adds the missing ports** (`Clock`,
-`Transport`, `Codec`), and **hides/dissolves the rest**.
+Two consequences of the value-shape representation:
 
-### 2.3 Verbosity and leaks (orthogonal, still real)
-
-- The 9-bound key constraint and 11-bound value constraint are spelled out at every impl site
-  (`reconcile_engine.rs:122-135`, `reconcile_store.rs:75`, the `get_mut` impl). No bound bundle.
-- `MaybeTombstone + Reconcilable + Timestamped` sit inside a *value* bound, although they are
-  properties of the **entry**, not of any plain value.
-- The internal wrapper `(Hlc, Option<V>)` leaks into the **public** hook
-  `add_pre_insert<F: … Fn(&K, &(Hlc, Option<V>)) …>` (`reconcile_store.rs:171`) and into
-  `PersistedState`/`DatedEntries` (`persistence.rs:51`). The mechanism is on the public surface.
+- The internal tuple `(Hlc, Option<V>)` leaks onto the public surface — into the
+  `add_pre_insert` hook (`reconcile_store.rs:171`) and into `PersistedState` (`persistence.rs:51`).
+- The generic constraints are spelled out in full at every implementation site (a nine-bound key
+  constraint and an eleven-bound value constraint, e.g. `reconcile_engine.rs:122-135`,
+  `reconcile_store.rs:75`), with the entry-semantics bounds attached to the *value* parameter rather
+  than to the entry.
 
 ---
 
-## 3. Target architecture: the hexagon
+## 3. Target architecture: ports & adapters
+
+### 3.1 Principle
+
+The target is a **hexagonal** architecture. The domain — storage, protocol, causality, conflict
+resolution, tombstone lifecycle — depends only on a small set of **ports** (traits) that it defines
+itself. **Adapters** implement those ports against concrete infrastructure. All dependency arrows
+point **inward**: adapters depend on the domain, never the reverse.
+
+Two rules follow:
+
+1. **Ports reveal intent and are public.** A port names a capability the domain needs from the
+   outside world (a clock, a transport, a codec, durability). It is part of the crate's contract.
+2. **Mechanism stays internal.** How a diff round is computed, or how a range hash is queried, is an
+   implementation detail of the domain and is not exposed.
+
+### 3.2 The hexagon
 
 ```
-                         ┌─────────────────────── adapters (infra) ───────────────────────┐
+                         ┌─────────────────────── adapters (infrastructure) ──────────────┐
    driving side          │                                                                │
    (application)         │   HlcClock        UdpTransport      BincodeCodec    FileSnapshot│
-        │                │  (chrono/time)   (tokio/UDP)        (bincode)     / InMemory     │
+        │                │  (system time)   (tokio / UDP)      (bincode)     / InMemory     │
         ▼                │       │               │                 │              │         │
   ┌───────────┐  impl    └───────┼───────────────┼─────────────────┼──────────────┼─────────┘
   │  Store    │           ports: │ Clock         │ Transport       │ Codec        │ Persistence
-  │  (facade) │◀──────────────── ▼ ───────────── ▼ ─────────────── ▼ ──────────── ▼ ────────
+  │ (facade)  │◀──────────────── ▼ ───────────── ▼ ─────────────── ▼ ──────────── ▼ ────────
   └───────────┘                 ┌──────────────────────────────────────────────────────────┐
-        ▲                       │                    DOMAIN  (hexagon)                       │
-        │  inbound/driving port │  reconciliation algorithm · conflict policy (LWW)          │
+        ▲                       │                    DOMAIN  (hexagon interior)              │
+        │  driving port         │  anti-entropy algorithm · conflict policy (LWW)            │
         └───────────────────────│  tombstone lifecycle · HRTree + Fingerprint (mechanism)    │
-                                │  Hlc (value) · Entry/State (value)  —  NO tokio/bincode    │
+                                │  Hlc · Entry / State (value types)  —  no tokio / bincode  │
                                 └──────────────────────────────────────────────────────────┘
 ```
 
-- **Domain (interior):** the reconciliation diff algorithm, the conflict-resolution policy, the
-  tombstone lifecycle + causal-stability rule, the `HRTree` and `Fingerprint` (internal mechanism),
-  and the value types `Hlc`, `Entry`, `State`. **Depends on no infrastructure crate.** The grep in
-  §2.1 shows this is *almost already true* — only the wall-clock read needs to move out.
-- **Outbound (driven) ports** — the well-designed traits the domain depends on:
-  `Clock`, `Transport`, `Codec`, `Persistence`.
-- **Adapters** implement the ports: `HlcClock` (system time), `UdpTransport` (tokio), `BincodeCodec`
-  (bincode), `FileSnapshot`/`InMemory` (durability).
-- **Inbound (driving) port:** the `Store` API the application calls (insert/remove/get/run).
+### 3.3 Domain core
 
-The hexagonal payoff is concrete and testable: an in-memory `Transport` adapter makes the
-convergence proptest deterministic (no real sockets); a fixed `Clock` makes HLC behaviour
-reproducible.
+The interior contains, with no infrastructure dependency:
 
-### 3.2 The ports (well-designed, domain-revealing, the only public traits)
+- the anti-entropy algorithm (`start_diff` / `diff_round`),
+- the conflict-resolution policy (last-write-wins over the HLC order),
+- the tombstone lifecycle and the causal-stability garbage-collection rule,
+- the `HRTree` and `Fingerprint` (the storage and range-hash mechanism),
+- the value types `Hlc`, `Entry`, `State`.
+
+### 3.4 Ports
+
+Four outbound ports, each removing one concrete infrastructure dependency from the domain:
 
 ```rust
-// ── Clock ─────────────────────────────────────────────────────────────────────
-// Removes the domain's dependency on chrono::Utc (hlc.rs:35). The HLC algorithm
-// stays domain logic; only the physical-time source crosses the boundary.
+// Clock — abstracts the time source (replaces the direct chrono::Utc read).
+// The HLC algorithm stays in the domain; only physical time crosses the boundary.
 pub trait Clock: Send + Sync + 'static {
     type Timestamp: Copy + Ord + Hash + Serialize + DeserializeOwned + Send + Sync + 'static;
-    /// Mint a fresh, strictly-monotonic local timestamp.
-    fn now(&self) -> Self::Timestamp;
-    /// Advance past a timestamp received from a peer (causality).
-    fn observe(&self, remote: Self::Timestamp);
+    fn now(&self) -> Self::Timestamp;           // mint a strictly-monotonic local stamp
+    fn observe(&self, remote: Self::Timestamp);  // advance past a peer's stamp (causality)
 }
 
-// ── Transport ───────────────────────────────────────────────────────────────────
-// Removes the dependency on tokio::net::UdpSocket. Datagram in / datagram out.
+// Transport — abstracts datagram I/O (replaces tokio::net::UdpSocket).
 #[async_trait::async_trait]
 pub trait Transport: Send + Sync + 'static {
     type Addr: Clone + Eq + Hash + Send + Sync;
@@ -142,32 +170,42 @@ pub trait Transport: Send + Sync + 'static {
     fn local_addr(&self) -> io::Result<Self::Addr>;
 }
 
-// ── Codec ─────────────────────────────────────────────────────────────────────
-// Removes the dependency on bincode. Encodes/decodes protocol messages; auth wraps it.
+// Codec — abstracts wire encoding (replaces bincode). Authentication wraps it externally.
 pub trait Codec: Send + Sync + 'static {
     type Error: std::error::Error + Send + Sync + 'static;
     fn encode<T: Serialize>(&self, value: &T, out: &mut Vec<u8>) -> Result<(), Self::Error>;
     fn decode_stream<T: DeserializeOwned>(&self, bytes: &[u8]) -> Result<Vec<T>, Self::Error>;
 }
 
-// ── Persistence (already exists, persistence.rs:77 — the model port) ────────────
+// Persistence — durability boundary (already present, the model the others follow).
 pub trait Persistence<K, V>: Send + Sync + 'static {
     fn load(&self) -> io::Result<Option<PersistedState<K, V>>>;
     fn save(&self, state: &PersistedState<K, V>) -> io::Result<()>;
 }
 ```
 
-Default adapters: `HlcClock: Clock<Timestamp = Hlc>` (its `now`/`observe`, `hlc.rs:121,146`, already
-match the port exactly), `UdpTransport(Arc<UdpSocket>)`, `BincodeCodec(DefaultOptions)`,
-`FileSnapshot`/`InMemoryPersistence`. The `Authenticator`/MAC stays a `pub(crate)` wrapper
-**outside and ahead of** the `Codec` — auth-before-deserialize is a security property (issue #108,
-§6.5), never folded into the codec.
+### 3.5 Adapters
 
-### 3.3 Domain types that replace the value-shape plumbing traits
+| Port | Default adapter | Backed by |
+|---|---|---|
+| `Clock` | `HlcClock` (its `now`/`observe`, `hlc.rs:121,146`, already match the port) | system time |
+| `Transport` | `UdpTransport(Arc<UdpSocket>)` | tokio / UDP |
+| `Codec` | `BincodeCodec(DefaultOptions)` | bincode |
+| `Persistence` | `FileSnapshot`, `InMemory` | file / memory |
+
+Message authentication (`Authenticator` / MAC) sits **ahead of** the codec: the MAC is verified on
+raw bytes before any decoding occurs. It is never folded into the `Codec`.
+
+The ports make the domain testable in isolation: an in-memory `Transport` (optionally lossy and
+reordering) and a fixed `Clock` make convergence and HLC behaviour deterministic without real
+sockets or wall-clock time.
+
+### 3.6 Domain types and conflict policy
+
+A single, intention-revealing type represents a stored cell, replacing the `(Hlc, Option<V>)` tuple
+and the three value-shape helper traits:
 
 ```rust
-// One stored, replicated cell — replaces (Hlc, Option<V>) and dissolves
-// MaybeTombstone / Reconcilable / Timestamped into a concrete, screaming domain type.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct Entry<T, V> { pub stamp: T, pub state: State<V> }
 
@@ -177,245 +215,116 @@ pub enum State<V> { Present(V), Tombstone }
 impl<T: Ord + Copy, V: Clone> Entry<T, V> {
     pub fn is_tombstone(&self) -> bool { matches!(self.state, State::Tombstone) }
     pub fn value(&self) -> Option<&V> { /* … */ }
-    /// Default conflict policy: last-write-wins over the timestamp's total order.
-    pub fn merge(&self, other: &Self) -> Self {
+    pub fn merge(&self, other: &Self) -> Self {        // last-write-wins (strict >)
         if other.stamp > self.stamp { other.clone() } else { self.clone() }
     }
 }
 ```
 
-This removes `(Hlc, Option<V>)` from the public `add_pre_insert` signature and gives
-`PersistedState` a named field type. `version_hash` (`reconcile_engine.rs:55`) keeps working since
-`Entry` derives `Hash`. **On-wire/on-disk change** (acceptable, unpublished); sequence it where the
-proptest oracle re-runs (Phase 4, §5).
+`Entry` carries the tombstone, timestamp, and merge semantics as a concrete domain type;
+`add_pre_insert` and `PersistedState` take `Entry<…>` rather than the bare tuple. Conflict
+resolution is **domain policy**, not an infrastructure port: last-write-wins is the concrete
+default. A pluggable `Resolve` seam is warranted only if a second policy (e.g. a CRDT) becomes a
+real requirement.
 
-### 3.4 The internal mechanism stays internal
+### 3.7 Internal mechanism
 
-`HashRangeQueryable` + `Diffable` are deleted as *traits*. The range-hash capability becomes
-inherent methods on the concrete `HRTree`; `start_diff`/`diff_round` become `pub(crate)` free
-functions over it, living in a `proto` module. **None of this is public.** The wire types
-`HashSegment`/`DiffRange` are `pub(crate)`. This is the "popote interne" — it must not appear in the
-crate's external contract. Move `diff_round` **verbatim**: it carries the #106/#111 size-not-hash
-rule and the #112 malformed-bound hardening (§6.3, §6.4).
+The anti-entropy mechanism is not a port. `HashRangeQueryable` and `Diffable` are removed as traits:
+range-hash querying becomes inherent methods on the concrete `HRTree`, and `start_diff` / `diff_round`
+become `pub(crate)` functions over it. The wire types `HashSegment` / `DiffRange` are `pub(crate)`.
+None of this appears in the public surface.
 
-### 3.5 Conflict resolution: domain policy, not an infra port
+### 3.8 Generic bounds
 
-LWW-on-`Hlc` is **domain logic**, so it lives in the domain as the concrete default (`Entry::merge`
-above). It is *not* an outbound port. Expose a `Resolve` seam **only if** swapping LWW for another
-strategy (e.g. a CRDT) is a real roadmap item; otherwise a trait here would be the same speculative
-ceremony we are removing. Recommendation: ship the concrete LWW default; add the seam when a second
-policy actually exists.
-
-### 3.6 Bound bundles to de-verbose (stable supertrait + blanket impl)
+The repeated multi-bound constraints are expressed once, as supertrait bundles with blanket impls,
+so implementation sites read `impl<K: Key, V: Value>`:
 
 ```rust
-pub trait Key:
-    Clone + Debug + Hash + Ord + Send + Sync + Serialize + DeserializeOwned + 'static {}
+pub trait Key:   Clone + Debug + Hash + Ord + Send + Sync + Serialize + DeserializeOwned + 'static {}
 impl<T> Key for T where T: /* same */ {}
 
-pub trait Value:
-    Clone + Debug + Hash + PartialEq + Send + Sync + Serialize + DeserializeOwned + 'static {}
+pub trait Value: Clone + Debug + Hash + PartialEq + Send + Sync + Serialize + DeserializeOwned + 'static {}
 impl<T> Value for T where T: /* same */ {}
 ```
 
-The 11-line `where` block at `reconcile_engine.rs:122-135` collapses to `impl<K: Key, V: Value>`;
-the entry semantics travel with `Entry`, not with `V`.
+Entry semantics travel with `Entry`, not with the `V` bound.
 
-### 3.7 Workspace = compiler-enforced dependency inversion
+### 3.9 Crate structure
 
-This is where the **multi-crate workspace you asked for earns its keep** (and supersedes the
-"single-crate-first" hedge from the previous draft): a crate boundary is the only thing that
-*mechanically prevents* the domain from importing tokio/bincode. The hexagon becomes:
+The layers are separated into a workspace so that the inward dependency direction is enforced by the
+compiler:
 
 ```
-reconcile-core     // DOMAIN + PORTS. Defines Clock, Transport, Codec, Persistence (traits),
-                   //   Entry/State, Hlc, Fingerprint, HRTree, the diff algorithm, LWW.
-                   //   deps: serde, blake3 only. NO tokio, NO bincode, NO chrono-IO, NO ipnet.
-reconcile-net      // ADAPTERS: UdpTransport (tokio), BincodeCodec (bincode), Authenticator,
-                   //   peer discovery (ipnet/rand).            deps: reconcile-core + infra.
-reconcile-store    // ADAPTERS: FileSnapshot / InMemory persistence.  deps: reconcile-core + infra.
-reconcile          // WIRING + driving API: ReconcileStore, Config.   deps: all of the above.
+reconcile-core   // DOMAIN + PORTS: Clock, Transport, Codec, Persistence (traits);
+                 //   Entry / State, Hlc, Fingerprint, HRTree, the diff algorithm, LWW.
+                 //   deps: serde, blake3.  (no tokio, bincode, chrono-IO, ipnet, runtime rand)
+reconcile-net    // ADAPTERS: UdpTransport, BincodeCodec, Authenticator, peer discovery.
+reconcile-store  // ADAPTERS: FileSnapshot / InMemory persistence.
+reconcile        // WIRING + driving API: the Store facade, configuration.
 ```
 
-The dependency arrow points **only inward** (adapters → core, never the reverse). If someone writes
-`use tokio::…` in `reconcile-core`, it fails to compile — that is the guarantee a single crate
-cannot give. Ports are defined **in `reconcile-core`** (hexagonal "dependency inversion": the domain
-owns the interface, the adapter depends on it).
+Ports are defined in `reconcile-core`; adapters depend on `reconcile-core`. Infrastructure cannot be
+imported into the core without a compile error — the guarantee a single crate cannot provide.
 
 ---
 
-## 4. Iso-functional cleanups (orthogonal to the ports work, ~450 lines)
+## 4. Current → target mapping
 
-Mechanical, behaviour-preserving simplifications, valid under any philosophy. Verified by the
-existing test suite (a clean compile + green tests *is* the proof).
-
-| Cleanup | `file:line` | Win |
-|---|---|---|
-| **8 iterator types → one shared cursor + projection.** `IntoIter/Iter/IterMut/Values/ValuesMut/Keys/IntoKeys/IntoValues` recopy the same descent; 3 twin `*Layer` enums. | `hrtree_iter.rs:63-530` | **~250 lines** |
-| **7 flat `Arc<RwLock<…>>` + 11-field manual `Clone` → one `Arc<Inner>` + `#[derive(Clone)]`.** One lock-discipline story instead of eight. | `reconcile_engine.rs:64-105` | **~50 lines** |
-| **Broadcast copy-pasted 3× (insert / insert_bulk / acks) → one `broadcast_messages` helper.** | `reconcile_engine.rs:194-254,407-502` | **~30 lines** |
-| **Nested `fn aux(...)` re-declaring bounds** already fixed by the `impl` block. | `hrtree.rs` `get/insert/remove/position/…` | **~30 lines** |
-| **Manual `Clone` on `ReconcileStore`/`TimeoutWheel` → derive** once `Arc<Inner>` lands; dual-index wheel behind one lock. | `reconcile_store.rs:60-72`, `timeout_wheel.rs:11-25` | **~20 lines** |
-| **steal-left/steal-right rebalance dup; silent `.unwrap()` on network serialize → `.expect()`.** | `hrtree.rs:142-259`, `reconcile_engine.rs:320,579+` | clarity |
-
-The **core algorithm is not over-engineered** (HLC, causal-stability gate, fingerprint caching are
-tight and necessary). The bloat is in **scaffolding**, not logic.
-
----
-
-## 5. Migration phases — one issue per phase
-
-> **How to use this section.** After this PR merges, open **one GitHub issue per phase** (or one
-> Project item) by copying its block verbatim — each is written to stand alone: goal, dependency,
-> files, a `- [ ]` task list, and acceptance criteria that double as the issue's *definition of
-> done*. Phases are strictly ordered by the **Depends on** field; the dependency graph is linear
-> (`0 → 1 → 2 → 3 → 4 → 5 → 6`) except that **Phase 0 is independent** and can ship immediately.
-> Suggested labels are given per phase. "Oracle" = the existing test(s) that must stay green and
-> therefore prove the change is behaviour-preserving (except Phase 4, which changes encoding).
-
-| # | Phase | Depends on | Risk | Net LoC | Contract change? |
-|---|---|---|---|---|---|
-| 0 | Iso-functional cleanups | — | low | **−450** | none |
-| 1 | Bound bundles + hide the plumbing | 0 | low | −40 | public surface shrinks |
-| 2 | Dissolve `Diffable`/`HashRangeQueryable` | 1 | low | −60 | none (internals) |
-| 3 | `Clock` port | 1 | low | +30 | none |
-| 4 | `Entry`/`State` domain type | 2, 3 | **high** | ~0 | **wire + on-disk** |
-| 5 | `Transport` + `Codec` ports | 4 | medium | ~0 | wire frozen, not changed |
-| 6 | Workspace split | 5 | medium | ~0 | none |
+| Current | Target |
+|---|---|
+| `(Hlc, Option<V>)` tuple | `Entry<Hlc, V>` + `State<V>` domain type |
+| `MaybeTombstone`, `Timestamped` | inherent `Entry` methods / field access |
+| `Reconcilable` (LWW over tuple) | `Entry::merge` (LWW), optional `Resolve` policy seam |
+| `HashRangeQueryable`, `Diffable` (public) | inherent `HRTree` methods + `pub(crate)` diff functions |
+| `pub mod diff` exposing wire types | `pub(crate)` `HashSegment` / `DiffRange` |
+| `chrono::Utc` read in `hlc.rs` | `Clock` port; `HlcClock` adapter holds the time read |
+| `UdpSocket` in `reconcile_engine.rs` | `Transport` port; `UdpTransport` adapter |
+| `bincode` in `reconcile_engine.rs` | `Codec` port; `BincodeCodec` adapter |
+| `Persistence` | unchanged (the model port) |
+| Multi-bound `where` blocks | `Key` / `Value` supertrait bundles |
+| Single crate | `reconcile-core` / `-net` / `-store` / `reconcile` workspace |
 
 ---
 
-### Phase 0 — Iso-functional cleanups
-**Goal:** remove ~450 lines of scaffolding with zero behaviour change, to shrink the surface every
-later phase touches. · **Depends on:** nothing (ship first). · **Risk:** low. ·
-**Labels:** `refactor`, `good-first-issue`.
+## 5. Invariants
 
-**Tasks**
-- [ ] Collapse the 8 iterator types + 3 twin `*Layer` enums into one shared cursor + projection (`hrtree_iter.rs:63-530`).
-- [ ] Fold the 7 flat `Arc<RwLock<…>>` fields into one `Arc<Inner>`; replace the 11-field manual `Clone` with `#[derive(Clone)]` (`reconcile_engine.rs:64-105`).
-- [ ] Extract the broadcast logic duplicated 3× into one `broadcast_messages` helper (`reconcile_engine.rs:194-254,407-502`).
-- [ ] Drop the nested `fn aux(...)` bound re-declarations now covered by the `impl` block (`hrtree.rs` `get/insert/remove/position`).
-- [ ] Derive `Clone` on `ReconcileStore`/`TimeoutWheel` once `Arc<Inner>` lands; put the dual index behind one lock (`reconcile_store.rs:60-72`, `timeout_wheel.rs:11-25`).
-- [ ] Deduplicate steal-left/steal-right rebalance (`hrtree.rs:142-259`); turn silent `.unwrap()` on network serialize into `.expect("…")` (`reconcile_engine.rs:320,579+`).
+The following load-bearing properties are preserved across any restructuring; they encode the
+correctness and security guarantees established in [`REVIEW.md`](./REVIEW.md).
 
-**Acceptance** — `cargo test` passes unchanged; `cargo clippy` clean; net diff is negative; **no
-public signature changes** (`cargo public-api diff` empty).
-
----
-
-### Phase 1 — Bound bundles + hide the plumbing
-**Goal:** introduce `Key`/`Value` supertrait bundles and demote internal mechanism out of the
-public surface. · **Depends on:** Phase 0. · **Risk:** low. · **Labels:** `refactor`, `api`.
-
-**Tasks**
-- [ ] Add `pub trait Key: …` and `pub trait Value: …` with blanket impls (§3.6).
-- [ ] Replace the 11-line `where` block at `reconcile_engine.rs:122-135` (and the `reconcile_store.rs:75` / `get_mut` sites) with `impl<K: Key, V: Value>`.
-- [ ] In `lib.rs`, demote from `pub` to `pub(crate)`: `mod diff` internals, `fingerprint` internals, `hrtree_iter`, `gen_ip`, `hlc::HlcClock` internals, `auth` (keep `Persistence` and the `Store` facade public).
-- [ ] Audit `tests/` for imports of newly-demoted paths; move those tests into `#[cfg(test)]` units inside the crate where needed.
-
-**Acceptance** — suite green; `cargo public-api diff` shows **only removals** (surface shrinks, nothing added yet); no `tests/diff.rs` import resolves to a demoted public path.
+1. **Fingerprint format & arithmetic** — `[u64; 4]`, per-element BLAKE3, add/sub mod 2²⁵⁶; the
+   golden vectors in `fingerprint.rs` hold.
+2. **HLC total order** `(wall_ms, counter, node_id)` (`hlc.rs:44-54`) — the derived ordering *is* the
+   conflict order; `Clock::Timestamp = Hlc` preserves it, and merge uses strict `>`.
+3. **Size-not-hash emptiness/equality** in `diff_round` (`diff.rs:135-141`).
+4. **Malformed-bound / inverted-range hardening** in `diff_round` (`diff.rs:100-134`).
+5. **Authenticate before deserialise** — the MAC is verified on raw bytes before the codec runs; the
+   `Codec` port never absorbs authentication.
+6. **Causal-stability tombstone gate** — a tombstone is garbage-collected only after every monotonic
+   cluster member has acknowledged the exact version hash.
+7. **`version_hash` determinism** (`reconcile_engine.rs:55`) — preserved as `Entry` derives `Hash`.
 
 ---
 
-### Phase 2 — Dissolve `Diffable` / `HashRangeQueryable`
-**Goal:** delete the two exposed-mechanism traits; the diff algorithm becomes `pub(crate)` functions
-over the concrete `HRTree`. · **Depends on:** Phase 1. · **Risk:** low. · **Labels:** `refactor`.
+## 6. Migration sequence
 
-**Tasks**
-- [ ] Move `start_diff`/`diff_round` **verbatim** into a `pub(crate) mod proto` as free functions taking `&HRTree` (preserve invariants §6.3, §6.4 byte-for-byte).
-- [ ] Turn `HashRangeQueryable`'s methods into inherent methods on `HRTree`; delete the trait.
-- [ ] Delete `Diffable`; make `HashSegment`/`DiffRange` `pub(crate)`.
-- [ ] Drop the test-only `MockStore`; point the diff test at `HRTree` directly.
+The path from the current structure to the target is ordered by dependency. Each step is
+behaviour-preserving and verified by the existing test suite, except the `Entry` step, which changes
+the wire and on-disk formats (acceptable while the formats are unstable).
 
-**Acceptance** — `tests/diff.rs` (regression cases #106/#111/#112) and `proptest_hrtree.rs` green; `grep -r 'Diffable\|HashRangeQueryable' src/` empty; nothing diff-related is `pub`.
+1. **Bound bundles & encapsulation** — introduce `Key` / `Value`; demote the protocol mechanism and
+   other internals from `pub` to `pub(crate)`.
+2. **Dissolve the diff traits** — remove `HashRangeQueryable` / `Diffable`; move `start_diff` /
+   `diff_round` verbatim to `pub(crate)` functions over `HRTree`.
+3. **`Clock` port** — extract `Clock`; `HlcClock` becomes its adapter and holds the physical-time
+   read; the domain becomes time-source-free.
+4. **`Entry` / `State` domain type** — replace `(Hlc, Option<V>)`; dissolve `MaybeTombstone` /
+   `Timestamped`; fold `Reconcilable` into `Entry::merge`; update the public hook and
+   `PersistedState`. *Changes the wire and on-disk formats.*
+5. **`Transport` & `Codec` ports** — extract both; `UdpTransport` / `BincodeCodec` adapters; the
+   engine becomes a thin driver over the ports, with authentication ahead of the codec.
+6. **Workspace split** — promote the layers to `reconcile-core` / `reconcile-net` /
+   `reconcile-store` / `reconcile`; ports defined in the core; the core carries no infrastructure
+   dependency.
 
----
-
-### Phase 3 — `Clock` port
-**Goal:** make the domain time-source-free; the HLC algorithm stays, only the physical-time read
-moves to an adapter. · **Depends on:** Phase 1. · **Risk:** low. · **Labels:** `feature`, `api`.
-
-**Tasks**
-- [ ] Define `pub trait Clock { type Timestamp; fn now(); fn observe(); }` (§3.2) in the domain.
-- [ ] Make `HlcClock` the default adapter implementing `Clock<Timestamp = Hlc>`; move the `chrono::Utc::now()` read (`hlc.rs:35`) inside it.
-- [ ] Thread `C: Clock` through the engine; replace `Timestamped` tuple access with `entry.stamp` field access.
-- [ ] Add a `FixedClock`/`ManualClock` test adapter.
-
-**Acceptance** — `hlc.rs` unit tests (monotonicity, `observe`, `(wall,counter,node)` tie-break, §6.2) green; domain modules import no `chrono`; a test using `FixedClock` produces deterministic stamps.
-
----
-
-### Phase 4 — `Entry` / `State` domain type ⚠️ encoding change
-**Goal:** replace the leaky `(Hlc, Option<V>)` tuple with a screaming domain type and dissolve the
-value-shape traits. · **Depends on:** Phases 2 and 3. · **Risk:** HIGH (changes wire + on-disk
-format — acceptable while unpublished). · **Labels:** `feature`, `breaking`, `api`.
-
-**Tasks**
-- [ ] Add `Entry<T, V>` + `enum State<V> { Present(V), Tombstone }` with inherent `is_tombstone`/`value`/`merge` (default LWW, §3.3); derive `Hash`/`Serialize`.
-- [ ] Replace every `(Hlc, Option<V>)` with `Entry<Hlc, V>`; delete `MaybeTombstone` and `Timestamped`; fold `Reconcilable` into `Entry::merge`.
-- [ ] Fix the public hook signature `add_pre_insert` (`reconcile_store.rs:171`) to take `&Entry<…>` instead of the tuple.
-- [ ] Update `PersistedState`/`DatedEntries` (`persistence.rs:51`) to the named type; bump any on-disk version marker.
-- [ ] Confirm `version_hash` (`reconcile_engine.rs:55`) still hashes deterministically over `Entry` (§6.7).
-
-**Acceptance** — `tests/service.rs` (resurrection, conflict, convergence), `proptest_hrtree.rs`, and a `FileSnapshot` save→load round-trip all green; **`add_pre_insert` no longer mentions `(Hlc, Option<V>)`** anywhere public; LWW `>` (not `>=`) preserved (§6.2).
-
----
-
-### Phase 5 — `Transport` + `Codec` ports
-**Goal:** lift the last infrastructure (tokio/UDP, bincode) out of the domain; the engine becomes a
-thin driver over ports. · **Depends on:** Phase 4. · **Risk:** medium. ·
-**Labels:** `feature`, `api`.
-
-**Tasks**
-- [ ] Define `Transport` and `Codec` ports (§3.2); keep `Authenticator`/MAC **ahead of** the codec (verify-then-decode, §6.5).
-- [ ] Implement `UdpTransport(Arc<UdpSocket>)` and `BincodeCodec(DefaultOptions)` adapters; freeze the bincode `DefaultOptions` config and the `Message` enum tag order.
-- [ ] Rewrite the engine recv/send loop (`reconcile_engine.rs`) to delegate to the ports; remove direct `tokio::net`/`bincode` imports from the engine.
-- [ ] Add an in-memory (optionally lossy/reordering) `Transport` test adapter.
-
-**Acceptance** — `tests/service.rs` convergence and `fuzz_packets.rs` green; a **deterministic** convergence proptest runs over the in-memory transport with no real sockets; engine module imports neither `tokio::net` nor `bincode`.
-
----
-
-### Phase 6 — Workspace split
-**Goal:** promote the layers to crates so the compiler enforces the inward-only dependency
-direction. · **Depends on:** Phase 5. · **Risk:** medium. · **Labels:** `build`, `refactor`.
-
-**Tasks**
-- [ ] Create the workspace: `reconcile-core` (domain + ports), `reconcile-net` (Transport/Codec/auth/discovery), `reconcile-store` (persistence adapters), `reconcile` (wiring + driving API).
-- [ ] Move modules accordingly; ports are **defined in `reconcile-core`**.
-- [ ] Pin dependencies so `reconcile-core` lists only `serde` + `blake3` (no tokio/bincode/chrono-IO/ipnet/rand-runtime).
-- [ ] Re-export the public API from the top-level `reconcile` crate so downstream `use` paths are unchanged where possible.
-
-**Acceptance** — full suite green from the workspace root; `cargo tree -p reconcile-core` shows **no** tokio/bincode/chrono/ipnet; adding `use tokio::…;` to `reconcile-core` fails to compile (the guarantee a single crate cannot give).
-
----
-
-## 6. What must NOT change (load-bearing)
-
-1. **`Fingerprint` wire format & arithmetic** (`[u64;4]`, add/sub mod 2²⁵⁶, per-element BLAKE3) +
-   golden vectors in `fingerprint.rs`. Relocate only.
-2. **HLC total order `(wall_ms, counter, node_id)`** (`hlc.rs:44-54`) — the derived `Ord` *is* the
-   conflict order. `Clock::Timestamp = Hlc` must preserve it; do not weaken `>` to `>=` in merge.
-3. **Size-not-hash emptiness/equality in `diff_round`** (#106/#111, `diff.rs:135-141`).
-4. **Malformed-bound / inverted-range hardening in `diff_round`** (#112, `diff.rs:100-134`).
-5. **Auth-before-deserialize** (#108): MAC verified on raw bytes *before* `Codec::decode`; the
-   `Codec` port never absorbs auth.
-6. **Causal-stability tombstone gate:** GC only after every monotonic `members` entry acked the
-   exact `version_hash`. Pinned by the resurrection test in `tests/service.rs`.
-7. **`version_hash` determinism** (`reconcile_engine.rs:55`, `DefaultHasher` fixed keys) — keep it
-   when `Entry` derives `Hash`.
-
----
-
-## 7. Summary
-
-The crate already has a clean, infra-free domain mechanism (HRTree/fingerprint/diff) and exactly one
-well-formed port (`Persistence`). The "usine à gaz" is (a) internal mechanism — `Diffable`,
-`HashRangeQueryable`, `MaybeTombstone` — *published* as if it were the contract, and (b) the absence
-of ports, leaving the domain welded to tokio/UDP/bincode/chrono inside one god-module. The refonte
-is therefore not "fewer traits" nor "more traits" — it is **the right traits as ports** (`Clock`,
-`Transport`, `Codec`, `Persistence`) defined by the domain, **the plumbing hidden** (`diff`,
-range-hash) or **dissolved into screaming domain types** (`Entry`/`State` for the tombstone/version
-model), **bound bundles** to kill the verbosity, and a **workspace** whose crate boundaries enforce
-the inward-only dependency direction the hexagon requires. The seven load-bearing invariants of §6
-are held fixed, and the existing test suite keeps every phase honest.
+Steps 1–3 are independent of the format change; step 4 is the single format-breaking step; steps 5–6
+complete the boundary extraction and enforce it at the crate level.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,508 @@
+# Architecture review & refonte foundations — `reconcile-rs` (crate `reconcile`)
+
+> Forward-looking **architecture** document: a critical review of the current layering and
+> contracts, a concrete target architecture (layers, module tree, trait signatures), and a
+> phased, test-green migration path.
+>
+> - **Date:** 2026-06-01
+> - **Manifest version:** `0.0.0-git` (unpublished under this shape — no backward-compatibility
+>   contract yet, so the API and the on-wire/on-disk formats may be broken freely).
+> - **Scope:** architecture, contracts and abstraction. This is **not** a defect review — for the
+>   correctness/security peer-review see [`REVIEW.md`](./REVIEW.md). Most of its critical findings
+>   (F1–F8: `hash==0` sentinel, packet-panic DoS, missing auth, tombstone resurrection,
+>   physical-clock LWW, weak XOR fingerprint, reachable `unimplemented!()`, unstable
+>   `DefaultHasher`) are **already fixed** in the current code (256-bit BLAKE3 fingerprint, HLC,
+>   per-datagram MAC, causal-stability gate, `checked_sub` hardening). This document assumes that
+>   corrected baseline and asks a different question: *is the architecture clean?*
+> - **Method:** static reading of `src/`, `tests/`, `Cargo.toml`. No source file modified by this
+>   document. Every claim carries a `file:line` proof against the audited tree.
+
+---
+
+## 1. Diagnosis in one sentence
+
+The code is **correct and well-tested but layer-collapsed**: a data structure, a wire protocol, a
+replication-semantics policy (HLC + LWW + tombstone GC), a transport (UDP/bincode/MAC) and a user
+facade all live in one flat module set **with no contract boundaries** — and the one place where
+abstraction was attempted (the associated types of `Diffable`) adds ceremony without flexibility.
+
+The fix is to introduce **named seams** — traits at the layer boundaries — and to make the
+value/tombstone/clock/transport models **pluggable**, *without touching the handful of things that
+are correctness- or compatibility-load-bearing* (§5).
+
+---
+
+## 2. Critical review of the current architecture
+
+### 2.1 The five layers, and where they leak
+
+The crate naturally decomposes into five layers, but the modules do not reflect them:
+
+| Layer | Responsibility | Today's files |
+|---|---|---|
+| **L1 — Data structure** | Ordered map with O(log n) range fingerprints | `hrtree.rs`, `hrtree_iter.rs`, `fingerprint.rs` |
+| **L2 — Reconciliation protocol** | Range-subdivision set-difference algorithm over fingerprints; pure, transport-agnostic, no I/O | `diff.rs` |
+| **L3 — Replication semantics** | What a *version* is (clock), how conflicts *merge*, what a *tombstone* is, when a tombstone is GC-safe (causal stability) | `hlc.rs`, `reconcilable.rs`, `timeout_wheel.rs` + ack logic **buried inside** `reconcile_engine.rs` |
+| **L4 — Transport + codec + membership** | UDP socket I/O, bincode framing, MAC auth, peer discovery/sampling, the async protocol *driver* | `reconcile_engine.rs`, `auth.rs`, `gen_ip.rs` |
+| **L5 — Service facade** | The single public type users hold; wiring, persistence, builder config | `reconcile_store.rs`, `persistence.rs` |
+
+**Two clean layering violations** stand out:
+
+1. **L3 logic is embedded in L4.** Clock advancement (`clock.observe`), per-value tombstone
+   version-hashing (`version_hash`, `reconcile_engine.rs:55`) and ack tracking
+   (`tombstone_acks`, `reconcile_engine.rs:83`) live inside the engine's message loop rather than
+   in a semantics layer. The *policy* (when is a deletion safe to forget?) is tangled with the
+   *mechanism* (UDP datagrams).
+2. **L2 is reached by a blanket impl that hardwires L1's key type.** `diff.rs:78`,
+   `impl<K: Clone, T: HashRangeQueryable<Key = K>> Diffable for T`, means nobody ever implements
+   `Diffable` directly; the protocol is welded onto the data-structure trait.
+
+### 2.2 Seven hard-coded couplings that block abstraction
+
+| # | Coupling | Proof | Why it hurts |
+|---|---|---|---|
+| C1 | **Clock hardwired to HLC** | `reconcile_engine.rs:86` (`clock: Arc<HlcClock>`), `hlc.rs` | No `Clock`/`Timestamp` seam; a different versioning scheme (vector clocks, externally-supplied stamps) cannot be plugged in. |
+| C2 | **Conflict resolution hardwired to LWW-on-Hlc** | `reconcilable.rs:27` (`impl Reconcilable for (Hlc, V)`) | Merge policy is fixed; no way to override per value type without re-implementing the engine. |
+| C3 | **Value model hardwired to `(Hlc, Option<V>)`** | `reconcile_store.rs:52`, `persistence.rs:51` (`DatedEntries = Vec<(K,(Hlc,Option<V>))>`) | The timestamp+tombstone tuple is structural, not a named type. |
+| C4 | **Tombstone leaks into the public API** | `reconcile_store.rs:171` — `add_pre_insert<F: … Fn(&K, &(Hlc, Option<V>)) …>` | Users of the *public* hook must know the internal wrapping `(Hlc, Option<V>)`; the abstraction boundary is broken at the surface. |
+| C5 | **Tombstone logic fragmented** | `reconcilable.rs:43` (`MaybeTombstone`), `Option<V>`, `timeout_wheel.rs`, `tombstone_acks` (`reconcile_engine.rs:83`), store GC loop | One concept (a deletion and its safe lifetime) is smeared across five places. |
+| C6 | **Transport=UDP & codec=bincode hardwired** | `reconcile_engine.rs:67` (`socket: Arc<UdpSocket>`), `:21` (`use bincode::…`) | No `Transport`/`Codec` seam; cannot swap UDP→QUIC or bincode→protobuf, and cannot unit-test the driver without real sockets. |
+| C7 | **Public surface leaks internals** | `lib.rs:30-37` exposes `pub mod diff, fingerprint, hrtree_iter, hlc, gen_ip` next to `reconcile_store` | A user cannot tell the stable external contract (`ReconcileStore`) from low-level plumbing (`HashSegment`, `Fingerprint` internals, iterators, `HlcClock`). |
+
+### 2.3 The verbosity: bounds and the vacuous two-trait split
+
+The owner's "verbose, unreadable traits" complaint has two concrete causes.
+
+**(a) Giant `where` blocks, repeated.** The same nine-bound key constraint and eleven-bound value
+constraint are spelled out at every impl site:
+
+```rust
+// reconcile_engine.rs:122-135
+impl<
+        K: Clone + Debug + DeserializeOwned + Hash + Ord + Send + Serialize + Sync + 'static,
+        V: Clone + DeserializeOwned + Hash + MaybeTombstone + PartialEq + Reconcilable
+            + Send + Serialize + Sync + Timestamped + 'static,
+    > ReconcileEngine<K, V>
+```
+
+The identical key bound reappears at `reconcile_store.rs:75` and in the `get_mut` impl. There is no
+trait-alias/bundle, so every reader re-parses the same wall of bounds. Worse, `MaybeTombstone +
+Reconcilable + Timestamped` are mixed into a *value* bound — but those are **semantics of the entry
+type**, not properties any plain value has. They belong to the entry model (§3.4), not to `V`.
+
+**(b) A two-trait split whose associated types are vacuous.** `HashRangeQueryable` (`diff.rs:30`)
+plus `Diffable` (`diff.rs:58`), where `Diffable::ComparisonItem` is *always* `HashSegment<K>` and
+`Diffable::DifferenceItem` is *always* `DiffRange<K>` (`diff.rs:78-80`). The associated types
+suggest flexibility that does not exist; the blanket impl means `Diffable` is never implemented by
+hand. Two traits and two associated types pay for zero generality.
+
+---
+
+## 3. Target architecture
+
+### 3.1 Structural decision: single crate now, **workspace-ready** module tree
+
+The owner's stated target is a **multi-crate workspace**. The recommendation here is to **reach it
+in two moves, not one**: first reorganize into a layered *module* tree inside the single crate, with
+explicit `pub` / `pub(crate)` contracts and module names chosen so that "promote each `mod` to a
+crate" is mechanical; then split into a workspace once the layers have stabilized (and ideally once
+a sub-crate has an external consumer).
+
+**Why module-first, crate-second:**
+
+- *Pre-1.0, unpublished.* A workspace's main payoff — independent versioning and compile-time
+  isolation of sub-crates — has near-zero value before any external consumer exists.
+- *Risk isolation.* The hard part of this refonte is the **trait design** (§3.3) and the
+  **god-object split** (§3.5). Doing that *and* fighting cross-crate visibility, `Cargo.toml`
+  plumbing and feature-flag propagation simultaneously multiplies risk for no behavioural gain.
+- *Tests stay honest.* `tests/service.rs` and `tests/proptest_hrtree.rs` reach across all layers;
+  one crate lets them stay green through every phase without being rewritten against several crates.
+
+**The single downside, and its mitigation.** Module-level `pub(crate)` is a softer wall than a crate
+boundary: a lazy cross-layer reach still compiles. Mitigation: the explicit re-export facade
+(§3.2), code review, and — later — a `clippy.toml`/`cargo-deny`-style disallowed-path lint in CI.
+
+**Bascule criteria (when to actually split into the workspace):** when `hrtree/`+`proto/` gains an
+external consumer, or when `no_std`/alternative-transport feature isolation is wanted. The module
+tree below names each layer after its eventual crate so the split is a move, not a redesign.
+
+```
+hrtree/    → reconcile-hrtree   (L1)
+proto/     → reconcile-proto    (L2)
+semantics/ → reconcile-core     (L3)
+net/       → reconcile-net      (L4)
+store/     → reconcile          (L5, the umbrella crate)
+```
+
+### 3.2 Target module tree (single crate, workspace-ready)
+
+```
+src/
+  lib.rs                 // THE public facade: re-exports L5 + the few L1/L3 extension points
+  prelude.rs             // optional `pub use` bundle for downstream users
+  bounds.rs              // pub: Key, Value supertrait bundles (used everywhere)
+
+  hrtree/                // L1  (future crate: reconcile-hrtree)
+    mod.rs               //   pub: HRTree, Fingerprint, RangeHashMap (the merged L1/L2 contract)
+    node.rs
+    iter.rs
+    fingerprint.rs
+
+  proto/                 // L2  (future crate: reconcile-proto)  — pub(crate)
+    mod.rs               //   start_diff / diff_round as free fns over RangeHashMap
+    segment.rs           //   HashSegment, DiffRange  (wire types)
+
+  semantics/             // L3  (future crate: reconcile-core)
+    mod.rs
+    clock.rs             //   pub: Clock, Timestamp, Versioned
+    merge.rs             //   pub: Merge (was Reconcilable)
+    entry.rs             //   pub: Entry<T,V>, State<V>  (replaces (Hlc, Option<V>))
+    hlc.rs               //   pub: Hlc (impl Timestamp) + pub(crate) HlcClock (impl Clock)
+    stability.rs         //   pub(crate): TombstoneTracker (was tombstone_acks + timeout_wheel)
+
+  net/                   // L4  (future crate: reconcile-net)
+    mod.rs
+    transport.rs         //   pub: Transport trait; pub(crate) UdpTransport
+    codec.rs             //   pub: Codec trait;     pub(crate) BincodeCodec
+    auth.rs              //   pub(crate): Mac, Authenticator, ClusterKey, Payload
+    membership.rs        //   pub(crate): PeerTable, discovery (gen_ip)
+    driver.rs            //   pub(crate): ProtocolDriver (the slimmed-down engine)
+
+  store/                 // L5  (this crate's reason to exist)
+    mod.rs               //   pub: ReconcileStore, Config
+    persistence.rs       //   pub: Persistence, FileSnapshot, InMemoryPersistence, PersistedState
+```
+
+### 3.3 External vs internal contract, per layer
+
+- **L1 (`hrtree/`) — external:** `HRTree`, `Fingerprint`, and the merged range-hash trait
+  `RangeHashMap` (§3.6). Legitimately reusable on their own. Everything else (`node`, cached-hash
+  internals) is `pub(crate)`.
+- **L2 (`proto/`) — internal only.** The protocol is an implementation detail of replication.
+  `HashSegment`/`DiffRange` are **wire types**: `pub(crate)`, never in the public API. (Today
+  `diff.rs` is `pub mod` at `lib.rs:30` — coupling **C7**; demote it.)
+- **L3 (`semantics/`) — external:** `Clock`, `Timestamp`, `Versioned`, `Merge`, `Entry`, `State`,
+  `Hlc` — the **extension points** users plug into to change clock or conflict policy. `HlcClock`,
+  `TombstoneTracker` are `pub(crate)`.
+- **L4 (`net/`) — external:** the `Transport` and `Codec` *traits* (so an embedder can swap UDP for
+  QUIC, or bincode for protobuf). Concrete `UdpTransport`/`BincodeCodec`, `Authenticator`,
+  `PeerTable`, `ProtocolDriver` are `pub(crate)`.
+- **L5 (`store/`) — external:** `ReconcileStore`, `Config`, the `Persistence` family. ~90% of the
+  surface users actually touch.
+
+`lib.rs` shrinks from eight `pub mod` (`lib.rs:30-37`) to a tight facade:
+
+```rust
+pub mod store;        // ReconcileStore, Config
+pub mod persistence;  // Persistence family (or re-exported from store)
+pub mod semantics;    // Clock / Merge / Entry / Hlc — extension points
+pub mod hrtree;       // L1 reusable data structure
+pub mod net;          // Transport / Codec traits (concretes stay pub(crate))
+
+pub(crate) mod proto;
+pub(crate) mod bounds;
+
+pub use store::{Config, ReconcileStore};
+pub use hrtree::{Fingerprint, HRTree};
+pub use semantics::{Clock, Entry, Hlc, Merge, State, Timestamp, Versioned};
+pub use persistence::{FileSnapshot, InMemoryPersistence, PersistedState, Persistence};
+```
+
+The key change: `diff`, `fingerprint` internals, `hrtree_iter`, `gen_ip`, `hlc::HlcClock` and
+`auth` stop being top-level `pub`. Users can no longer mistake plumbing for the stable contract.
+
+### 3.4 Bound bundles — kill the repeated `where` clauses
+
+`#![feature(trait_alias)]` is unstable. Use the **stable supertrait + blanket-impl** pattern: a
+marker supertrait bundles the bounds, a blanket impl makes every qualifying type satisfy it
+automatically, and downstream users never implement it by hand.
+
+```rust
+// src/bounds.rs
+use std::fmt::Debug;
+use std::hash::Hash;
+use serde::{de::DeserializeOwned, Serialize};
+
+/// Everything a key must satisfy across the stack. Implemented automatically.
+pub trait Key:
+    Clone + Debug + Hash + Ord + Send + Sync + Serialize + DeserializeOwned + 'static {}
+impl<T> Key for T where
+    T: Clone + Debug + Hash + Ord + Send + Sync + Serialize + DeserializeOwned + 'static {}
+
+/// Everything a *stored* value must satisfy: serializable, hashable (for the
+/// fingerprint), comparable (to detect a no-op merge), thread-safe.
+pub trait Value:
+    Clone + Debug + Hash + PartialEq + Send + Sync + Serialize + DeserializeOwned + 'static {}
+impl<T> Value for T where
+    T: Clone + Debug + Hash + PartialEq + Send + Sync + Serialize + DeserializeOwned + 'static {}
+```
+
+The twelve-line bound block at `reconcile_engine.rs:122-135` collapses to `impl<K: Key, V: Value>`
+(plus the entry-model bounds, which now travel with `Entry`, §3.5). Note the *conceptual* cleanup,
+not just cosmetics: `MaybeTombstone + Reconcilable + Timestamped` move **out** of the value bound and
+**into** the entry model where they belong.
+
+### 3.5 Clock / Version abstraction (generalizes HLC)
+
+Split HLC's two roles: the *timestamp* (a value type with a total order) and the *clock* (a stateful
+minter/observer).
+
+```rust
+// src/semantics/clock.rs
+
+/// A version stamp with a globally-deterministic total order. `Ord` MUST be a genuine
+/// total order shared by all replicas (the conflict survivor is `max` over it), and it
+/// MUST be part of the value's `Hash` so the fingerprint reflects version changes.
+pub trait Timestamp:
+    Clone + Copy + Ord + std::hash::Hash + Send + Sync
+    + serde::Serialize + serde::de::DeserializeOwned + 'static {}
+
+/// A per-node clock that mints monotonic timestamps and advances on observation.
+pub trait Clock: Send + Sync + 'static {
+    type Timestamp: Timestamp;
+    /// Mint a fresh timestamp, strictly greater than every timestamp previously produced
+    /// or observed by this clock (local monotonicity).
+    fn now(&self) -> Self::Timestamp;
+    /// Advance to account for a timestamp received from a peer, so a subsequent `now()` is
+    /// ordered after `remote` (causality; prevents lost updates under skew).
+    fn observe(&self, remote: Self::Timestamp);
+}
+
+/// A value carrying a version stamp: lets the engine read a stored value's timestamp
+/// (to advance the clock) without knowing the concrete value type. Replaces `Timestamped`.
+pub trait Versioned {
+    type Timestamp: Timestamp;
+    fn timestamp(&self) -> Self::Timestamp;
+}
+```
+
+`Hlc: Timestamp` — the derived `Ord` already *is* the `(wall_ms, counter, node_id)` total order
+(`hlc.rs:44-54`); **do not change it** (§5.2). `HlcClock: Clock<Timestamp = Hlc>` — its `now`/
+`observe` (`hlc.rs:121`, `:146`) already match the trait exactly, so this is pure renaming.
+`Timestamped` (`hlc.rs:171`) becomes `Versioned`.
+
+### 3.6 First-class tombstones — replace `(Hlc, Option<V>)`
+
+The deepest fix, addressing **C3/C4/C5**. The value model is currently the tuple `(Hlc, Option<V>)`
+with tombstone = `None`, and that tuple leaks into the public `add_pre_insert` (`reconcile_store.rs:171`)
+and into `PersistedState` (`persistence.rs:51`). Make it an explicit, named type with one trait.
+
+```rust
+// src/semantics/entry.rs
+
+/// One stored, replicated cell: a version stamp plus either a live value or a tombstone.
+/// Replaces the leaky `(Hlc, Option<V>)`.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+pub struct Entry<T, V> { pub stamp: T, pub state: State<V> }
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+pub enum State<V> { Present(V), Tombstone }
+
+impl<T: Timestamp, V> Versioned for Entry<T, V> {
+    type Timestamp = T;
+    fn timestamp(&self) -> T { self.stamp }
+}
+
+impl<T, V> Entry<T, V> {
+    pub fn is_tombstone(&self) -> bool { matches!(self.state, State::Tombstone) }
+    pub fn value(&self) -> Option<&V> {
+        match &self.state { State::Present(v) => Some(v), State::Tombstone => None }
+    }
+}
+```
+
+This dissolves the fragmented `MaybeTombstone` trait (`reconcilable.rs:43`) into an inherent method,
+removes the `Option` wrapper from the public hook signature, and gives `PersistedState` a named field
+type. `version_hash` (`reconcile_engine.rs:55`) keeps working because `Entry` derives `Hash`.
+
+> **Wire/disk format note.** The bincode encoding of `Entry<Hlc, V>` differs from
+> `(Hlc, Option<V>)`. This is a **breaking on-disk/on-wire change** — acceptable because the crate
+> is unpublished (`0.0.0`) and has no compatibility contract. Sequence it (Phase 4, §4) so the
+> proptest oracle re-runs against the new shape.
+
+### 3.7 Merge abstraction (generalizes LWW)
+
+```rust
+// src/semantics/merge.rs
+
+/// Conflict resolution. MUST be commutative, associative and idempotent so all replicas
+/// converge (Strong Eventual Consistency). Returns the winner of two concurrently-held
+/// values for the same key.
+pub trait Merge { fn merge(&self, other: &Self) -> Self; }
+
+/// Last-write-wins over any total-order timestamp. Generalizes `Reconcilable for (Hlc, V)`.
+impl<T: Timestamp, V: Clone> Merge for Entry<T, V> {
+    fn merge(&self, other: &Self) -> Self {
+        if other.stamp > self.stamp { other.clone() } else { self.clone() }
+    }
+}
+```
+
+**Recommendation: keep `Merge` as a trait on the entry type** (mirroring today's
+`Reconcilable for (Hlc, V)`, `reconcilable.rs:27`) with LWW supplied by the blanket impl above —
+**do not** introduce a separate `Lww<C>` strategy object. The engine already calls
+`local.reconcile(&remote)` with no policy parameter; a free-standing strategy would force a policy
+generic through the entire stack (driver, store, config) for a generalization nobody has requested.
+The trait keeps the call site identical and still lets a user override merge by newtyping their value.
+
+Do **not** weaken the strict `>` (§5.2): "equal stamp ⇒ keep self" is what makes merge commutative,
+pinned by `reconcile_is_commutative_on_equal_wall_and_counter` (`reconcilable.rs:59`).
+
+### 3.8 Merge the `HashRangeQueryable` + `Diffable` pair into one trait
+
+Kill the vacuous two-trait split (§2.3b). Keep **one** trait `RangeHashMap` (the renamed
+`HashRangeQueryable`), **delete** the `Diffable` trait, and turn `start_diff`/`diff_round` into
+**free functions** in `proto/` parameterized by `RangeHashMap`. This removes the redundant trait
+*and* its vacuous associated types in one move, and relocates the protocol (L2) out of the
+data-structure contract (L1).
+
+```rust
+// src/hrtree/mod.rs  — the L1 contract, the only thing the protocol needs
+pub trait RangeHashMap {
+    type Key: Ord + Clone;
+    fn range_hash<R: RangeBounds<Self::Key>>(&self, range: &R) -> Fingerprint;
+    fn insertion_position(&self, key: &Self::Key) -> usize;
+    fn key_at(&self, index: usize) -> &Self::Key;
+    fn len(&self) -> usize;
+    fn is_empty(&self) -> bool { self.len() == 0 }
+}
+
+// src/proto/mod.rs  — L2, pure, no I/O, pub(crate)
+pub(crate) fn start_diff<M: RangeHashMap>(map: &M) -> Vec<HashSegment<M::Key>> { /* moved verbatim */ }
+pub(crate) fn diff_round<M: RangeHashMap>(
+    map: &M,
+    in_comparison: Vec<HashSegment<M::Key>>,
+    out_comparison: &mut Vec<HashSegment<M::Key>>,
+    differences: &mut Vec<DiffRange<M::Key>>,
+) { /* moved verbatim, including the #106/#111/#112 hardening */ }
+```
+
+> **Move `diff_round` verbatim.** Its body (`diff.rs:90-200`) contains the size-not-hash
+> emptiness/equality decision (issues #106/#111, `diff.rs:135-141`) and the malformed-bound /
+> inverted-range hardening (issue #112, `diff.rs:100-134`). It is correctness-critical; this is a
+> **relocation, not a rewrite** (§5.3, §5.4).
+
+### 3.9 Transport and Codec abstractions
+
+Decouple UDP and bincode (**C6**). Keep the async surface minimal so `UdpTransport` is a thin
+wrapper and `tests/fuzz_packets.rs` can still drive raw bytes.
+
+```rust
+// src/net/transport.rs
+#[async_trait::async_trait]   // hand-rolled `impl Future` also fine; async-trait is simplest here
+pub trait Transport: Send + Sync + 'static {
+    type Addr: Clone + Send + Sync;
+    async fn recv_from(&self, buf: &mut [u8]) -> std::io::Result<(usize, Self::Addr)>;
+    async fn send_to(&self, buf: &[u8], dst: &Self::Addr) -> std::io::Result<usize>;
+    fn local_addr(&self) -> std::io::Result<Self::Addr>;
+}
+
+// src/net/codec.rs
+/// Frames protocol messages to/from bytes. The MAC/auth layer wraps the codec output; the
+/// codec itself is auth-agnostic. Streaming decode (multiple messages per datagram) is
+/// preserved by decoding from a cursor.
+pub trait Codec: Send + Sync + 'static {
+    type Error: std::error::Error + Send + Sync + 'static;
+    fn encode<T: serde::Serialize>(&self, value: &T, out: &mut Vec<u8>) -> Result<(), Self::Error>;
+    fn decode_stream<T: serde::de::DeserializeOwned>(&self, bytes: &[u8]) -> Result<Vec<T>, Self::Error>;
+}
+```
+
+`UdpTransport(Arc<UdpSocket>)` and `BincodeCodec(DefaultOptions)` are the `pub(crate)` defaults
+wired by `Config`. **Keep `BincodeCodec` on the exact same `DefaultOptions` and the same `Message`
+enum tag order** (`reconcile_engine.rs:108-120`) — the on-wire representation of
+`ComparisonItem/Update/Ack`, `HashSegment` and `Fingerprint` must not change beyond the `Entry`
+re-encoding of §3.6 (§5.1). The MAC/`Authenticator` stays a **separate `pub(crate)` wrapper outside
+and ahead of** the codec — auth-before-deserialize is a security property (issue #108, §5.5), never
+folded into the codec.
+
+### 3.10 Decomposing the god object `ReconcileEngine`
+
+`ReconcileEngine` (`reconcile_engine.rs:64-87`, 789 lines) currently fuses: map ownership, the UDP
+socket, bincode ser/de, MAC framing, peer expiry, member tracking, the clock, tombstone-ack state,
+the `Message` enum, the recv/dispatch loop, broadcast-on-write, and the pre-insert hook. Split into
+single-responsibility components owned by a thin driver:
+
+| New component | Owns / does | Carved from |
+|---|---|---|
+| `Transport` + `UdpTransport` (`net/`) | socket bind, `recv_from`/`send_to`, retries | `socket`, `send_to_retry`, `MAX_SENDTO_RETRIES` |
+| `Codec` + `BincodeCodec` (`net/`) | `Message` encode / decode-stream | `Serializer`/`Deserializer`, `BUFFER_SIZE` framing |
+| `Authenticator` (`net/auth.rs`) | MAC open/seal, `Payload` gate | `auth.rs` (already isolated) |
+| `PeerTable` (`net/membership.rs`) | `peers` (expiring) + `members` (monotonic) + `gen_ip` sampling | `peers`, `members`, `get_peers`, `PEER_EXPIRATION`, `gen_ip` |
+| `TombstoneTracker` (`semantics/stability.rs`) | `tombstone_acks` + reciprocal-ack + `TimeoutWheel` + `is_gc_ready` predicate | `tombstone_acks`, ack logic in `handle_messages`, `timeout_wheel.rs` |
+| `Arc<dyn Clock>` (or `Arc<HlcClock>`) | mint/observe | `clock` field, `clock_now`, the `observe` call |
+| `ProtocolDriver` (`net/driver.rs`) | the slim coordinator: `run()` loop, dispatch, broadcast-on-write | what remains after the extractions |
+
+**Wiring.** `ProtocolDriver` holds `Arc<RwLock<HRTree>>`, a `Transport`, a `Codec`, an
+`Authenticator`, a `PeerTable`, a `TombstoneTracker`, and a `Clock`. Its `run()` loop becomes:
+`transport.recv_from` → `authenticator.open` → `codec.decode_stream` → classify into
+comparisons/updates/acks → delegate (comparisons → `proto::diff_round`; updates → `apply_updates`,
+which calls `clock.observe`, `entry.merge`, `tombstone_tracker.record`; acks → `tombstone_tracker`)
+→ each delegate returns outbound messages, which the driver encodes + auths + sends. This turns
+`handle_messages` (today ~150 lines mixing five concerns) into a ~30-line dispatcher.
+
+**Causal-stability invariant survives the split intact** (§5.6): a tombstone is GC-eligible only
+when *every* member in `PeerTable.members` has acked the *exact* `version_hash` currently held.
+Concentrate that logic in `TombstoneTracker::is_gc_ready(key, version, &members)`, byte-for-byte.
+
+---
+
+## 4. Phased migration (ordered, each independently committable, test-green)
+
+Every phase ends with `cargo test` green against the **existing** suite (the behavioural oracle).
+No big-bang.
+
+| Phase | What | Files | Risk | Oracle |
+|---|---|---|---|---|
+| **1 — Bound bundles + facade** *(cheapest, highest visible value)* | Add `bounds.rs` (`Key`/`Value`), replace the repeated `where` blocks; demote `diff`, `fingerprint` internals, `hrtree_iter`, `gen_ip`, `hlc::HlcClock` to `pub(crate)` in `lib.rs`. (`MaybeTombstone+Reconcilable+Timestamped` stay explicit until Phase 4.) | `lib.rs`, `bounds.rs` (new), `reconcile_engine.rs`, `reconcile_store.rs` | very low | whole suite compiles+passes unchanged; a successful compile *proves* the bundles are equivalent. Check `tests/diff.rs` for direct imports of demoted paths and keep them reachable (`#[cfg(test)] pub use`). |
+| **2 — Merge L1/L2, relocate protocol** | Rename `HashRangeQueryable`→`RangeHashMap` into `hrtree/`; delete `Diffable`; move `start_diff`/`diff_round` **verbatim** into `proto/`; update the two engine call sites. | `diff.rs`→`hrtree/`+`proto/`, `hrtree.rs`, engine, `tests/diff.rs` (import-only) | low | `tests/diff.rs` (#106/#111/#112) + `proptest_hrtree.rs` convergence catch any accidental edit to moved code. |
+| **3 — Clock/Timestamp/Versioned** | Introduce the three traits; `impl Timestamp for Hlc`, `impl Clock for HlcClock`; rename `Timestamped`→`Versioned`. Engine still holds `Arc<HlcClock>`, called through the trait. | `hlc.rs`→`semantics/{clock,hlc}.rs`, `reconcilable.rs`, engine | low | `hlc.rs` unit tests (monotonicity, observe-advances, total-order tie-break) move with the type, stay green. |
+| **4 — First-class `Entry`** *(highest risk: changes encoding)* | `Entry`/`State` replace `(Hlc,Option<V>)`; `Reconcilable`→`Merge`; delete `MaybeTombstone`; fix the public `add_pre_insert` signature; update `PersistedState`/`DatedEntries`. | `entry.rs`+`merge.rs` (new), engine, `reconcile_store.rs:171`, `persistence.rs:51` | **highest** | `tests/service.rs` (resurrection, conflicts, two-node convergence), `proptest_hrtree.rs` (lossy-transport convergence = strongest round-trip check), `FileSnapshot` round-trips (`reconcile_store.rs` persistence tests). |
+| **5 — Extract `TombstoneTracker` + `PeerTable`** | Pull acks+reciprocal+`TimeoutWheel` into `semantics/stability.rs` with `is_gc_ready`; pull `peers`/`members`/`gen_ip` into `net/membership.rs`. | `timeout_wheel.rs`→`stability.rs`, `gen_ip.rs`→`membership.rs`, engine, store GC loop | medium | resurrection + authenticated-node tests in `tests/service.rs`; `fuzz_packets.rs` for ack robustness. |
+| **6 — Extract `Transport`/`Codec`, slim the driver** | Introduce the traits + `UdpTransport`/`BincodeCodec`; rewrite `handle_messages`/`run` as `ProtocolDriver` delegating to Phase-5 components; keep `Authenticator` ahead of the codec; freeze `DefaultOptions`/`Message` tag order. | `net/{transport,codec,driver}.rs`, `reconcile_engine.rs`→`driver.rs`, `auth.rs`→`net/auth.rs` | medium | `tests/service.rs` two-node convergence + `fuzz_packets.rs` (malformed datagram never panics) + `proptest_hrtree.rs` lossy convergence. |
+| **7 — Final facade + module move + docs** | Physically move files into `hrtree/ proto/ semantics/ net/ store/`; finalize `lib.rs` + optional `prelude`; update README/module docs to name the layers and extension points; materialize crate boundaries for the eventual workspace split. | tree move, `lib.rs`, README | low | everything compiles, full suite green, `cargo doc` builds. |
+
+**Ordering rationale.** Each phase depends only on its predecessors. Phase 1 delivers visible value
+immediately. The highest-risk encoding change (Phase 4) sits in the middle, where the test oracle is
+richest, not at the end where regressions are expensive to localize.
+
+---
+
+## 5. What must NOT change (correctness / compatibility load-bearing)
+
+1. **`Fingerprint` wire format and arithmetic** — the `[u64;4]` 256-bit abelian group (add/sub mod
+   2²⁵⁶, per-element BLAKE3), its `combine`/`remove`, and the golden vectors in `fingerprint.rs`.
+   The whole protocol's correctness rests on `combine` being a commutative group so range
+   fingerprints compose; the golden vectors pin the exact bytes. Relocate the file only.
+2. **HLC total order `(wall_ms, counter, node_id)`** (`hlc.rs:44-54`) — the derived `Ord` field
+   order *is* the conflict-resolution order. Generalizing to a `Timestamp` trait must preserve
+   `Hlc`'s exact `Ord`/`Hash`. Do not reorder fields; do not weaken `>` to `>=` in merge.
+3. **The size-not-hash emptiness/equality decision in `diff_round`** (issues #106/#111,
+   `diff.rs:135-141`) — decisions on `size`/`local_size`, never on `hash == ZERO`, because a
+   non-empty range can legitimately fingerprint to zero. Move verbatim.
+4. **Malformed-bound / inverted-range hardening in `diff_round`** (issue #112, `diff.rs:100-134`) —
+   dropping unsupported bound shapes and `checked_sub` instead of `unimplemented!()`/underflow. A
+   remote-DoS fix; preserve every branch. Pinned by `tests/diff.rs`.
+5. **Auth-before-deserialize ordering** (issue #108) — `Authenticator::open` runs on raw bytes
+   *before* any `Codec::decode`, and only accepted senders are recorded as peers/members. The
+   `Codec`/`Transport` split keeps the MAC gate outside and ahead of the codec, never folded in.
+6. **Causal-stability tombstone gate** — GC only after every `members` entry has acked the exact
+   `version_hash` held; `members` is monotonic (never auto-expired) precisely so a long-partitioned
+   peer cannot resurrect a deletion. `TombstoneTracker` must reproduce this exactly. Pinned by the
+   resurrection test in `tests/service.rs`.
+7. **`version_hash` determinism** (`reconcile_engine.rs:55`) — `DefaultHasher`'s fixed keys make the
+   token identical across nodes. Do **not** swap to a randomized/seeded hasher when `Entry` gains
+   its derived `Hash`.
+
+---
+
+## 6. Summary
+
+The refonte is not a rewrite. It is the introduction of five **named seams** —
+`RangeHashMap` (L1/L2), `Clock`/`Timestamp`/`Versioned` + `Merge` + `Entry` (L3), `Transport`/`Codec`
+(L4) — plus a `Key`/`Value` bound bundle to kill the verbosity, plus the decomposition of one
+god-object into single-responsibility components. The seven load-bearing invariants of §5 are held
+fixed throughout, and the existing test suite (`service`, `proptest_hrtree`, `diff`, `fuzz_packets`)
+is the oracle that keeps every one of the seven migration phases honest. The module tree is named so
+that the owner's ultimate target — a multi-crate workspace — becomes a mechanical move once the
+layers have proven stable.


### PR DESCRIPTION
## Summary

Adds **`ARCHITECTURE.md`**, a forward-looking architecture document organized around **hexagonal architecture (ports & adapters)**. Documentation only — **no source changes**, every claim carries a `file:line` proof.

The thesis is deliberately *not* "fewer traits" nor "more traits", but **the right traits in the right place**:

- The "usine à gaz" is **internal mechanism published as public API** — `Diffable`, `HashRangeQueryable`, `MaybeTombstone` are plumbing (not "screaming", not domain-revealing) yet exposed via `pub mod`. → hide / dissolve them.
- The real defect is the **absence of ports**: a grep-backed coupling map shows the domain mechanism (HRTree/fingerprint/diff) is *already* infra-free, while all of tokio/UDP/bincode/rand/ipnet is welded into one god-module (`reconcile_engine.rs`) and the HLC reads `chrono::Utc` directly. → introduce the ports the domain actually needs.

## What the document contains

- **Coupling map** (§2.1) and a **trait-by-trait classification** (§2.2): `port` vs `plumbing` vs `domain-type`. The crate already has exactly one well-formed port (`Persistence`) — it becomes the model.
- **Hexagonal target** (§3): domain core (infra-free) + outbound ports `Clock` / `Transport` / `Codec` / `Persistence` (with real Rust signatures) + adapters (`HlcClock`, `UdpTransport`, `BincodeCodec`, `FileSnapshot`/`InMemory`).
- **Domain types** `Entry`/`State` replacing the leaky `(Hlc, Option<V>)` tuple and dissolving the value-shape traits (§3.3); plumbing kept `pub(crate)` (§3.4); conflict resolution stays a domain policy, not an infra port (§3.5); `Key`/`Value` bound bundles to de-verbose (§3.6).
- **Workspace** justified as compiler-enforced dependency inversion (§3.7): `reconcile-core` cannot import tokio/bincode by construction.
- **~450 lines of iso-functional cleanups** (§4) as risk-free Phase 0.
- **Migration plan as one issue per phase** (§5): each phase is a self-contained block — goal, explicit dependency, files, `- [ ]` task list, acceptance criteria (definition of done), risk, suggested labels — ready to be copied verbatim into a GitHub issue.
- **Seven load-bearing invariants** (§6) that must not change (fingerprint arithmetic, HLC total order, diff hardening #106/#111/#112, auth-before-deserialize #108, causal-stability tombstone gate, `version_hash` determinism).

## Process

This PR is **docs only** and stays that way. After review + merge, we'll open **one issue per phase** (or a GitHub Project) — §5 is written to make that mechanical.

https://claude.ai/code/session_013wAEBvQ4ZCb5hEksqz9oTd