### PR TITLE
Step 1 (#140): Key/Value bound bundles + pub(crate) encapsulation

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -29,20 +29,25 @@ jobs:
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
     - name: Format
       run: cargo fmt --check
+    # `--features internal-testing` exposes the `reconcile::testing` seam so the external
+    # integration-test oracles (`tests/diff.rs`, `tests/proptest_hrtree.rs`) and the benchmark,
+    # which reach now-`pub(crate)` reconciliation internals, still compile and run. The
+    # `--all-features` steps already cover it; the default steps make it explicit so the oracle
+    # always runs.
     - name: Lint
-      run: cargo clippy --all
+      run: cargo clippy --all --features internal-testing
     - name: Lint (all features)
       run: cargo clippy --all --all-features
     - name: Build
       run: cargo build --all --verbose
     - name: Run tests
-      run: cargo test --all --verbose
+      run: cargo test --all --features internal-testing --verbose
     - name: Run tests (all features)
       run: cargo test --all --all-features --verbose
     - name: Run doc-tests
-      run: cargo test --doc --all --verbose
+      run: cargo test --doc --all --features internal-testing --verbose
     - name: Check that the benchmarks can still compile
-      run: cargo bench --no-run
+      run: cargo bench --no-run --features internal-testing
     - name: Generate the documentation
       run: cargo doc --all --verbose
     - name: Generate the documentation (all features)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,10 @@ metrics = ["dep:metrics"]
 # `src/prometheus.rs`). Pulls the exporter's HTTP listener stack; opt-in only. Implies
 # `metrics`, which feeds the same facade.
 metrics-prometheus = ["metrics", "dep:metrics-exporter-prometheus"]
+# Exposes the `crate::testing` seam (re-exports of `pub(crate)` reconciliation internals) so the
+# external integration-test oracles (`tests/diff.rs`, `tests/proptest_hrtree.rs`) can reach them.
+# No deps; not part of the supported public API.
+internal-testing = []
 
 [dependencies]
 arrayvec = "0.7.4"

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,427 +1,447 @@
-use std::collections::BTreeMap;
-use std::time::Duration;
+// The benchmark drives the internal range-fingerprint via `HashRangeQueryable::hash`, which lives
+// in the now-`pub(crate)` `diff` module. Like the integration-test oracles it reaches that internal
+// through the gated `reconcile::testing` seam, so the real bench body only compiles with the
+// `internal-testing` feature. Without it we fall back to an empty `main` so the target still links.
+#[cfg(not(feature = "internal-testing"))]
+fn main() {}
 
-use rand::{distributions::Standard, Rng, SeedableRng};
+#[cfg(feature = "internal-testing")]
+use imp::main;
 
-use criterion::{
-    criterion_group, criterion_main, AxisScale, BenchmarkId, Criterion, PlotConfiguration,
-    SamplingMode, Throughput,
-};
+#[cfg(feature = "internal-testing")]
+mod imp {
+    use std::collections::BTreeMap;
+    use std::time::Duration;
 
-use reconcile::diff::HashRangeQueryable;
-use reconcile::{reconcile_store::Config, HRTree, Hlc, ReconcileStore, ValueOnly};
+    use rand::{distributions::Standard, Rng, SeedableRng};
 
-fn hrtree_new(c: &mut Criterion) {
-    let mut group = c.benchmark_group("HRTree::new");
-    group.bench_function("BTreeMap::new()", |b| b.iter(BTreeMap::<u32, u32>::new));
-    group.bench_function("HRTree::new()", |b| b.iter(HRTree::<u32, u32>::new));
-}
+    use criterion::{
+        criterion_group, AxisScale, BenchmarkId, Criterion, PlotConfiguration, SamplingMode,
+        Throughput,
+    };
 
-/// Measure the time to insert N elements in the tree
-fn hrtree_fill(c: &mut Criterion) {
-    let mut rng = rand::rngs::StdRng::seed_from_u64(42);
+    use reconcile::testing::HashRangeQueryable;
+    use reconcile::{reconcile_store::Config, HRTree, Hlc, ReconcileStore, ValueOnly};
 
-    let mut key_values = Vec::new();
-    for _ in 0..1_000_000 {
-        let key: u32 = rng.gen();
-        let value: u32 = rng.gen();
-        key_values.push((key, value));
+    fn hrtree_new(c: &mut Criterion) {
+        let mut group = c.benchmark_group("HRTree::new");
+        group.bench_function("BTreeMap::new()", |b| b.iter(BTreeMap::<u32, u32>::new));
+        group.bench_function("HRTree::new()", |b| b.iter(HRTree::<u32, u32>::new));
     }
-    let key_values = &key_values;
 
-    let plot_config = PlotConfiguration::default().summary_scale(AxisScale::Logarithmic);
-    let mut group = c.benchmark_group("HRTree::fill");
-    group.plot_config(plot_config);
-    let mut size = 10;
-    while size <= key_values.len() {
-        group.throughput(Throughput::Elements(size as u64));
-        group.sample_size(10.max(1_000_000 / size).min(100));
-        group.sampling_mode(SamplingMode::Linear);
-        group.bench_with_input(
-            BenchmarkId::new("BTreeMap::fill", size),
-            &size,
-            |b, &size| {
+    /// Measure the time to insert N elements in the tree
+    fn hrtree_fill(c: &mut Criterion) {
+        let mut rng = rand::rngs::StdRng::seed_from_u64(42);
+
+        let mut key_values = Vec::new();
+        for _ in 0..1_000_000 {
+            let key: u32 = rng.gen();
+            let value: u32 = rng.gen();
+            key_values.push((key, value));
+        }
+        let key_values = &key_values;
+
+        let plot_config = PlotConfiguration::default().summary_scale(AxisScale::Logarithmic);
+        let mut group = c.benchmark_group("HRTree::fill");
+        group.plot_config(plot_config);
+        let mut size = 10;
+        while size <= key_values.len() {
+            group.throughput(Throughput::Elements(size as u64));
+            group.sample_size(10.max(1_000_000 / size).min(100));
+            group.sampling_mode(SamplingMode::Linear);
+            group.bench_with_input(
+                BenchmarkId::new("BTreeMap::fill", size),
+                &size,
+                |b, &size| {
+                    b.iter(|| {
+                        let mut tree = BTreeMap::<u32, u32>::new();
+                        for (k, v) in key_values[..size].iter().copied() {
+                            tree.insert(k, v);
+                        }
+                    })
+                },
+            );
+            group.bench_with_input(BenchmarkId::new("HRTree::fill", size), &size, |b, &size| {
                 b.iter(|| {
-                    let mut tree = BTreeMap::<u32, u32>::new();
+                    let mut tree = HRTree::<u32, u32>::new();
                     for (k, v) in key_values[..size].iter().copied() {
                         tree.insert(k, v);
                     }
                 })
-            },
-        );
-        group.bench_with_input(BenchmarkId::new("HRTree::fill", size), &size, |b, &size| {
-            b.iter(|| {
+            });
+            size *= 10;
+        }
+    }
+
+    /// Measure the time to insert (and remove) 1 element in a tree of size N
+    fn hrtree_insert(c: &mut Criterion) {
+        let mut rng = rand::rngs::StdRng::seed_from_u64(42);
+
+        let mut key_values = Vec::new();
+        for _ in 0..1_000_000 {
+            let key: u32 = rng.gen();
+            let value: u32 = rng.gen();
+            key_values.push((key, value));
+        }
+        let key_values = &key_values;
+
+        let plot_config = PlotConfiguration::default().summary_scale(AxisScale::Logarithmic);
+        let mut group = c.benchmark_group("HRTree::insert");
+        group.plot_config(plot_config);
+        let mut size = 10;
+        while size <= key_values.len() {
+            group.throughput(Throughput::Elements(size as u64));
+            group.sample_size(10.max(1_000_000 / size).min(100));
+            group.sampling_mode(SamplingMode::Linear);
+            group.bench_with_input(
+                BenchmarkId::new("BTreeMap::insert", size),
+                &size,
+                |b, &size| {
+                    let mut tree = BTreeMap::<u32, u32>::new();
+                    for (k, v) in key_values[..size].iter().copied() {
+                        tree.insert(k, v);
+                    }
+                    b.iter(|| {
+                        // NOTE: do the insertion first because inserting a just-removed element is
+                        // likely easier; do not reuse the same key, since it was just removed during
+                        // the last iteration
+                        let k = rng.gen();
+                        let v = rng.gen();
+                        tree.insert(k, v);
+                        tree.remove(&k);
+                    })
+                },
+            );
+            group.bench_with_input(
+                BenchmarkId::new("HRTree::insert", size),
+                &size,
+                |b, &size| {
+                    let mut tree = HRTree::<u32, u32>::new();
+                    for (k, v) in key_values[..size].iter().copied() {
+                        tree.insert(k, v);
+                    }
+                    b.iter(|| {
+                        // NOTE: do the insertion first because inserting a just-removed element is
+                        // likely easier; do not reuse the same key, since it was just removed during
+                        // the last iteration
+                        let k = rng.gen();
+                        let v = rng.gen();
+                        tree.insert(k, v);
+                        tree.remove(&k);
+                    })
+                },
+            );
+            size *= 10;
+        }
+    }
+
+    /// Measure the time to remove (and restore) 1 element in a tree of size N
+    fn hrtree_remove(c: &mut Criterion) {
+        let mut rng = rand::rngs::StdRng::seed_from_u64(42);
+
+        let mut key_values = Vec::new();
+        for _ in 0..1_000_000 {
+            let key: u32 = rng.gen();
+            let value: u32 = rng.gen();
+            key_values.push((key, value));
+        }
+        let key_values = &key_values;
+
+        let plot_config = PlotConfiguration::default().summary_scale(AxisScale::Logarithmic);
+        let mut group = c.benchmark_group("HRTree::remove");
+        group.plot_config(plot_config);
+        let mut size = 10;
+        while size <= key_values.len() {
+            group.throughput(Throughput::Elements(size as u64));
+            group.sample_size(10.max(1_000_000 / size).min(100));
+            group.sampling_mode(SamplingMode::Linear);
+            group.bench_with_input(
+                BenchmarkId::new("BTreeMap::remove", size),
+                &size,
+                |b, &size| {
+                    let mut tree = BTreeMap::<u32, u32>::new();
+                    for (k, v) in key_values[..size].iter().copied() {
+                        tree.insert(k, v);
+                    }
+                    b.iter(|| {
+                        // NOTE: do the removal first because removing a just-inserted element is
+                        // likely easier; do not reuse the same key, since it was just reinserted
+                        // during the last iteration
+                        let idx = rng.gen_range(0..size);
+                        let (k, v) = &key_values[idx];
+                        tree.remove(k);
+                        tree.insert(*k, *v);
+                    })
+                },
+            );
+            group.bench_with_input(
+                BenchmarkId::new("HRTree::remove", size),
+                &size,
+                |b, &size| {
+                    let mut tree = HRTree::<u32, u32>::new();
+                    for (k, v) in key_values[..size].iter().copied() {
+                        tree.insert(k, v);
+                    }
+                    b.iter(|| {
+                        // NOTE: do the removal first because removing a just-inserted element is
+                        // likely easier; do not reuse the same key, since it was just reinserted
+                        // during the last iteration
+                        let idx = rng.gen_range(0..size);
+                        let (k, v) = &key_values[idx];
+                        tree.remove(k);
+                        tree.insert(*k, *v);
+                    })
+                },
+            );
+            size *= 10;
+        }
+    }
+
+    /// Measure the time to compute the hash over a range in a HRTree of size N
+    fn hrtree_hash(c: &mut Criterion) {
+        let mut rng = rand::rngs::StdRng::seed_from_u64(42);
+
+        let mut key_values = Vec::new();
+        for _ in 0..1_000_000 {
+            let key: u32 = rng.gen();
+            let value: u32 = rng.gen();
+            key_values.push((key, value));
+        }
+        let key_values = &key_values;
+
+        let plot_config = PlotConfiguration::default().summary_scale(AxisScale::Logarithmic);
+        let mut group = c.benchmark_group("HRTree::hash");
+        group.plot_config(plot_config);
+        let mut size = 10;
+        while size <= key_values.len() {
+            group.sample_size(10.max(1_000_000 / size).min(100));
+            group.sampling_mode(SamplingMode::Linear);
+            group.bench_with_input(BenchmarkId::from_parameter(size), &size, |b, &size| {
                 let mut tree = HRTree::<u32, u32>::new();
                 for (k, v) in key_values[..size].iter().copied() {
                     tree.insert(k, v);
                 }
-            })
-        });
-        size *= 10;
-    }
-}
-
-/// Measure the time to insert (and remove) 1 element in a tree of size N
-fn hrtree_insert(c: &mut Criterion) {
-    let mut rng = rand::rngs::StdRng::seed_from_u64(42);
-
-    let mut key_values = Vec::new();
-    for _ in 0..1_000_000 {
-        let key: u32 = rng.gen();
-        let value: u32 = rng.gen();
-        key_values.push((key, value));
-    }
-    let key_values = &key_values;
-
-    let plot_config = PlotConfiguration::default().summary_scale(AxisScale::Logarithmic);
-    let mut group = c.benchmark_group("HRTree::insert");
-    group.plot_config(plot_config);
-    let mut size = 10;
-    while size <= key_values.len() {
-        group.throughput(Throughput::Elements(size as u64));
-        group.sample_size(10.max(1_000_000 / size).min(100));
-        group.sampling_mode(SamplingMode::Linear);
-        group.bench_with_input(
-            BenchmarkId::new("BTreeMap::insert", size),
-            &size,
-            |b, &size| {
-                let mut tree = BTreeMap::<u32, u32>::new();
-                for (k, v) in key_values[..size].iter().copied() {
-                    tree.insert(k, v);
-                }
                 b.iter(|| {
-                    // NOTE: do the insertion first because inserting a just-removed element is
-                    // likely easier; do not reuse the same key, since it was just removed during
-                    // the last iteration
-                    let k = rng.gen();
-                    let v = rng.gen();
-                    tree.insert(k, v);
-                    tree.remove(&k);
+                    let k1: u32 = rng.gen();
+                    let k2: u32 = rng.gen();
+                    let range = if k1 < k2 { k1..k2 } else { k2..k1 };
+                    tree.hash(&range);
                 })
-            },
-        );
-        group.bench_with_input(
-            BenchmarkId::new("HRTree::insert", size),
-            &size,
-            |b, &size| {
-                let mut tree = HRTree::<u32, u32>::new();
-                for (k, v) in key_values[..size].iter().copied() {
-                    tree.insert(k, v);
-                }
-                b.iter(|| {
-                    // NOTE: do the insertion first because inserting a just-removed element is
-                    // likely easier; do not reuse the same key, since it was just removed during
-                    // the last iteration
-                    let k = rng.gen();
-                    let v = rng.gen();
-                    tree.insert(k, v);
-                    tree.remove(&k);
-                })
-            },
-        );
-        size *= 10;
+            });
+            size *= 10;
+        }
     }
-}
 
-/// Measure the time to remove (and restore) 1 element in a tree of size N
-fn hrtree_remove(c: &mut Criterion) {
-    let mut rng = rand::rngs::StdRng::seed_from_u64(42);
-
-    let mut key_values = Vec::new();
-    for _ in 0..1_000_000 {
-        let key: u32 = rng.gen();
-        let value: u32 = rng.gen();
-        key_values.push((key, value));
-    }
-    let key_values = &key_values;
-
-    let plot_config = PlotConfiguration::default().summary_scale(AxisScale::Logarithmic);
-    let mut group = c.benchmark_group("HRTree::remove");
-    group.plot_config(plot_config);
-    let mut size = 10;
-    while size <= key_values.len() {
-        group.throughput(Throughput::Elements(size as u64));
-        group.sample_size(10.max(1_000_000 / size).min(100));
-        group.sampling_mode(SamplingMode::Linear);
-        group.bench_with_input(
-            BenchmarkId::new("BTreeMap::remove", size),
-            &size,
-            |b, &size| {
-                let mut tree = BTreeMap::<u32, u32>::new();
-                for (k, v) in key_values[..size].iter().copied() {
-                    tree.insert(k, v);
-                }
-                b.iter(|| {
-                    // NOTE: do the removal first because removing a just-inserted element is
-                    // likely easier; do not reuse the same key, since it was just reinserted
-                    // during the last iteration
-                    let idx = rng.gen_range(0..size);
-                    let (k, v) = &key_values[idx];
-                    tree.remove(k);
-                    tree.insert(*k, *v);
-                })
-            },
-        );
-        group.bench_with_input(
-            BenchmarkId::new("HRTree::remove", size),
-            &size,
-            |b, &size| {
-                let mut tree = HRTree::<u32, u32>::new();
-                for (k, v) in key_values[..size].iter().copied() {
-                    tree.insert(k, v);
-                }
-                b.iter(|| {
-                    // NOTE: do the removal first because removing a just-inserted element is
-                    // likely easier; do not reuse the same key, since it was just reinserted
-                    // during the last iteration
-                    let idx = rng.gen_range(0..size);
-                    let (k, v) = &key_values[idx];
-                    tree.remove(k);
-                    tree.insert(*k, *v);
-                })
-            },
-        );
-        size *= 10;
-    }
-}
-
-/// Measure the time to compute the hash over a range in a HRTree of size N
-fn hrtree_hash(c: &mut Criterion) {
-    let mut rng = rand::rngs::StdRng::seed_from_u64(42);
-
-    let mut key_values = Vec::new();
-    for _ in 0..1_000_000 {
-        let key: u32 = rng.gen();
-        let value: u32 = rng.gen();
-        key_values.push((key, value));
-    }
-    let key_values = &key_values;
-
-    let plot_config = PlotConfiguration::default().summary_scale(AxisScale::Logarithmic);
-    let mut group = c.benchmark_group("HRTree::hash");
-    group.plot_config(plot_config);
-    let mut size = 10;
-    while size <= key_values.len() {
-        group.sample_size(10.max(1_000_000 / size).min(100));
-        group.sampling_mode(SamplingMode::Linear);
-        group.bench_with_input(BenchmarkId::from_parameter(size), &size, |b, &size| {
-            let mut tree = HRTree::<u32, u32>::new();
-            for (k, v) in key_values[..size].iter().copied() {
-                tree.insert(k, v);
-            }
-            b.iter(|| {
-                let k1: u32 = rng.gen();
-                let k2: u32 = rng.gen();
-                let range = if k1 < k2 { k1..k2 } else { k2..k1 };
-                tree.hash(&range);
-            })
-        });
-        size *= 10;
-    }
-}
-
-/// Compare the in-memory cost of a **naive dated mirror** (`HRTree<K, (Hlc, Option<V>)>`, which
-/// drags along a timestamp it never uses) against the **lightweight value-only mirror**
-/// (`HRTree<K, ValueOnly<V>>`) that issue #128 introduces.
-///
-/// Criterion times the *fill* of each tree at growing sizes; the value-only tree both builds faster
-/// (less to move/hash per entry) and, as the one-off report below shows, stores fewer bytes per
-/// entry — the whole point of the optimization for fleets with many passive read replicas.
-fn mirror_memory(c: &mut Criterion) {
-    let dated = std::mem::size_of::<(Hlc, Option<u32>)>();
-    let light = std::mem::size_of::<ValueOnly<u32>>();
-    println!(
-        "[mirror memory] per-entry value size: dated (Hlc, Option<u32>) = {dated} B, \
+    /// Compare the in-memory cost of a **naive dated mirror** (`HRTree<K, (Hlc, Option<V>)>`, which
+    /// drags along a timestamp it never uses) against the **lightweight value-only mirror**
+    /// (`HRTree<K, ValueOnly<V>>`) that issue #128 introduces.
+    ///
+    /// Criterion times the *fill* of each tree at growing sizes; the value-only tree both builds faster
+    /// (less to move/hash per entry) and, as the one-off report below shows, stores fewer bytes per
+    /// entry — the whole point of the optimization for fleets with many passive read replicas.
+    fn mirror_memory(c: &mut Criterion) {
+        let dated = std::mem::size_of::<(Hlc, Option<u32>)>();
+        let light = std::mem::size_of::<ValueOnly<u32>>();
+        println!(
+            "[mirror memory] per-entry value size: dated (Hlc, Option<u32>) = {dated} B, \
          value-only ValueOnly<u32> = {light} B, saved = {} B/entry",
-        dated - light
+            dated - light
+        );
+
+        let mut rng = rand::rngs::StdRng::seed_from_u64(42);
+        let mut keys = Vec::new();
+        for _ in 0..1_000_000 {
+            keys.push(rng.gen::<u32>());
+        }
+        let keys = &keys;
+
+        let plot_config = PlotConfiguration::default().summary_scale(AxisScale::Logarithmic);
+        let mut group = c.benchmark_group("mirror_memory::fill");
+        group.plot_config(plot_config);
+        let mut size = 10;
+        while size <= keys.len() {
+            group.throughput(Throughput::Elements(size as u64));
+            group.sample_size(10.max(1_000_000 / size).min(100));
+            group.sampling_mode(SamplingMode::Linear);
+            group.bench_with_input(
+                BenchmarkId::new("dated (Hlc, Option<u32>)", size),
+                &size,
+                |b, &size| {
+                    b.iter(|| {
+                        let mut tree = HRTree::<u32, (Hlc, Option<u32>)>::new();
+                        for &k in keys[..size].iter() {
+                            tree.insert(k, (Hlc::new(k as u64, 0, 0), Some(k)));
+                        }
+                    })
+                },
+            );
+            group.bench_with_input(
+                BenchmarkId::new("value-only ValueOnly<u32>", size),
+                &size,
+                |b, &size| {
+                    b.iter(|| {
+                        let mut tree = HRTree::<u32, ValueOnly<u32>>::new();
+                        for &k in keys[..size].iter() {
+                            tree.insert(k, ValueOnly(Some(k)));
+                        }
+                    })
+                },
+            );
+            size *= 10;
+        }
+    }
+
+    /// Measure the time to send 1 insertion, and 1 removal between 2 ReconcileStore instances containing N items
+    fn service_send(c: &mut Criterion) {
+        let port = 8080;
+        let peer_net = "127.0.0.1/8".parse().unwrap();
+        let addr1 = "127.0.0.44".parse().unwrap();
+        let addr2 = "127.0.0.45".parse().unwrap();
+        let cfg1 = Config {
+            port,
+            listen_addr: addr1,
+            peer_net,
+            cluster_key: None,
+            node_id: None,
+            encrypt: false,
+        };
+        let cfg2 = Config {
+            port,
+            listen_addr: addr2,
+            peer_net,
+            cluster_key: None,
+            node_id: None,
+            encrypt: false,
+        };
+
+        let mut rng = rand::rngs::ThreadRng::default();
+
+        let key_values: Vec<(u32, u32)> =
+            (&mut rng).sample_iter(Standard).take(1_000_000).collect();
+
+        let rt = tokio::runtime::Runtime::new().unwrap();
+
+        let plot_config = PlotConfiguration::default().summary_scale(AxisScale::Logarithmic);
+        let mut group = c.benchmark_group("ReconcileStore::send");
+        group.plot_config(plot_config);
+        let mut size = 10;
+        while size <= key_values.len() {
+            group.sample_size(10.max(1_000_000 / size).min(100));
+            group.sampling_mode(SamplingMode::Linear);
+            group.bench_with_input(BenchmarkId::from_parameter(size), &size, |b, &size| {
+                rt.block_on(async {
+                    // start reconciliation stores
+                    let store1 = ReconcileStore::new(cfg1).await.with_seed(addr2);
+                    store1.insert_bulk(&key_values[..size]);
+                    let store2 = ReconcileStore::new(cfg2).await.with_seed(addr1);
+                    store2.insert_bulk(&key_values[..size]);
+                    let task1 = tokio::spawn(store1.clone().run());
+                    let task2 = tokio::spawn(store2.clone().run());
+
+                    b.iter(|| {
+                        let k: u32 = rng.gen();
+                        let v: u32 = rng.gen();
+                        store1.insert(k, v);
+                        while store2.get(&k).is_none() {
+                            std::thread::sleep(Duration::from_micros(1));
+                        }
+                        store1.remove(&k);
+                        while store2.get(&k).is_some() {
+                            std::thread::sleep(Duration::from_micros(1));
+                        }
+                    });
+
+                    task2.abort();
+                    task1.abort();
+                    let _ = tokio::join!(task1, task2);
+                })
+            });
+            size *= 10;
+        }
+    }
+
+    /// Measure the time to reconcile 1 insertion/removal between ReconcileStore instances containing N items
+    fn service_reconcile(c: &mut Criterion) {
+        let port = 8080;
+        let peer_net = "127.0.0.1/8".parse().unwrap();
+        let addr1 = "127.0.0.44".parse().unwrap();
+        let addr2 = "127.0.0.45".parse().unwrap();
+        let cfg1 = Config::default()
+            .with_port(port)
+            .with_listen_addr(addr1)
+            .with_peer_net(peer_net);
+        let cfg2 = Config::default()
+            .with_port(port)
+            .with_listen_addr(addr2)
+            .with_peer_net(peer_net);
+
+        let mut rng = rand::rngs::ThreadRng::default();
+
+        let key_values: Vec<(u32, u32)> =
+            (&mut rng).sample_iter(Standard).take(1_000_000).collect();
+
+        let rt = tokio::runtime::Runtime::new().unwrap();
+
+        let plot_config = PlotConfiguration::default().summary_scale(AxisScale::Logarithmic);
+        let mut group = c.benchmark_group("ReconcileStore::reconcile");
+        group.plot_config(plot_config);
+        let mut size = 10;
+        while size <= key_values.len() {
+            group.sample_size(10.max(1_000_000 / size).min(100));
+            group.sampling_mode(SamplingMode::Linear);
+            group.bench_with_input(BenchmarkId::from_parameter(size), &size, |b, &size| {
+                rt.block_on(async {
+                    // start reconciliation services
+                    let store1 = ReconcileStore::new(cfg1).await.with_seed(addr2);
+                    store1.insert_bulk(&key_values[..size]);
+                    let store2 = ReconcileStore::new(cfg2).await.with_seed(addr1);
+                    store2.insert_bulk(&key_values[..size]);
+                    let task1 = tokio::spawn(store1.clone().run());
+                    let task2 = tokio::spawn(store2.clone().run());
+
+                    b.iter(|| {
+                        let k: u32 = rng.gen();
+                        let v: u32 = rng.gen();
+                        store1.just_insert(k, v);
+                        let clone = store1.clone();
+                        let task = tokio::spawn(async move { clone.start_reconciliation().await });
+                        while store2.get(&k).is_none() {
+                            std::thread::sleep(Duration::from_micros(1));
+                        }
+                        store1.just_remove(&k);
+                        task.abort();
+                        let clone = store1.clone();
+                        let task = tokio::spawn(async move { clone.start_reconciliation().await });
+                        while store2.get(&k).is_some() {
+                            std::thread::sleep(Duration::from_micros(1));
+                        }
+                        task.abort();
+                    });
+
+                    task2.abort();
+                    task1.abort();
+                    let _ = tokio::join!(task1, task2);
+                })
+            });
+            size *= 10;
+        }
+    }
+
+    criterion_group!(
+        benches,
+        hrtree_new,
+        hrtree_fill,
+        hrtree_insert,
+        hrtree_remove,
+        hrtree_hash,
+        mirror_memory,
+        service_send,
+        service_reconcile,
     );
-
-    let mut rng = rand::rngs::StdRng::seed_from_u64(42);
-    let mut keys = Vec::new();
-    for _ in 0..1_000_000 {
-        keys.push(rng.gen::<u32>());
+    // Equivalent to `criterion_main!(benches)`, but exposed as a named fn so the top-level `main`
+    // (defined outside this feature-gated module) can drive it.
+    pub fn main() {
+        benches();
+        Criterion::default().configure_from_args().final_summary();
     }
-    let keys = &keys;
-
-    let plot_config = PlotConfiguration::default().summary_scale(AxisScale::Logarithmic);
-    let mut group = c.benchmark_group("mirror_memory::fill");
-    group.plot_config(plot_config);
-    let mut size = 10;
-    while size <= keys.len() {
-        group.throughput(Throughput::Elements(size as u64));
-        group.sample_size(10.max(1_000_000 / size).min(100));
-        group.sampling_mode(SamplingMode::Linear);
-        group.bench_with_input(
-            BenchmarkId::new("dated (Hlc, Option<u32>)", size),
-            &size,
-            |b, &size| {
-                b.iter(|| {
-                    let mut tree = HRTree::<u32, (Hlc, Option<u32>)>::new();
-                    for &k in keys[..size].iter() {
-                        tree.insert(k, (Hlc::new(k as u64, 0, 0), Some(k)));
-                    }
-                })
-            },
-        );
-        group.bench_with_input(
-            BenchmarkId::new("value-only ValueOnly<u32>", size),
-            &size,
-            |b, &size| {
-                b.iter(|| {
-                    let mut tree = HRTree::<u32, ValueOnly<u32>>::new();
-                    for &k in keys[..size].iter() {
-                        tree.insert(k, ValueOnly(Some(k)));
-                    }
-                })
-            },
-        );
-        size *= 10;
-    }
-}
-
-/// Measure the time to send 1 insertion, and 1 removal between 2 ReconcileStore instances containing N items
-fn service_send(c: &mut Criterion) {
-    let port = 8080;
-    let peer_net = "127.0.0.1/8".parse().unwrap();
-    let addr1 = "127.0.0.44".parse().unwrap();
-    let addr2 = "127.0.0.45".parse().unwrap();
-    let cfg1 = Config {
-        port,
-        listen_addr: addr1,
-        peer_net,
-        cluster_key: None,
-        node_id: None,
-        encrypt: false,
-    };
-    let cfg2 = Config {
-        port,
-        listen_addr: addr2,
-        peer_net,
-        cluster_key: None,
-        node_id: None,
-        encrypt: false,
-    };
-
-    let mut rng = rand::rngs::ThreadRng::default();
-
-    let key_values: Vec<(u32, u32)> = (&mut rng).sample_iter(Standard).take(1_000_000).collect();
-
-    let rt = tokio::runtime::Runtime::new().unwrap();
-
-    let plot_config = PlotConfiguration::default().summary_scale(AxisScale::Logarithmic);
-    let mut group = c.benchmark_group("ReconcileStore::send");
-    group.plot_config(plot_config);
-    let mut size = 10;
-    while size <= key_values.len() {
-        group.sample_size(10.max(1_000_000 / size).min(100));
-        group.sampling_mode(SamplingMode::Linear);
-        group.bench_with_input(BenchmarkId::from_parameter(size), &size, |b, &size| {
-            rt.block_on(async {
-                // start reconciliation stores
-                let store1 = ReconcileStore::new(cfg1).await.with_seed(addr2);
-                store1.insert_bulk(&key_values[..size]);
-                let store2 = ReconcileStore::new(cfg2).await.with_seed(addr1);
-                store2.insert_bulk(&key_values[..size]);
-                let task1 = tokio::spawn(store1.clone().run());
-                let task2 = tokio::spawn(store2.clone().run());
-
-                b.iter(|| {
-                    let k: u32 = rng.gen();
-                    let v: u32 = rng.gen();
-                    store1.insert(k, v);
-                    while store2.get(&k).is_none() {
-                        std::thread::sleep(Duration::from_micros(1));
-                    }
-                    store1.remove(&k);
-                    while store2.get(&k).is_some() {
-                        std::thread::sleep(Duration::from_micros(1));
-                    }
-                });
-
-                task2.abort();
-                task1.abort();
-                let _ = tokio::join!(task1, task2);
-            })
-        });
-        size *= 10;
-    }
-}
-
-/// Measure the time to reconcile 1 insertion/removal between ReconcileStore instances containing N items
-fn service_reconcile(c: &mut Criterion) {
-    let port = 8080;
-    let peer_net = "127.0.0.1/8".parse().unwrap();
-    let addr1 = "127.0.0.44".parse().unwrap();
-    let addr2 = "127.0.0.45".parse().unwrap();
-    let cfg1 = Config::default()
-        .with_port(port)
-        .with_listen_addr(addr1)
-        .with_peer_net(peer_net);
-    let cfg2 = Config::default()
-        .with_port(port)
-        .with_listen_addr(addr2)
-        .with_peer_net(peer_net);
-
-    let mut rng = rand::rngs::ThreadRng::default();
-
-    let key_values: Vec<(u32, u32)> = (&mut rng).sample_iter(Standard).take(1_000_000).collect();
-
-    let rt = tokio::runtime::Runtime::new().unwrap();
-
-    let plot_config = PlotConfiguration::default().summary_scale(AxisScale::Logarithmic);
-    let mut group = c.benchmark_group("ReconcileStore::reconcile");
-    group.plot_config(plot_config);
-    let mut size = 10;
-    while size <= key_values.len() {
-        group.sample_size(10.max(1_000_000 / size).min(100));
-        group.sampling_mode(SamplingMode::Linear);
-        group.bench_with_input(BenchmarkId::from_parameter(size), &size, |b, &size| {
-            rt.block_on(async {
-                // start reconciliation services
-                let store1 = ReconcileStore::new(cfg1).await.with_seed(addr2);
-                store1.insert_bulk(&key_values[..size]);
-                let store2 = ReconcileStore::new(cfg2).await.with_seed(addr1);
-                store2.insert_bulk(&key_values[..size]);
-                let task1 = tokio::spawn(store1.clone().run());
-                let task2 = tokio::spawn(store2.clone().run());
-
-                b.iter(|| {
-                    let k: u32 = rng.gen();
-                    let v: u32 = rng.gen();
-                    store1.just_insert(k, v);
-                    let clone = store1.clone();
-                    let task = tokio::spawn(async move { clone.start_reconciliation().await });
-                    while store2.get(&k).is_none() {
-                        std::thread::sleep(Duration::from_micros(1));
-                    }
-                    store1.just_remove(&k);
-                    task.abort();
-                    let clone = store1.clone();
-                    let task = tokio::spawn(async move { clone.start_reconciliation().await });
-                    while store2.get(&k).is_some() {
-                        std::thread::sleep(Duration::from_micros(1));
-                    }
-                    task.abort();
-                });
-
-                task2.abort();
-                task1.abort();
-                let _ = tokio::join!(task1, task2);
-            })
-        });
-        size *= 10;
-    }
-}
-
-criterion_group!(
-    benches,
-    hrtree_new,
-    hrtree_fill,
-    hrtree_insert,
-    hrtree_remove,
-    hrtree_hash,
-    mirror_memory,
-    service_send,
-    service_reconcile,
-);
-criterion_main!(benches);
+} // mod imp

--- a/src/bounds.rs
+++ b/src/bounds.rs
@@ -1,0 +1,56 @@
+// Copyright 2023 Developers of the reconcile project.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Generic-bound bundles (see ARCHITECTURE.md §3.8).
+//!
+//! The reconciliation machinery repeats the same multi-bound constraints on every key and value
+//! type parameter. [`Key`] and [`Value`] bundle those *data* bounds (Clone/Debug/Hash/…/`'static`)
+//! once, with blanket impls, so implementation sites can read `impl<K: Key, V: Value>` instead of
+//! spelling the full list out each time.
+//!
+//! These bundles cover only the data bounds; *entry-semantics* bounds (such as
+//! [`Projectable`](crate::reconcilable::Projectable)) are not bundled here and travel as extra
+//! bounds alongside `V: Value` where required.
+
+use std::fmt::Debug;
+use std::hash::Hash;
+
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+
+/// Bundle of the data bounds required of a key type throughout the reconciliation machinery.
+///
+/// A blanket impl makes any type that satisfies the listed bounds a `Key` automatically, so this
+/// never has to be implemented by hand. It does not add or remove any concrete bound; it is purely
+/// a shorthand for the repeated `Clone + Debug + Hash + Ord + Send + Sync + Serialize +
+/// DeserializeOwned + 'static` list.
+pub trait Key:
+    Clone + Debug + Hash + Ord + Send + Sync + Serialize + DeserializeOwned + 'static
+{
+}
+
+impl<T> Key for T where
+    T: Clone + Debug + Hash + Ord + Send + Sync + Serialize + DeserializeOwned + 'static
+{
+}
+
+/// Bundle of the data bounds required of a value type throughout the reconciliation machinery.
+///
+/// A blanket impl makes any type that satisfies the listed bounds a `Value` automatically, so this
+/// never has to be implemented by hand. It does not add or remove any concrete bound; it is purely
+/// a shorthand for the repeated `Clone + Debug + Hash + PartialEq + Send + Sync + Serialize +
+/// DeserializeOwned + 'static` list. Note it requires `PartialEq` (not `Ord`), unlike [`Key`].
+pub trait Value:
+    Clone + Debug + Hash + PartialEq + Send + Sync + Serialize + DeserializeOwned + 'static
+{
+}
+
+impl<T> Value for T where
+    T: Clone + Debug + Hash + PartialEq + Send + Sync + Serialize + DeserializeOwned + 'static
+{
+}

--- a/src/gen_ip.rs
+++ b/src/gen_ip.rs
@@ -14,7 +14,10 @@ use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use rand::Rng;
 
 /// Select a random IP address from the given network
-/// ```
+///
+/// `gen_ip` is a crate-internal helper (`pub(crate)`), so this example is illustrative only and is
+/// not compiled as a doctest (it cannot name the private path from an external crate).
+/// ```ignore
 /// # use rand::SeedableRng;
 /// # use reconcile::gen_ip::gen_ip;
 /// #
@@ -30,7 +33,9 @@ pub fn gen_ip<R: Rng>(rng: &mut R, network: IpNet) -> IpAddr {
 }
 
 /// Select a random IPv4 address from the given network
-/// ```
+///
+/// Crate-internal helper; example illustrative only (not compiled as a doctest).
+/// ```ignore
 /// # use rand::SeedableRng;
 /// # use reconcile::gen_ip::gen_ipv4;
 /// #
@@ -44,7 +49,9 @@ pub fn gen_ipv4<R: Rng>(rng: &mut R, network: Ipv4Net) -> Ipv4Addr {
 }
 
 /// Select a random IPv6 address from the given network
-/// ```
+///
+/// Crate-internal helper; example illustrative only (not compiled as a doctest).
+/// ```ignore
 /// # use rand::SeedableRng;
 /// # use reconcile::gen_ip::gen_ipv6;
 /// #

--- a/src/hrtree.rs
+++ b/src/hrtree.rs
@@ -22,8 +22,8 @@
 //! published on Arxiv in February 2023:
 //! [Range-Based Set Reconciliation](https://arxiv.org/abs/2212.13567), by Aljoscha Meyer
 //!
-//! [`HRTree`] implements the [`Diffable`](crate::diff::Diffable)
-//! and [`HashRangeQueryable`] traits.
+//! [`HRTree`] implements the crate-internal `Diffable` and `HashRangeQueryable`
+//! traits (see the `diff` module) that drive range reconciliation.
 
 use std::cmp::Ordering;
 use std::hash::Hash;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,12 +27,10 @@
 //! unauthenticated or forged datagrams. See the README "Security model" section for the full
 //! threat model and scope.
 
-pub mod diff;
+pub mod bounds;
 pub mod fingerprint;
-pub mod gen_ip;
 pub mod hlc;
 pub mod hrtree;
-pub mod hrtree_iter;
 pub mod mirror;
 pub mod persistence;
 pub mod reconcilable;
@@ -43,14 +41,41 @@ pub mod reconcile_store;
 pub mod prometheus;
 
 pub(crate) mod auth;
+// Internal reconciliation mechanism. Demoted to `pub(crate)` (ARCHITECTURE.md §3.7): these are
+// implementation details, not part of the supported public surface. The few internals the
+// integration-test oracles need are re-exported through the gated [`testing`] module below.
+pub(crate) mod diff;
+pub(crate) mod gen_ip;
+pub(crate) mod hrtree_iter;
 pub(crate) mod observability;
 pub(crate) mod reconcile_engine;
 pub(crate) mod timeout_wheel;
 
+pub use bounds::{Key, Value};
 pub use fingerprint::Fingerprint;
 pub use hlc::Hlc;
 pub use hrtree::HRTree;
+// The `hrtree_iter` module is `pub(crate)`, but these iterator types appear in public `HRTree`
+// method return types, so they must stay publicly reachable. A `pub` type re-exported from a
+// `pub(crate)` module is publicly reachable, which avoids private-in-public errors (E0446).
+pub use hrtree_iter::{IntoIter, IntoKeys, IntoValues, Iter, IterMut, Keys, Values, ValuesMut};
 pub use mirror::ReconcileMirror;
 pub use persistence::{FileSnapshot, InMemoryPersistence, PersistedState, Persistence};
 pub use reconcilable::{Projectable, ValueOnly};
 pub use reconcile_store::ReconcileStore;
+
+/// Internal seam for the external integration-test oracles (`tests/diff.rs`,
+/// `tests/proptest_hrtree.rs`).
+///
+/// The reconciliation mechanism modules are `pub(crate)` (ARCHITECTURE.md §3.7), but the
+/// integration tests need to reach a handful of their internals to drive the diff protocol. This
+/// module re-exports exactly those symbols so the default public surface stays clean while the
+/// tests can still reach them. It is hidden from docs and only compiled under `cfg(test)` or the
+/// `internal-testing` feature (integration tests are separate crates, so `cfg(test)` does not
+/// apply to them — they enable the feature instead).
+#[doc(hidden)]
+#[cfg(any(test, feature = "internal-testing"))]
+pub mod testing {
+    pub use crate::diff::{DiffRange, Diffable, HashRangeQueryable, HashSegment};
+    pub use crate::fingerprint::hash;
+}

--- a/src/mirror.rs
+++ b/src/mirror.rs
@@ -63,6 +63,7 @@ use tokio::time::timeout;
 use tracing::{debug, trace, warn};
 
 use crate::auth;
+use crate::bounds::Key;
 use crate::diff::{Diffable, HashRangeQueryable};
 use crate::fingerprint::Fingerprint;
 use crate::gen_ip::gen_ip;
@@ -116,10 +117,11 @@ impl<K, V> Clone for ReconcileMirror<K, V> {
     }
 }
 
-impl<
-        K: Clone + Debug + DeserializeOwned + Hash + Ord + Send + Serialize + Sync + 'static,
-        V: Clone + DeserializeOwned + Hash + Send + Serialize + Sync + 'static,
-    > ReconcileMirror<K, V>
+// NOTE: `V` here is NOT the `Value` bundle: a mirror only ever handles the value-only projection,
+// so it does not require `V: PartialEq` (which `Value` includes). The data bounds are spelled out
+// to keep the required bound set identical (no tightening). `K` matches `Key` exactly.
+impl<K: Key, V: Clone + Debug + DeserializeOwned + Hash + Send + Serialize + Sync + 'static>
+    ReconcileMirror<K, V>
 {
     /// Create a new mirror bound to the configured UDP socket.
     ///

--- a/src/reconcile_engine.rs
+++ b/src/reconcile_engine.rs
@@ -23,12 +23,13 @@ use ipnet::IpNet;
 use parking_lot::RwLock;
 use rand::rngs::StdRng;
 use rand::SeedableRng;
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 use tokio::net::{ToSocketAddrs, UdpSocket};
 use tokio::time::timeout;
 use tracing::{debug, error, info, instrument, trace, warn};
 
 use crate::auth;
+use crate::bounds::{Key, Value};
 use crate::diff::HashRangeQueryable;
 use crate::diff::{Diffable, HashSegment};
 use crate::fingerprint::Fingerprint;
@@ -151,21 +152,8 @@ pub(crate) enum Message<K: Serialize, V: Serialize, P: Serialize> {
     ValueUpdate((K, P)),
 }
 
-impl<
-        K: Clone + Debug + DeserializeOwned + Hash + Ord + Send + Serialize + Sync + 'static,
-        V: Clone
-            + DeserializeOwned
-            + Hash
-            + MaybeTombstone
-            + PartialEq
-            + Projectable
-            + Reconcilable
-            + Send
-            + Serialize
-            + Sync
-            + Timestamped
-            + 'static,
-    > ReconcileEngine<K, V>
+impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestamped>
+    ReconcileEngine<K, V>
 {
     pub async fn new(config: Config) -> Self {
         let socket = UdpSocket::bind(SocketAddr::new(config.listen_addr, config.port))

--- a/src/reconcile_store.rs
+++ b/src/reconcile_store.rs
@@ -22,6 +22,7 @@ use parking_lot::{MappedRwLockReadGuard, RwLockReadGuard};
 use serde::{de::DeserializeOwned, Serialize};
 use tracing::{info, instrument, warn};
 
+use crate::bounds::{Key, Value};
 use crate::fingerprint::Fingerprint;
 use crate::hlc::Hlc;
 use crate::persistence::{DatedEntries, InMemoryPersistence, PersistedState, Persistence};
@@ -74,11 +75,7 @@ where
     }
 }
 
-impl<
-        K: Clone + Debug + DeserializeOwned + Hash + Ord + Send + Serialize + Sync + 'static,
-        V: Clone + DeserializeOwned + Hash + PartialEq + Send + Serialize + Sync + 'static,
-    > ReconcileStore<K, V>
-{
+impl<K: Key, V: Value> ReconcileStore<K, V> {
     /// Create a new `ReconcileStore`, set up network and tombstones.
     pub async fn new(config: Config) -> Self {
         let svc = ReconcileStore {
@@ -361,10 +358,12 @@ impl<
     }
 }
 
-impl<
-        K: Clone + Debug + DeserializeOwned + Hash + Ord + Send + Serialize + Sync + 'static,
-        V: Clone + DeserializeOwned + Hash + Send + Serialize + Sync + 'static,
-    > ReconcileStore<K, V>
+// NOTE: this block intentionally does NOT use the `Value` bundle for `V`: `get_mut` does not
+// require `V: PartialEq` (unlike the main impl above), and `Value` includes `PartialEq`. Spelling
+// the data bounds out here keeps the required bound set identical (no tightening). `K` matches the
+// `Key` bundle exactly, so it is bundled.
+impl<K: Key, V: Clone + Debug + DeserializeOwned + Hash + Send + Serialize + Sync + 'static>
+    ReconcileStore<K, V>
 {
     pub fn get_mut<F: FnOnce(Option<&mut V>)>(&self, k: &K, callback: F) {
         use crate::reconcilable::Projectable;

--- a/tests/diff.rs
+++ b/tests/diff.rs
@@ -1,9 +1,11 @@
+#![cfg(feature = "internal-testing")]
+
 use std::hash::Hash;
 use std::ops::{Bound, RangeBounds};
 
-use reconcile::diff::{DiffRange, Diffable, HashRangeQueryable, HashSegment};
 use reconcile::fingerprint::Fingerprint;
 use reconcile::hrtree::HRTree;
+use reconcile::testing::{DiffRange, Diffable, HashRangeQueryable, HashSegment};
 
 pub fn diff<K, D: Diffable<ComparisonItem = HashSegment<K>, DifferenceItem = DiffRange<K>>>(
     local: &D,

--- a/tests/proptest_hrtree.rs
+++ b/tests/proptest_hrtree.rs
@@ -20,6 +20,8 @@
 //!    key sets, and convergence survives reordered, duplicated and dropped
 //!    messages — modelling the lossy UDP transport.
 
+#![cfg(feature = "internal-testing")]
+
 use std::collections::BTreeMap;
 use std::ops::Bound;
 
@@ -28,9 +30,9 @@ use rand::rngs::StdRng;
 use rand::seq::SliceRandom;
 use rand::{Rng, SeedableRng};
 
-use reconcile::diff::{DiffRange, Diffable, HashRangeQueryable, HashSegment};
-use reconcile::fingerprint::{hash, Fingerprint};
+use reconcile::fingerprint::Fingerprint;
 use reconcile::hrtree::HRTree;
+use reconcile::testing::{hash, DiffRange, Diffable, HashRangeQueryable, HashSegment};
 
 // ---------------------------------------------------------------------------
 // Property 1: HRTree is observationally equivalent to a BTreeMap oracle, and


### PR DESCRIPTION
Step 1 of the hexagonal migration (#138). **Behaviour- and format-preserving** — only the generic-bounds spelling and the public-API surface change.

## Bound bundles (ARCHITECTURE.md §3.8)
New `src/bounds.rs` with blanket-impl supertrait bundles, re-exported at the crate root:
```rust
pub trait Key:   Clone + Debug + Hash + Ord + Send + Sync + Serialize + DeserializeOwned + 'static {}
pub trait Value: Clone + Debug + Hash + PartialEq + Send + Sync + Serialize + DeserializeOwned + 'static {}
```
The 9/11-bound `where` blocks become `impl<K: Key, V: Value>` in `reconcile_engine.rs` / `reconcile_store.rs` / `mirror.rs`. The entry-semantics bounds (`MaybeTombstone`/`Projectable`/`Reconcilable`/`Timestamped`) are kept as **extras** — they're dissolved in step 4, not here. Two sites (`get_mut`, `mirror`) keep `V` spelled out because they don't require `PartialEq`; using `Value` there would have *tightened* the bound.

## Encapsulation (ARCHITECTURE.md §3.7)
Demoted to `pub(crate)`: `diff`, `gen_ip`, `hrtree_iter` (and `HlcClock`/`Timestamped` confirmed non-public). Still public: `Persistence`+types, `ReconcileStore`+`Config`, `ReconcileMirror`, `Hlc`, `HRTree`, `Fingerprint`, and the new `Key`/`Value`. The `hrtree_iter` iterator types appear in public `HRTree` return types, so they stay `pub` and are re-exported at the crate root (avoids E0446). Public-API shrink confirmed: `reconcile::{diff, gen_ip, hrtree_iter::Iter, hlc::HlcClock}` now fail with E0603.

## Test seam (the encapsulation-vs-oracle resolution)
`tests/diff.rs` + `tests/proptest_hrtree.rs` import diff/fingerprint internals as an *external* crate. Rather than weaken the public surface:
- New dev-only feature `internal-testing = []`.
- `lib.rs`: `#[doc(hidden)] #[cfg(any(test, feature = "internal-testing"))] pub mod testing` re-exporting `diff::{DiffRange, Diffable, HashRangeQueryable, HashSegment}` + `fingerprint::hash`.
- The two oracle files are `#[cfg(feature = "internal-testing")]` and import via `reconcile::testing::*`. Under a plain `cargo test` they compile to 0 tests; under the feature they run.
- `.github/workflows/master.yml`: added `--features internal-testing` to the `clippy --all`, `test --all`, `test --doc --all`, and `bench --no-run` steps so the oracles always run in CI. `devcontainer.yml` untouched (its smoke is `cargo test --lib`).

## Two extra consumers handled (flagged for review)
- **`benches/bench.rs`** also reached an internal (`HashRangeQueryable`), so it's routed through `reconcile::testing` and feature-gated (with a no-op `main` fallback so the target still links without the feature). This re-indentation is the bulk of the diff (~818 lines, mostly whitespace).
- **`gen_ip` doctests** named the now-private path, so they became ` ```ignore ` illustrative blocks (doc-only; the 3 "ignored" doc-tests).

## Verification (all green)
- `cargo build` / `--all-features`; `cargo fmt --check`
- `cargo test` (oracles gated out) and `cargo test --all-features` (oracles run: diff 3, proptest 5, fuzz 1, mirror 2, observability 3, lib 67, service 8)
- `cargo test --doc --all-features` (10 passed, 3 ignored)
- `cargo clippy --all-targets --all-features` and `--features internal-testing`, both `-D warnings`

Invariants #1/#3/#4 preserved (diff logic untouched, just reached via the seam). No wire/on-disk/behaviour change.

Part of #138. Implements #140.

https://claude.ai/code/session_01T5j1LeUSC9xY8oGMiFtczP

---
_Generated by [Claude Code](https://claude.ai/code/session_01T5j1LeUSC9xY8oGMiFtczP)_