### PR TITLE
feat(reconcile): geography-aware gossip (#53) + Kubernetes-native DNS discovery

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -195,6 +195,15 @@ pub trait Persistence<K, V>: Send + Sync + 'static {
     fn load(&self) -> io::Result<Option<PersistedState<K, V>>>;
     fn save(&self, state: &PersistedState<K, V>) -> io::Result<()>;
 }
+
+// Discovery — an optional source of peer addresses (replaces, for cloud-native deployments, the
+// random per-network IP probing). It is *additive*: the store seeds whatever it returns into the
+// known-peer set; it never grants causal-stability membership (which a peer must earn via an
+// authenticated dated datagram), so it cannot affect tombstone GC correctness. Boxed-future rather
+// than async_trait to keep the dependency footprint unchanged (it is always behind Arc<dyn ..>).
+pub trait Discovery: Send + Sync + 'static {
+    fn discover(&self) -> DiscoverFuture<'_>;  // io::Result<Vec<IpAddr>>
+}
 ```
 
 ### 3.5 Adapters
@@ -205,6 +214,7 @@ pub trait Persistence<K, V>: Send + Sync + 'static {
 | `Transport` | `UdpTransport(Arc<UdpSocket>)` | tokio / UDP |
 | `Codec` | `BincodeCodec(DefaultOptions)` | bincode |
 | `Persistence` | `FileSnapshot`, `InMemory` | file / memory |
+| `Discovery` | `DnsDiscovery` (headless-Service DNS); engine random per-net probing otherwise | `tokio::net::lookup_host` |
 
 Message authentication (`Authenticator` / MAC) sits **ahead of** the codec: the MAC is verified on
 raw bytes before any decoding occurs. It is never folded into the `Codec`.
@@ -314,6 +324,7 @@ without a compile error — the guarantee a single crate cannot provide.
 | `UdpSocket` in `reconcile_engine.rs` | `Transport` port; `UdpTransport` adapter |
 | `bincode` in `reconcile_engine.rs` | `Codec` port; `BincodeCodec` adapter |
 | `Persistence` | unchanged (the model port) |
+| `gen_ip` random IP-scan (only discovery) | `Discovery` port; `DnsDiscovery` adapter (k8s-native), probing kept as the no-port default |
 | Multi-bound `where` blocks | `Key` / `Value` supertrait bundles |
 | Single crate | `reconcile-core` / `-net` / `-store` / `reconcile` workspace |
 
@@ -333,7 +344,11 @@ correctness and security guarantees tracked in [`PROGRESS.md`](./PROGRESS.md).
 5. **Authenticate before deserialise** — the MAC is verified on raw bytes before the codec runs; the
    `Codec` port never absorbs authentication.
 6. **Causal-stability tombstone gate** — a tombstone is garbage-collected only after every monotonic
-   cluster member has acknowledged the exact version hash.
+   cluster member has acknowledged the exact version hash. Dynamic discovery (e.g. `DnsDiscovery`)
+   only ever feeds the gossip-target `peers` set, **never** the `members` set: membership stays
+   earned by an authenticated dated datagram, so a discovered (unverified) address can neither block
+   GC nor be the subject of a GC release. Decommissioning a member that has vanished from discovery
+   uses the same `decommission_peer` escape hatch as `forget_peer`.
 7. **`version_hash` determinism** (`reconcile_engine.rs:55`) — preserved as `Entry` derives `Hash`.
 8. **Value-only projection hash is timestamp-less** — the dated `Entry` hashes with its `stamp`
    (feeding `version_hash`), while its `State<V>` projection hashes the value alone, so a dated

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -196,13 +196,17 @@ pub trait Persistence<K, V>: Send + Sync + 'static {
     fn save(&self, state: &PersistedState<K, V>) -> io::Result<()>;
 }
 
-// Discovery — an optional source of peer addresses (replaces, for cloud-native deployments, the
-// random per-network IP probing). It is *additive*: the store seeds whatever it returns into the
-// known-peer set; it never grants causal-stability membership (which a peer must earn via an
-// authenticated dated datagram), so it cannot affect tombstone GC correctness. Boxed-future rather
-// than async_trait to keep the dependency footprint unchanged (it is always behind Arc<dyn ..>).
+// Discovery — the single source of peer addresses. The default `RandomProbe` adapter (speculative,
+// one random address per declared network each round) and the `DnsDiscovery` adapter (authoritative,
+// k8s headless-Service DNS) both implement it. `is_authoritative` distinguishes the two: a speculative
+// result only steers the current round's targets, an authoritative one is the current truth (seeded
+// into the known-peer set, an absence decommissions after a grace period). Either way it never grants
+// causal-stability membership (which a peer must earn via an authenticated dated datagram), so it
+// cannot affect tombstone GC correctness. Boxed-future rather than async_trait to keep the dependency
+// footprint unchanged (it is always behind Arc<dyn ..>).
 pub trait Discovery: Send + Sync + 'static {
-    fn discover(&self) -> DiscoverFuture<'_>;  // io::Result<Vec<IpAddr>>
+    fn discover(&self) -> DiscoverFuture<'_>;       // io::Result<Vec<IpAddr>>
+    fn is_authoritative(&self) -> bool { true }     // RandomProbe overrides to false
 }
 ```
 
@@ -214,7 +218,7 @@ pub trait Discovery: Send + Sync + 'static {
 | `Transport` | `UdpTransport(Arc<UdpSocket>)` | tokio / UDP |
 | `Codec` | `BincodeCodec(DefaultOptions)` | bincode |
 | `Persistence` | `FileSnapshot`, `InMemory` | file / memory |
-| `Discovery` | `DnsDiscovery` (headless-Service DNS); engine random per-net probing otherwise | `tokio::net::lookup_host` |
+| `Discovery` | `RandomProbe` (default, speculative per-net probing); `DnsDiscovery` (authoritative, headless-Service DNS) | `gen_ip` / `tokio::net::lookup_host` |
 
 Message authentication (`Authenticator` / MAC) sits **ahead of** the codec: the MAC is verified on
 raw bytes before any decoding occurs. It is never folded into the `Codec`.
@@ -324,7 +328,7 @@ without a compile error — the guarantee a single crate cannot provide.
 | `UdpSocket` in `reconcile_engine.rs` | `Transport` port; `UdpTransport` adapter |
 | `bincode` in `reconcile_engine.rs` | `Codec` port; `BincodeCodec` adapter |
 | `Persistence` | unchanged (the model port) |
-| `gen_ip` random IP-scan (only discovery) | `Discovery` port; `DnsDiscovery` adapter (k8s-native), probing kept as the no-port default |
+| `gen_ip` random IP-scan inline in the engine | `Discovery` port; `RandomProbe` (speculative, the default) + `DnsDiscovery` (authoritative, k8s-native) adapters |
 | Multi-bound `where` blocks | `Key` / `Value` supertrait bundles |
 | Single crate | `reconcile-core` / `-net` / `-store` / `reconcile` workspace |
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,15 @@ metrics = ["dep:metrics"]
 # `src/prometheus.rs`). Pulls the exporter's HTTP listener stack; opt-in only. Implies
 # `metrics`, which feeds the same facade.
 metrics-prometheus = ["metrics", "dep:metrics-exporter-prometheus"]
+# Reserved for a future `hickory-resolver`-backed DNS discovery adapter (SRV records, explicit
+# TTL/ndots control, robust resolution in static/musl images). Not implemented yet: the default
+# `DnsDiscovery` uses the system resolver via `tokio::net::lookup_host` and needs no extra crate.
+dns-hickory = []
+
+[[example]]
+name = "k8s_node"
+# Builds the metrics/readiness endpoint into the binary; the Kubernetes probes target `/metrics`.
+required-features = ["metrics-prometheus"]
 
 [dependencies]
 arrayvec = "0.7.4"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+# Production image for a Kubernetes-native reconcile node.
+#
+# Multi-stage build: compile the `k8s_node` example with the Prometheus metrics endpoint, then ship
+# only the binary on a distroless glibc base. glibc (not musl) is deliberate: peer discovery resolves
+# the headless Service through `getaddrinfo` (`tokio::net::lookup_host`), which is most reliable on
+# glibc. A static musl image would need the (reserved) `dns-hickory` feature instead.
+#
+# Build:  docker build -t reconcile:latest .
+# The container reads its configuration from the environment — see deploy/k8s/.
+
+# ---- builder ----
+FROM rust:1-bookworm AS builder
+WORKDIR /src
+
+# Copy the manifest and sources. (Cargo.lock is copied if present; ignored otherwise.)
+COPY Cargo.toml Cargo.lock* ./
+COPY src ./src
+COPY examples ./examples
+COPY benches ./benches
+
+# Build the Kubernetes node binary with the metrics/readiness endpoint compiled in.
+RUN cargo build --release --example k8s_node --features metrics-prometheus
+
+# ---- runtime ----
+FROM gcr.io/distroless/cc-debian12 AS runtime
+COPY --from=builder /src/target/release/examples/k8s_node /usr/local/bin/k8s_node
+
+# Gossip (UDP) and metrics/probes (TCP). Match deploy/k8s/ and the container env.
+EXPOSE 8080/udp
+EXPOSE 9000/tcp
+
+# Run as the distroless non-root user.
+USER 65532:65532
+
+ENTRYPOINT ["/usr/local/bin/k8s_node"]

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -87,6 +87,8 @@ resolved; all but one High resolved or mitigated.
 - ◯ Key rotation / management — [#137](https://github.com/Akvize/reconcile-rs/issues/137).
 
 ### Scaling & robustness
+- ✅ Multi-region reconciliation: per-region discovery probes + geography-aware gossip with
+  bounded cross-region fan-out (decentralized, no gateway nodes) — [#53](https://github.com/Akvize/reconcile-rs/issues/53).
 - ◯ Membership / discovery: replace random IP-scan with SWIM/HyParView, bounded fan-out
   (F10 — [#147](https://github.com/Akvize/reconcile-rs/issues/147)).
 - ◯ Bound the `peers` map; cap messages/segments per datagram; bincode limit

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -89,6 +89,9 @@ resolved; all but one High resolved or mitigated.
 ### Scaling & robustness
 - ✅ Multi-location reconciliation: per-network discovery probes + geography-aware gossip with
   bounded cross-network fan-out (decentralized, no gateway nodes) — [#53](https://github.com/Akvize/reconcile-rs/issues/53).
+- ✅ Runtime reconfiguration: live `set_nets`/`add_net`/`remove_net`, `set_remote_interval`/
+  `set_remote_fanout`, `set_reconcile_interval`, `set_tombstone_timeout` (auto-derived local net;
+  anti-entropy repair decoupled from net membership, so topology changes cannot cause divergence).
 - ◯ Membership / discovery: replace random IP-scan with SWIM/HyParView, bounded fan-out
   (F10 — [#147](https://github.com/Akvize/reconcile-rs/issues/147)).
 - ◯ Bound the `peers` map; cap messages/segments per datagram; bincode limit

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -87,8 +87,8 @@ resolved; all but one High resolved or mitigated.
 - ◯ Key rotation / management — [#137](https://github.com/Akvize/reconcile-rs/issues/137).
 
 ### Scaling & robustness
-- ✅ Multi-region reconciliation: per-region discovery probes + geography-aware gossip with
-  bounded cross-region fan-out (decentralized, no gateway nodes) — [#53](https://github.com/Akvize/reconcile-rs/issues/53).
+- ✅ Multi-location reconciliation: per-network discovery probes + geography-aware gossip with
+  bounded cross-network fan-out (decentralized, no gateway nodes) — [#53](https://github.com/Akvize/reconcile-rs/issues/53).
 - ◯ Membership / discovery: replace random IP-scan with SWIM/HyParView, bounded fan-out
   (F10 — [#147](https://github.com/Akvize/reconcile-rs/issues/147)).
 - ◯ Bound the `peers` map; cap messages/segments per datagram; bincode limit

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -44,7 +44,7 @@ Status of every finding (`Fxx`) from the original code audit (commit `64f1ebf`).
 | F7 | High | crafted `HashSegment` → panic/underflow | ✅ | #112 — bound validation + `checked_sub` |
 | F8 | High | `DefaultHasher` unstable on the wire | ✅ | #111 — wire fingerprint is BLAKE3 (`version_hash` still fixed-key `DefaultHasher`) |
 | F9 | High | UDP amplification / reflection | ◐ | mitigated by #108 (auth) + #106; rate-limiting / path validation still open |
-| F10 | High | IP-scan discovery, O(N²) membership | ◯ | [#147](https://github.com/Akvize/reconcile-rs/issues/147) — bounded-fan-out membership (SWIM/HyParView) |
+| F10 | High | IP-scan discovery, O(N²) membership | ◐ | [#147](https://github.com/Akvize/reconcile-rs/issues/147) — `Discovery` port + `DnsDiscovery` (k8s headless-Service DNS, no IP-scan) lands a cloud-native discovery path; bounded-fan-out membership (SWIM/HyParView) still open |
 | F11 | High | no property-testing / fuzzing | ✅ | #113 — `tests/proptest_hrtree.rs`, `tests/fuzz_packets.rs` |
 | F12 | Medium | debug `println!` in the hot path | ✅ | #113 — removed |
 | F13 | Medium | panic-only API (no `Result`) | ◯ | [#148](https://github.com/Akvize/reconcile-rs/issues/148) — `new`/`run` still return `Self`/`()`; `unwrap` on bind/send |
@@ -55,7 +55,7 @@ Status of every finding (`Fxx`) from the original code audit (commit `64f1ebf`).
 | F18 | Medium | resource exhaustion (`peers` map, bincode bomb) | ◯ | [#150](https://github.com/Akvize/reconcile-rs/issues/150) — unbounded `peers`; no bincode allocation limit |
 | F19 | Low | dependency hygiene | ◯ | [#151](https://github.com/Akvize/reconcile-rs/issues/151) — `overflow-checks` off; bincode `with_limit`; `cargo audit` |
 
-**Score:** 11 resolved · 3 partial (F9, F16, F17) · 5 open (F10, F13, F14, F18, F19). All Critical
+**Score:** 11 resolved · 4 partial (F9, F10, F16, F17) · 4 open (F13, F14, F18, F19). All Critical
 resolved; all but one High resolved or mitigated.
 
 ---
@@ -92,7 +92,9 @@ resolved; all but one High resolved or mitigated.
 - ✅ Runtime reconfiguration: live `set_nets`/`add_net`/`remove_net`, `set_remote_interval`/
   `set_remote_fanout`, `set_reconcile_interval`, `set_tombstone_timeout` (auto-derived local net;
   anti-entropy repair decoupled from net membership, so topology changes cannot cause divergence).
-- ◯ Membership / discovery: replace random IP-scan with SWIM/HyParView, bounded fan-out
+- ◐ Membership / discovery: `Discovery` port with a `DnsDiscovery` adapter gives a Kubernetes-native
+  path (headless-Service DNS + grace-period decommission of vanished pods) that sidesteps the random
+  IP-scan; bounded-fan-out membership (SWIM/HyParView) still open
   (F10 — [#147](https://github.com/Akvize/reconcile-rs/issues/147)).
 - ◯ Bound the `peers` map; cap messages/segments per datagram; bincode limit
   (F18 — [#150](https://github.com/Akvize/reconcile-rs/issues/150), F19 — [#151](https://github.com/Akvize/reconcile-rs/issues/151)).

--- a/README.md
+++ b/README.md
@@ -204,38 +204,39 @@ sink, not a source. The dated↔dated path (and its wire format) is byte-for-byt
 
 ## Multiple geographical locations
 
-A single cluster can span several geographical regions (issue #53). A **region is just an address
-range (CIDR)** that groups co-located nodes — size it to your topology: a whole cloud region, an
-availability zone, or a single subnet. The model is intentionally flat: there is no finer level
-(no rack/host) and no hierarchy, because the CIDR mask already lets you pick the granularity. Each
-node declares **its own** region with `with_local_region` and **every other** region with
-`with_remote_region`:
+A single cluster can span several geographical locations (issue #53). Each location is **just an
+address range** — a network (CIDR) that groups co-located nodes. Size it to your topology: a whole
+cloud region, an availability zone, or a single subnet. The model is intentionally flat (one CIDR
+per location, no rack/host level and no hierarchy), because the CIDR mask already lets you pick the
+granularity. Declare every network with `with_net` — **including this node's own**:
 
 ```rust
 use reconcile::{reconcile_store::Config, ReconcileStore};
 
 let config = Config::default()
     .with_listen_addr("10.1.0.7".parse().unwrap())
-    .with_local_region("10.1.0.0/16".parse().unwrap())  // this node's region
-    .with_remote_region("10.2.0.0/16".parse().unwrap()) // a remote region
-    .with_remote_region("10.3.0.0/16".parse().unwrap()); // another remote region
+    .with_net("10.1.0.0/16".parse().unwrap())  // this node's network (contains listen_addr)
+    .with_net("10.2.0.0/16".parse().unwrap())  // another location
+    .with_net("10.3.0.0/16".parse().unwrap()); // and another
 let store = ReconcileStore::<String, String>::new(config).await;
 ```
 
-The gossip is **geography-aware and decentralized** — there are no relay/gateway nodes to configure
-or fail over:
+This node's **local** network is whichever declared net contains its `listen_addr`; all others are
+**remote**. (If none contains it, the node logs a loud warning and treats only itself as local, so
+every peer is remote.) The gossip is **geography-aware and decentralized** — there are no
+relay/gateway nodes to configure or fail over:
 
-- **Discovery** probes one random address in *every* region each round, so peers in all locations
+- **Discovery** probes one random address in *every* network each round, so peers in all locations
   are auto-discovered (not just within a single flat CIDR).
-- **Anti-entropy** sends the full range-diff comparison to *local-region* peers every round (fast
-  intra-region convergence, as before) but to *remote-region* peers only every
-  `cross_region_interval` rounds and to at most `cross_region_fanout` peers per region — bounding WAN
-  traffic. Tune both with `with_cross_region_interval` / `with_cross_region_fanout`.
+- **Anti-entropy** sends the full range-diff comparison to *local-network* peers every round (fast
+  intra-network convergence, as before) but to *remote-network* peers only every `remote_interval`
+  rounds and to at most `remote_fanout` peers per network — bounding WAN traffic. Tune both with
+  `with_remote_interval` / `with_remote_fanout`.
 
-A peer's region is derived purely from its IP address (`IpNet::contains`), so **the wire format is
-unchanged** and a single-region cluster (no `with_remote_region`) behaves exactly as before. Live writes
+A peer's network is derived purely from its IP address (`IpNet::contains`), so **the wire format is
+unchanged** and a single-network cluster (no extra `with_net`) behaves exactly as before. Live writes
 still propagate immediately to all known peers; only the periodic anti-entropy is throttled across
-regions. Cross-region tombstone GC is correspondingly slower but remains strictly correct (it never
+networks. Cross-network tombstone GC is correspondingly slower but remains strictly correct (it never
 collects a tombstone before *every* member has acknowledged it).
 
 ## HRTree

--- a/README.md
+++ b/README.md
@@ -229,15 +229,46 @@ relay/gateway nodes to configure or fail over:
 - **Discovery** probes one random address in *every* network each round, so peers in all locations
   are auto-discovered (not just within a single flat CIDR).
 - **Anti-entropy** sends the full range-diff comparison to *local-network* peers every round (fast
-  intra-network convergence, as before) but to *remote-network* peers only every `remote_interval`
-  rounds and to at most `remote_fanout` peers per network — bounding WAN traffic. Tune both with
-  `with_remote_interval` / `with_remote_fanout`.
+  intra-network convergence, as before) but to *remote* peers only every `remote_interval` rounds and
+  to at most `remote_fanout` peers per network — bounding WAN traffic. Tune both with
+  `with_remote_interval` / `with_remote_fanout`. Crucially, **repair is decoupled from net
+  membership**: a peer learned by actual contact is always reconciled — peers matching no declared
+  network fall into an `unclassified` bucket that is repaired on the same throttled cadence — so the
+  declared topology only steers *discovery* and the local/remote split, never a peer's eligibility for
+  repair.
 
 A peer's network is derived purely from its IP address (`IpNet::contains`), so **the wire format is
 unchanged** and a single-network cluster (no extra `with_net`) behaves exactly as before. Live writes
 still propagate immediately to all known peers; only the periodic anti-entropy is throttled across
 networks. Cross-network tombstone GC is correspondingly slower but remains strictly correct (it never
 collects a tombstone before *every* member has acknowledged it).
+
+### Runtime reconfiguration
+
+The topology and gossip knobs can be retuned **live**, without recreating the node (which would
+re-bind the socket and lose its identity) — useful for elastic deployments: opening a new region,
+decommissioning one, or retuning WAN traffic on the fly. These `&self` methods on `ReconcileStore`
+take effect on the running `run()` loop:
+
+```rust
+store.add_net("10.4.0.0/16".parse().unwrap()); // start gossiping with a new location
+store.remove_net("10.3.0.0/16".parse().unwrap()); // stop probing a retired one
+store.set_nets(&nets);                          // replace the whole topology at once
+store.set_remote_interval(3);                   // retune cross-network cadence
+store.set_remote_fanout(4);                     //   and fan-out
+store.set_reconcile_interval(Duration::from_millis(500)); // retune the gossip cadence
+store.set_tombstone_timeout(Duration::from_secs(120));    // retune tombstone expiry
+```
+
+The **local network is re-derived automatically** from the declared nets and the listen address on
+every change, so it can never drift out of sync. Topology is per-node and **coordination-free** (no
+cluster-wide agreement, no wire tag), and changing it is **safe by construction**: because repair is
+decoupled from net membership (above), reshaping the topology can never orphan a known peer from
+anti-entropy — the worst case is suboptimal WAN traffic, never silent divergence. Note that nets are
+*not* a security boundary (authentication is the cluster key); a declared net only tells the node
+which address range to send discovery probes into, so **only declare ranges you operate**. When
+migrating a region, prefer `add_net(new)` *before* `remove_net(old)` so discovery keeps the cluster
+well-connected throughout. `ReconcileMirror` exposes the analogous `set_net`.
 
 ## HRTree
 

--- a/README.md
+++ b/README.md
@@ -202,6 +202,38 @@ tokio::spawn(mirror.clone().run());
 A mirror **always integrates** inbound updates and **never sends authoritative values** — it is a
 sink, not a source. The dated↔dated path (and its wire format) is byte-for-byte unchanged.
 
+## Multiple geographical locations
+
+A single cluster can span several geographical regions, each a separate subnet (issue #53). Declare
+the local region as `peer_net` and every other region with `with_region`:
+
+```rust
+use reconcile::{reconcile_store::Config, ReconcileStore};
+
+let config = Config::default()
+    .with_listen_addr("10.1.0.7".parse().unwrap())
+    .with_peer_net("10.1.0.0/16".parse().unwrap()) // local region
+    .with_region("10.2.0.0/16".parse().unwrap())   // a remote region
+    .with_region("10.3.0.0/16".parse().unwrap());  // another remote region
+let store = ReconcileStore::<String, String>::new(config).await;
+```
+
+The gossip is **geography-aware and decentralized** — there are no relay/gateway nodes to configure
+or fail over:
+
+- **Discovery** probes one random address in *every* region each round, so peers in all locations
+  are auto-discovered (not just within a single flat CIDR).
+- **Anti-entropy** sends the full range-diff comparison to *local-region* peers every round (fast
+  intra-region convergence, as before) but to *remote-region* peers only every
+  `cross_region_interval` rounds and to at most `remote_fanout` peers per region — bounding WAN
+  traffic. Tune both with `with_cross_region_interval` / `with_remote_fanout`.
+
+A peer's region is derived purely from its IP address (`IpNet::contains`), so **the wire format is
+unchanged** and a single-region cluster (no `with_region`) behaves exactly as before. Live writes
+still propagate immediately to all known peers; only the periodic anti-entropy is throttled across
+regions. Cross-region tombstone GC is correspondingly slower but remains strictly correct (it never
+collects a tombstone before *every* member has acknowledged it).
+
 ## HRTree
 
 The core of the protocol is made possible by the `HRTree` (Hash-Range Tree) data structure, which

--- a/README.md
+++ b/README.md
@@ -204,17 +204,21 @@ sink, not a source. The dated↔dated path (and its wire format) is byte-for-byt
 
 ## Multiple geographical locations
 
-A single cluster can span several geographical regions, each a separate subnet (issue #53). Declare
-the local region as `peer_net` and every other region with `with_region`:
+A single cluster can span several geographical regions (issue #53). A **region is just an address
+range (CIDR)** that groups co-located nodes — size it to your topology: a whole cloud region, an
+availability zone, or a single subnet. The model is intentionally flat: there is no finer level
+(no rack/host) and no hierarchy, because the CIDR mask already lets you pick the granularity. Each
+node declares **its own** region with `with_local_region` and **every other** region with
+`with_remote_region`:
 
 ```rust
 use reconcile::{reconcile_store::Config, ReconcileStore};
 
 let config = Config::default()
     .with_listen_addr("10.1.0.7".parse().unwrap())
-    .with_peer_net("10.1.0.0/16".parse().unwrap()) // local region
-    .with_region("10.2.0.0/16".parse().unwrap())   // a remote region
-    .with_region("10.3.0.0/16".parse().unwrap());  // another remote region
+    .with_local_region("10.1.0.0/16".parse().unwrap())  // this node's region
+    .with_remote_region("10.2.0.0/16".parse().unwrap()) // a remote region
+    .with_remote_region("10.3.0.0/16".parse().unwrap()); // another remote region
 let store = ReconcileStore::<String, String>::new(config).await;
 ```
 
@@ -225,11 +229,11 @@ or fail over:
   are auto-discovered (not just within a single flat CIDR).
 - **Anti-entropy** sends the full range-diff comparison to *local-region* peers every round (fast
   intra-region convergence, as before) but to *remote-region* peers only every
-  `cross_region_interval` rounds and to at most `remote_fanout` peers per region — bounding WAN
-  traffic. Tune both with `with_cross_region_interval` / `with_remote_fanout`.
+  `cross_region_interval` rounds and to at most `cross_region_fanout` peers per region — bounding WAN
+  traffic. Tune both with `with_cross_region_interval` / `with_cross_region_fanout`.
 
 A peer's region is derived purely from its IP address (`IpNet::contains`), so **the wire format is
-unchanged** and a single-region cluster (no `with_region`) behaves exactly as before. Live writes
+unchanged** and a single-region cluster (no `with_remote_region`) behaves exactly as before. Live writes
 still propagate immediately to all known peers; only the periodic anti-entropy is throttled across
 regions. Cross-region tombstone GC is correspondingly slower but remains strictly correct (it never
 collects a tombstone before *every* member has acknowledged it).

--- a/README.md
+++ b/README.md
@@ -270,6 +270,47 @@ which address range to send discovery probes into, so **only declare ranges you 
 migrating a region, prefer `add_net(new)` *before* `remove_net(old)` so discovery keeps the cluster
 well-connected throughout. `ReconcileMirror` exposes the analogous `set_net`.
 
+## Kubernetes (DNS-based discovery)
+
+The default discovery — probing random addresses in the declared networks — does not fit
+Kubernetes, where pod IPs are ephemeral and drawn from a large cluster CIDR, so a random probe
+almost never lands on a live pod. Instead, point the store at a **headless `Service`**
+(`clusterIP: None`): its DNS name resolves to one address record per ready pod, giving every peer in
+a single lookup — the canonical StatefulSet pattern, with **no Kubernetes API access and no RBAC**.
+
+```rust
+use reconcile::{reconcile_store::Config, ReconcileStore};
+
+let config = Config::default()
+    .with_listen_addr(pod_ip)         // bind to the pod IP (downward API: status.podIP)
+    .with_node_id(node_id);           // stable id derived from the pod name
+// Note: no `with_net` — discovery is purely DNS-driven in Kubernetes.
+let store = ReconcileStore::<String, String>::new(config)
+    .await
+    .with_dns_discovery("reconcile-headless.default.svc.cluster.local", 8080);
+store.run().await;
+```
+
+While `run()`ning, a background task resolves the name every `with_discovery_interval` (default
+5 s) and seeds every returned address as a known peer. A peer's *membership* (which gates tombstone
+garbage collection) is **never** granted by DNS — it is still earned through a genuine authenticated
+datagram — so an unverified or spoofable address can never block GC. When a pod is deleted it
+disappears from DNS; after `with_discovery_miss_threshold` consecutive successful rounds with the
+peer absent (default 3, i.e. ~15 s), it is **decommissioned** so its tombstones stop gating GC. A
+transient DNS failure is skipped entirely and never counts as a miss, so a resolver blip cannot
+decommission a healthy peer. This works alongside the geography-aware gossip above: declared
+networks (if any) still steer the engine's own probing and the local/remote throttle, while DNS
+feeds exact peer IPs into the always-reconciled set.
+
+This discovery feeds peers regardless of declared topology, so a discovered peer is always
+reconciled even with no `with_net`.
+
+Set the cluster key (`Config::with_cluster_key`, from a Kubernetes `Secret`) on every pod: without
+it the cluster runs **unauthenticated** (see the Security model above). A ready-to-adapt example
+node (`examples/k8s_node.rs`, env-driven) and manifests (headless `Service`, `StatefulSet`,
+`ConfigMap`, example `Secret`) live in [`deploy/k8s/`](deploy/k8s/); build the production image from
+the repository `Dockerfile`.
+
 ## HRTree
 
 The core of the protocol is made possible by the `HRTree` (Hash-Range Tree) data structure, which

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -282,21 +282,17 @@ fn mirror_memory(c: &mut Criterion) {
 /// Measure the time to send 1 insertion, and 1 removal between 2 ReconcileStore instances containing N items
 fn service_send(c: &mut Criterion) {
     let port = 8080;
-    let local_region = "127.0.0.1/8".parse().unwrap();
+    let net = "127.0.0.1/8".parse().unwrap();
     let addr1 = "127.0.0.44".parse().unwrap();
     let addr2 = "127.0.0.45".parse().unwrap();
-    let cfg1 = Config {
-        port,
-        listen_addr: addr1,
-        local_region,
-        ..Config::default()
-    };
-    let cfg2 = Config {
-        port,
-        listen_addr: addr2,
-        local_region,
-        ..Config::default()
-    };
+    let cfg1 = Config::default()
+        .with_port(port)
+        .with_listen_addr(addr1)
+        .with_net(net);
+    let cfg2 = Config::default()
+        .with_port(port)
+        .with_listen_addr(addr2)
+        .with_net(net);
 
     let mut rng = rand::rngs::ThreadRng::default();
 
@@ -346,17 +342,17 @@ fn service_send(c: &mut Criterion) {
 /// Measure the time to reconcile 1 insertion/removal between ReconcileStore instances containing N items
 fn service_reconcile(c: &mut Criterion) {
     let port = 8080;
-    let local_region = "127.0.0.1/8".parse().unwrap();
+    let net = "127.0.0.1/8".parse().unwrap();
     let addr1 = "127.0.0.44".parse().unwrap();
     let addr2 = "127.0.0.45".parse().unwrap();
     let cfg1 = Config::default()
         .with_port(port)
         .with_listen_addr(addr1)
-        .with_local_region(local_region);
+        .with_net(net);
     let cfg2 = Config::default()
         .with_port(port)
         .with_listen_addr(addr2)
-        .with_local_region(local_region);
+        .with_net(net);
 
     let mut rng = rand::rngs::ThreadRng::default();
 

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -282,19 +282,19 @@ fn mirror_memory(c: &mut Criterion) {
 /// Measure the time to send 1 insertion, and 1 removal between 2 ReconcileStore instances containing N items
 fn service_send(c: &mut Criterion) {
     let port = 8080;
-    let peer_net = "127.0.0.1/8".parse().unwrap();
+    let local_region = "127.0.0.1/8".parse().unwrap();
     let addr1 = "127.0.0.44".parse().unwrap();
     let addr2 = "127.0.0.45".parse().unwrap();
     let cfg1 = Config {
         port,
         listen_addr: addr1,
-        peer_net,
+        local_region,
         ..Config::default()
     };
     let cfg2 = Config {
         port,
         listen_addr: addr2,
-        peer_net,
+        local_region,
         ..Config::default()
     };
 
@@ -346,17 +346,17 @@ fn service_send(c: &mut Criterion) {
 /// Measure the time to reconcile 1 insertion/removal between ReconcileStore instances containing N items
 fn service_reconcile(c: &mut Criterion) {
     let port = 8080;
-    let peer_net = "127.0.0.1/8".parse().unwrap();
+    let local_region = "127.0.0.1/8".parse().unwrap();
     let addr1 = "127.0.0.44".parse().unwrap();
     let addr2 = "127.0.0.45".parse().unwrap();
     let cfg1 = Config::default()
         .with_port(port)
         .with_listen_addr(addr1)
-        .with_peer_net(peer_net);
+        .with_local_region(local_region);
     let cfg2 = Config::default()
         .with_port(port)
         .with_listen_addr(addr2)
-        .with_peer_net(peer_net);
+        .with_local_region(local_region);
 
     let mut rng = rand::rngs::ThreadRng::default();
 

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -289,17 +289,13 @@ fn service_send(c: &mut Criterion) {
         port,
         listen_addr: addr1,
         peer_net,
-        cluster_key: None,
-        node_id: None,
-        encrypt: false,
+        ..Config::default()
     };
     let cfg2 = Config {
         port,
         listen_addr: addr2,
         peer_net,
-        cluster_key: None,
-        node_id: None,
-        encrypt: false,
+        ..Config::default()
     };
 
     let mut rng = rand::rngs::ThreadRng::default();

--- a/deploy/k8s/configmap.yaml
+++ b/deploy/k8s/configmap.yaml
@@ -1,0 +1,19 @@
+# Non-secret configuration shared by every pod. The cluster key is NOT here — it lives in a Secret
+# (see secret.example.yaml) and is injected separately.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: reconcile-config
+  labels:
+    app: reconcile
+data:
+  # FQDN of the headless Service. Adjust the namespace if not "default".
+  RECONCILE_DNS_NAME: "reconcile-headless.default.svc.cluster.local"
+  RECONCILE_PORT: "8080"
+  # Address the in-process Prometheus/readiness endpoint listens on.
+  RECONCILE_METRICS_ADDR: "0.0.0.0:9000"
+  # How often (seconds) to re-resolve peers, and how many consecutive misses before a vanished pod
+  # is decommissioned (so its tombstones stop gating garbage collection).
+  RECONCILE_DISCOVERY_INTERVAL_SECS: "5"
+  RECONCILE_DISCOVERY_MISS_THRESHOLD: "3"
+  RECONCILE_LOG_LEVEL: "info"

--- a/deploy/k8s/secret.example.yaml
+++ b/deploy/k8s/secret.example.yaml
@@ -1,0 +1,18 @@
+# EXAMPLE ONLY — do not commit a real key. The 32-byte cluster key authenticates (and, with the
+# `encryption` feature, encrypts) every datagram; every pod must share the identical key.
+#
+# Generate one as 64 hex characters, e.g.:
+#   openssl rand -hex 32
+# then create the Secret without writing it to a file:
+#   kubectl create secret generic reconcile-secret \
+#     --from-literal=cluster-key="$(openssl rand -hex 32)"
+apiVersion: v1
+kind: Secret
+metadata:
+  name: reconcile-secret
+  labels:
+    app: reconcile
+type: Opaque
+stringData:
+  # 64 hex chars = 32 bytes. Replace before applying.
+  cluster-key: "0000000000000000000000000000000000000000000000000000000000000000"

--- a/deploy/k8s/service.yaml
+++ b/deploy/k8s/service.yaml
@@ -1,0 +1,24 @@
+# Headless Service: `clusterIP: None` makes the DNS name resolve to one A/AAAA record per ready
+# pod, which is exactly what `DnsDiscovery` consumes to find peers. It also gives the StatefulSet
+# its stable per-pod DNS names.
+apiVersion: v1
+kind: Service
+metadata:
+  name: reconcile-headless
+  labels:
+    app: reconcile
+spec:
+  clusterIP: None
+  # Only advertise ready pods, so a pod that is starting up or failing its probes is not gossiped to.
+  publishNotReadyAddresses: false
+  selector:
+    app: reconcile
+  ports:
+    - name: gossip
+      port: 8080
+      protocol: UDP
+      targetPort: gossip
+    - name: metrics
+      port: 9000
+      protocol: TCP
+      targetPort: metrics

--- a/deploy/k8s/statefulset.yaml
+++ b/deploy/k8s/statefulset.yaml
@@ -1,0 +1,71 @@
+# A StatefulSet gives each pod a stable name (reconcile-0, reconcile-1, …) and stable DNS, from
+# which `k8s_node` derives a stable node id for the HLC tie-break. Peers are discovered purely via
+# the headless Service DNS — no Kubernetes API access or RBAC is required.
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: reconcile
+  labels:
+    app: reconcile
+spec:
+  serviceName: reconcile-headless # must match the headless Service for stable pod DNS
+  replicas: 3
+  selector:
+    matchLabels:
+      app: reconcile
+  template:
+    metadata:
+      labels:
+        app: reconcile
+    spec:
+      # Give pods a moment to deregister from the Service DNS on shutdown.
+      terminationGracePeriodSeconds: 15
+      containers:
+        - name: reconcile
+          # Replace with your built image (see Dockerfile).
+          image: ghcr.io/akvize/reconcile:latest
+          imagePullPolicy: IfNotPresent
+          envFrom:
+            - configMapRef:
+                name: reconcile-config
+          env:
+            # Downward API: bind to the pod IP and derive identity from the pod name.
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            # Shared cluster key from the Secret (see secret.example.yaml).
+            - name: RECONCILE_CLUSTER_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: reconcile-secret
+                  key: cluster-key
+          ports:
+            - name: gossip
+              containerPort: 8080
+              protocol: UDP
+            - name: metrics
+              containerPort: 9000
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /metrics
+              port: metrics
+            initialDelaySeconds: 3
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /metrics
+              port: metrics
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              memory: 512Mi

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -14,7 +14,7 @@ use reconcile::{reconcile_store::Config, ReconcileStore};
 struct Args {
     port: u16,
     listen_addr: IpAddr,
-    local_region: IpNet,
+    net: IpNet,
     elements: usize,
     #[arg(short, long)]
     seed: Vec<IpAddr>,
@@ -27,7 +27,7 @@ async fn main() {
     let Args {
         port,
         listen_addr,
-        local_region,
+        net,
         seed,
         elements,
         log_level,
@@ -35,7 +35,7 @@ async fn main() {
     let config = Config::default()
         .with_port(port)
         .with_listen_addr(listen_addr)
-        .with_local_region(local_region);
+        .with_net(net);
     tracing_subscriber::fmt().with_max_level(log_level).init();
 
     // build collection

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -14,7 +14,7 @@ use reconcile::{reconcile_store::Config, ReconcileStore};
 struct Args {
     port: u16,
     listen_addr: IpAddr,
-    peer_net: IpNet,
+    local_region: IpNet,
     elements: usize,
     #[arg(short, long)]
     seed: Vec<IpAddr>,
@@ -27,7 +27,7 @@ async fn main() {
     let Args {
         port,
         listen_addr,
-        peer_net,
+        local_region,
         seed,
         elements,
         log_level,
@@ -35,7 +35,7 @@ async fn main() {
     let config = Config::default()
         .with_port(port)
         .with_listen_addr(listen_addr)
-        .with_peer_net(peer_net);
+        .with_local_region(local_region);
     tracing_subscriber::fmt().with_max_level(log_level).init();
 
     // build collection

--- a/examples/k8s_node.rs
+++ b/examples/k8s_node.rs
@@ -1,0 +1,120 @@
+// Copyright 2023 Developers of the reconcile project.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! A Kubernetes-native reconcile node.
+//!
+//! It binds to its pod IP, derives a stable node identity from the pod name, discovers its peers by
+//! resolving a headless `Service` over DNS, and exposes a `/metrics` endpoint for the kubelet
+//! probes. Everything is taken from the environment (the Kubernetes downward API + a ConfigMap /
+//! Secret), so the same image works for every replica. See `deploy/k8s/` for the manifests.
+//!
+//! Run it with the metrics endpoint built in:
+//!
+//! ```sh
+//! cargo run --release --example k8s_node --features metrics-prometheus
+//! ```
+
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+use std::net::{IpAddr, SocketAddr};
+use std::time::Duration;
+
+use tracing::{info, warn};
+
+use reconcile::{reconcile_store::Config, ReconcileStore};
+
+/// Read a required environment variable or exit with a clear message.
+fn required(name: &str) -> String {
+    std::env::var(name).unwrap_or_else(|_| panic!("missing required environment variable {name}"))
+}
+
+/// Read an optional environment variable, falling back to `default`.
+fn optional(name: &str, default: &str) -> String {
+    std::env::var(name).unwrap_or_else(|_| default.to_string())
+}
+
+/// Decode a 32-byte cluster key from a hex string (64 hex chars).
+fn parse_cluster_key(hex: &str) -> [u8; 32] {
+    let bytes: Vec<u8> = (0..hex.len())
+        .step_by(2)
+        .map(|i| {
+            u8::from_str_radix(&hex[i..i + 2], 16)
+                .expect("RECONCILE_CLUSTER_KEY must be valid hexadecimal")
+        })
+        .collect();
+    bytes
+        .try_into()
+        .expect("RECONCILE_CLUSTER_KEY must decode to exactly 32 bytes (64 hex chars)")
+}
+
+/// Derive a stable, per-pod node id from the (stable) StatefulSet pod name.
+fn node_id_from(pod_name: &str) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    pod_name.hash(&mut hasher);
+    hasher.finish()
+}
+
+#[tokio::main]
+async fn main() {
+    let log_level: tracing::Level = optional("RECONCILE_LOG_LEVEL", "info")
+        .parse()
+        .unwrap_or(tracing::Level::INFO);
+    tracing_subscriber::fmt().with_max_level(log_level).init();
+
+    // Identity & networking from the downward API.
+    let pod_ip: IpAddr = required("POD_IP")
+        .parse()
+        .expect("POD_IP must be a valid IP address");
+    let pod_name = optional("POD_NAME", "reconcile-node");
+    let port: u16 = optional("RECONCILE_PORT", "8080")
+        .parse()
+        .expect("RECONCILE_PORT must be a valid port number");
+
+    // Discovery & operational knobs from the ConfigMap.
+    let dns_name = required("RECONCILE_DNS_NAME");
+    let discovery_interval = Duration::from_secs(
+        optional("RECONCILE_DISCOVERY_INTERVAL_SECS", "5")
+            .parse()
+            .expect("RECONCILE_DISCOVERY_INTERVAL_SECS must be an integer"),
+    );
+    let miss_threshold: u32 = optional("RECONCILE_DISCOVERY_MISS_THRESHOLD", "3")
+        .parse()
+        .expect("RECONCILE_DISCOVERY_MISS_THRESHOLD must be an integer");
+    let metrics_addr: SocketAddr = optional("RECONCILE_METRICS_ADDR", "0.0.0.0:9000")
+        .parse()
+        .expect("RECONCILE_METRICS_ADDR must be host:port");
+
+    // Build the config. Note: NO `with_net` is declared — in Kubernetes, peers are found purely
+    // through DNS-resolved pod IPs, so the engine's random per-network probing is left disabled.
+    let mut config = Config::default()
+        .with_port(port)
+        .with_listen_addr(pod_ip)
+        .with_node_id(node_id_from(&pod_name));
+
+    match std::env::var("RECONCILE_CLUSTER_KEY") {
+        Ok(hex) if !hex.is_empty() => config = config.with_cluster_key(parse_cluster_key(&hex)),
+        _ => warn!(
+            "RECONCILE_CLUSTER_KEY is unset: the cluster runs UNAUTHENTICATED. Set it (from a \
+             Kubernetes Secret) on every pod in production."
+        ),
+    }
+
+    // Expose /metrics for the kubelet readiness/liveness probes.
+    reconcile::prometheus::serve(metrics_addr)
+        .await
+        .expect("failed to start the metrics endpoint");
+
+    let store = ReconcileStore::<String, String>::new(config)
+        .await
+        .with_dns_discovery(dns_name, port)
+        .with_discovery_interval(discovery_interval)
+        .with_discovery_miss_threshold(miss_threshold);
+
+    info!(%pod_ip, %pod_name, port, "reconcile k8s node starting; discovering peers over DNS");
+    store.run().await;
+}

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -6,28 +6,40 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-//! Dynamic peer discovery for cloud-native deployments.
+//! Dynamic peer discovery, behind a single port.
 //!
-//! By default a [`ReconcileStore`](crate::ReconcileStore) discovers peers by probing random
-//! addresses out of the declared networks ([`Config::with_net`](crate::reconcile_store::Config::with_net)).
-//! That works for flat or geographically partitioned CIDRs, but not for Kubernetes, where pod IPs
-//! are ephemeral and drawn from a large cluster CIDR — a random probe almost never hits a live pod.
+//! Every way a [`ReconcileStore`](crate::ReconcileStore) learns about peers goes through the
+//! [`Discovery`] port. Two built-in adapters implement it:
 //!
-//! This module adds an **optional, additive** discovery source: an implementation of the
-//! [`Discovery`] port returns the *current* set of peer addresses, which the store injects into its
-//! known-peer set every round (via [`ReconcileStore::seed_peer`](crate::ReconcileStore::seed_peer)).
-//! The built-in [`DnsDiscovery`] adapter resolves a **headless Service** DNS name (one address
-//! record per ready pod) — the canonical Kubernetes StatefulSet peer-discovery pattern, requiring
-//! no API client and no RBAC.
+//! - [`RandomProbe`] — the **default, speculative** source: one random address per declared network
+//!   each round ([`Config::with_net`](crate::reconcile_store::Config::with_net)). The probed address
+//!   might not be a live peer, so it is only used as a one-shot reconciliation target and is **not**
+//!   added to the known-peer set. This is what auto-discovers peers on a flat or geographically
+//!   partitioned CIDR. It is [non-authoritative](Discovery::is_authoritative).
+//! - [`DnsDiscovery`] — an **authoritative** source for Kubernetes: it resolves a **headless
+//!   Service** DNS name (one address record per ready pod), so a single lookup yields the real,
+//!   current peer set, with no API client and no RBAC. Random probing does not fit Kubernetes, where
+//!   pod IPs are ephemeral and drawn from a large cluster CIDR — a random probe almost never hits a
+//!   live pod.
 //!
-//! Discovery only ever feeds the gossip-target set; it never grants causal-stability *membership*,
-//! which a peer must still earn through a genuine authenticated, dated datagram. See
-//! [`ReconcileStore::with_dns_discovery`](crate::ReconcileStore::with_dns_discovery) for the
-//! grace-period decommissioning of pods that disappear from DNS.
+//! An **authoritative** result is treated as the current truth: each returned address is seeded into
+//! the known-peer set (via [`ReconcileStore::seed_peer`](crate::ReconcileStore::seed_peer)), and a
+//! previously-seen member now absent is decommissioned after a grace period (see
+//! [`ReconcileStore::with_dns_discovery`](crate::ReconcileStore::with_dns_discovery)). A
+//! non-authoritative result is speculative and only steers the current round's targets. In **all**
+//! cases discovery feeds the gossip-target set only; it never grants causal-stability *membership*,
+//! which a peer must still earn through a genuine authenticated, dated datagram.
 
 use std::future::Future;
 use std::net::IpAddr;
 use std::pin::Pin;
+use std::sync::Arc;
+
+use ipnet::IpNet;
+use parking_lot::RwLock;
+use rand::rngs::StdRng;
+
+use crate::gen_ip::probe_targets;
 
 /// The future returned by [`Discovery::discover`].
 ///
@@ -38,17 +50,57 @@ pub type DiscoverFuture<'a> =
 
 /// A source of candidate peer addresses for the reconciliation engine.
 ///
-/// [`discover`](Self::discover) is called once per discovery round. The result is interpreted as
-/// follows:
+/// [`discover`](Self::discover) is called once per discovery round. The result is interpreted
+/// according to [`is_authoritative`](Self::is_authoritative):
 ///
-/// - `Ok(addrs)` is an **authoritative snapshot** of the peers that should exist right now. Any
-///   address present refreshes the corresponding known peer; a previously-seen member that is
-///   *absent* from the snapshot is counted toward grace-period decommissioning.
+/// - `Ok(addrs)` from an **authoritative** source is a snapshot of the peers that should exist right
+///   now: each address refreshes the corresponding known peer, and a previously-seen member that is
+///   *absent* is counted toward grace-period decommissioning. From a **non-authoritative** source it
+///   is speculative — only the current round's targets, never seeded as known peers.
 /// - `Err(_)` is a **transient failure** (e.g. a DNS blip). It MUST NOT be read as "no peers": the
 ///   store skips the round entirely, so a momentary resolver hiccup never decommissions anyone.
 pub trait Discovery: Send + Sync + 'static {
     /// Resolve the current candidate peer set.
     fn discover(&self) -> DiscoverFuture<'_>;
+
+    /// Whether [`discover`](Self::discover) returns the *authoritative* current peer set (so an
+    /// absence drives decommissioning), or merely *speculative* probe targets.
+    ///
+    /// Defaults to `true`; the speculative [`RandomProbe`] overrides it to `false`.
+    fn is_authoritative(&self) -> bool {
+        true
+    }
+}
+
+/// The default, **speculative** discovery: one random address per declared network each round.
+///
+/// This is the historical auto-discovery for flat or geographically partitioned CIDRs (issue #53).
+/// The probed addresses might not be live peers, so they are used only as one-shot reconciliation
+/// targets and never seeded as known peers — if a peer exists there, it replies and is registered
+/// then. It shares the engine's live `nets` and `rng`, so retuning the topology at runtime
+/// immediately changes what is probed.
+pub struct RandomProbe {
+    nets: Arc<RwLock<Vec<IpNet>>>,
+    rng: Arc<RwLock<StdRng>>,
+}
+
+impl RandomProbe {
+    pub(crate) fn new(nets: Arc<RwLock<Vec<IpNet>>>, rng: Arc<RwLock<StdRng>>) -> Self {
+        RandomProbe { nets, rng }
+    }
+}
+
+impl Discovery for RandomProbe {
+    fn discover(&self) -> DiscoverFuture<'_> {
+        // Sample synchronously (no lock is held across the returned, already-ready future).
+        let nets = self.nets.read().clone();
+        let targets = probe_targets(&mut *self.rng.write(), &nets);
+        Box::pin(async move { Ok(targets) })
+    }
+
+    fn is_authoritative(&self) -> bool {
+        false
+    }
 }
 
 /// Discovers peers by resolving a DNS name to its set of address records.
@@ -110,5 +162,26 @@ mod tests {
         // transient blip rather than an empty peer set.
         let discovery = DnsDiscovery::new("this-name-should-not-resolve.invalid", 0);
         assert!(discovery.discover().await.is_err());
+    }
+
+    #[test]
+    fn dns_discovery_is_authoritative() {
+        assert!(DnsDiscovery::new("svc", 0).is_authoritative());
+    }
+
+    #[tokio::test]
+    async fn random_probe_is_speculative_and_in_network() {
+        use rand::SeedableRng;
+        let net: IpNet = "127.0.0.0/8".parse().unwrap();
+        let probe = RandomProbe::new(
+            Arc::new(RwLock::new(vec![net])),
+            Arc::new(RwLock::new(StdRng::seed_from_u64(42))),
+        );
+        // Speculative: an absence must never decommission a peer.
+        assert!(!probe.is_authoritative());
+        // One probe per declared network, each within that network.
+        let addrs = probe.discover().await.unwrap();
+        assert_eq!(addrs.len(), 1);
+        assert!(net.contains(&addrs[0]), "{net} should contain {}", addrs[0]);
     }
 }

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -1,0 +1,114 @@
+// Copyright 2023 Developers of the reconcile project.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Dynamic peer discovery for cloud-native deployments.
+//!
+//! By default a [`ReconcileStore`](crate::ReconcileStore) discovers peers by probing random
+//! addresses out of the declared networks ([`Config::with_net`](crate::reconcile_store::Config::with_net)).
+//! That works for flat or geographically partitioned CIDRs, but not for Kubernetes, where pod IPs
+//! are ephemeral and drawn from a large cluster CIDR — a random probe almost never hits a live pod.
+//!
+//! This module adds an **optional, additive** discovery source: an implementation of the
+//! [`Discovery`] port returns the *current* set of peer addresses, which the store injects into its
+//! known-peer set every round (via [`ReconcileStore::seed_peer`](crate::ReconcileStore::seed_peer)).
+//! The built-in [`DnsDiscovery`] adapter resolves a **headless Service** DNS name (one address
+//! record per ready pod) — the canonical Kubernetes StatefulSet peer-discovery pattern, requiring
+//! no API client and no RBAC.
+//!
+//! Discovery only ever feeds the gossip-target set; it never grants causal-stability *membership*,
+//! which a peer must still earn through a genuine authenticated, dated datagram. See
+//! [`ReconcileStore::with_dns_discovery`](crate::ReconcileStore::with_dns_discovery) for the
+//! grace-period decommissioning of pods that disappear from DNS.
+
+use std::future::Future;
+use std::net::IpAddr;
+use std::pin::Pin;
+
+/// The future returned by [`Discovery::discover`].
+///
+/// A boxed future is used (rather than the `async_trait` crate) so the port stays object-safe —
+/// it is always consumed behind `Arc<dyn Discovery>` — without pulling in an extra dependency.
+pub type DiscoverFuture<'a> =
+    Pin<Box<dyn Future<Output = std::io::Result<Vec<IpAddr>>> + Send + 'a>>;
+
+/// A source of candidate peer addresses for the reconciliation engine.
+///
+/// [`discover`](Self::discover) is called once per discovery round. The result is interpreted as
+/// follows:
+///
+/// - `Ok(addrs)` is an **authoritative snapshot** of the peers that should exist right now. Any
+///   address present refreshes the corresponding known peer; a previously-seen member that is
+///   *absent* from the snapshot is counted toward grace-period decommissioning.
+/// - `Err(_)` is a **transient failure** (e.g. a DNS blip). It MUST NOT be read as "no peers": the
+///   store skips the round entirely, so a momentary resolver hiccup never decommissions anyone.
+pub trait Discovery: Send + Sync + 'static {
+    /// Resolve the current candidate peer set.
+    fn discover(&self) -> DiscoverFuture<'_>;
+}
+
+/// Discovers peers by resolving a DNS name to its set of address records.
+///
+/// Point this at a Kubernetes **headless** `Service` (`clusterIP: None`): its DNS name resolves to
+/// one A/AAAA record per ready pod, so a single lookup yields every peer. Resolution uses
+/// [`tokio::net::lookup_host`], i.e. the system resolver (`getaddrinfo`) — no extra dependency, and
+/// it honours the in-cluster DNS configuration.
+pub struct DnsDiscovery {
+    name: String,
+    port: u16,
+}
+
+impl DnsDiscovery {
+    /// Create a DNS-based discovery source for `name` (a resolvable host, typically a headless
+    /// Service FQDN such as `reconcile-headless.default.svc.cluster.local`). `port` is the
+    /// reconciliation UDP port; it is only used to form the `host:port` string `lookup_host`
+    /// expects and is discarded from the returned addresses.
+    pub fn new(name: impl Into<String>, port: u16) -> Self {
+        DnsDiscovery {
+            name: name.into(),
+            port,
+        }
+    }
+}
+
+impl Discovery for DnsDiscovery {
+    fn discover(&self) -> DiscoverFuture<'_> {
+        let host = format!("{}:{}", self.name, self.port);
+        Box::pin(async move {
+            let addrs = tokio::net::lookup_host(host).await?;
+            Ok(addrs.map(|sock_addr| sock_addr.ip()).collect())
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn dns_discovery_resolves_loopback() {
+        // `localhost` resolves to a loopback address through the system resolver; this is a smoke
+        // test that the adapter wires `lookup_host` up correctly and strips the port.
+        let discovery = DnsDiscovery::new("localhost", 0);
+        let addrs = discovery
+            .discover()
+            .await
+            .expect("localhost should resolve");
+        assert!(
+            addrs.iter().any(|ip| ip.is_loopback()),
+            "expected a loopback address, got {addrs:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn dns_discovery_errors_on_unresolvable_name() {
+        // A syntactically valid but unresolvable name yields an `Err`, which the store treats as a
+        // transient blip rather than an empty peer set.
+        let discovery = DnsDiscovery::new("this-name-should-not-resolve.invalid", 0);
+        assert!(discovery.discover().await.is_err());
+    }
+}

--- a/src/gen_ip.rs
+++ b/src/gen_ip.rs
@@ -78,7 +78,7 @@ pub fn region_of(regions: &[IpNet], addr: IpAddr) -> Option<IpNet> {
 ///
 /// It is the first configured region whose CIDR contains `listen_addr`; if none does (a
 /// misconfiguration), it falls back to the first region. `regions` must be non-empty (the local
-/// `peer_net` is always its first element).
+/// region is always its first element).
 pub fn local_region(regions: &[IpNet], listen_addr: IpAddr) -> IpNet {
     region_of(regions, listen_addr).unwrap_or(regions[0])
 }

--- a/src/gen_ip.rs
+++ b/src/gen_ip.rs
@@ -57,6 +57,32 @@ pub fn gen_ipv6<R: Rng>(rng: &mut R, network: Ipv6Net) -> Ipv6Addr {
     network.network().bitor(random.bitand(network.hostmask()))
 }
 
+/// One random probe address per region CIDR.
+///
+/// Used for multi-region peer auto-discovery (issue #53): a node probes one random address inside
+/// each configured geographical region every reconciliation round, so discovery spans every region
+/// rather than a single flat CIDR.
+pub fn probe_targets<R: Rng>(rng: &mut R, regions: &[IpNet]) -> Vec<IpAddr> {
+    regions.iter().map(|&net| gen_ip(rng, net)).collect()
+}
+
+/// Return the first region in `regions` whose CIDR contains `addr`, if any.
+///
+/// A peer's geographical region is derived purely from its IP address, so the wire format carries
+/// no region tag (issue #53).
+pub fn region_of(regions: &[IpNet], addr: IpAddr) -> Option<IpNet> {
+    regions.iter().copied().find(|net| net.contains(&addr))
+}
+
+/// The region a node belongs to, given the address it listens on.
+///
+/// It is the first configured region whose CIDR contains `listen_addr`; if none does (a
+/// misconfiguration), it falls back to the first region. `regions` must be non-empty (the local
+/// `peer_net` is always its first element).
+pub fn local_region(regions: &[IpNet], listen_addr: IpAddr) -> IpNet {
+    region_of(regions, listen_addr).unwrap_or(regions[0])
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::HashSet;
@@ -87,5 +113,50 @@ mod tests {
         for addr in addrs {
             assert!(net.contains(&addr), "{net} should contain {addr}");
         }
+    }
+
+    #[test]
+    fn probe_targets_one_per_region() {
+        use super::probe_targets;
+        let mut rng = rand::rngs::StdRng::seed_from_u64(42);
+        let regions = [
+            "127.0.0.0/30".parse().unwrap(),
+            "127.0.1.0/30".parse().unwrap(),
+            "10.0.0.0/8".parse().unwrap(),
+        ];
+        let targets = probe_targets(&mut rng, &regions);
+        assert_eq!(targets.len(), regions.len());
+        for (target, region) in targets.iter().zip(regions.iter()) {
+            assert!(region.contains(target), "{region} should contain {target}");
+        }
+    }
+
+    #[test]
+    fn region_classification() {
+        use super::{local_region, region_of};
+        let regions: Vec<_> = ["127.0.0.0/30", "127.0.1.0/30"]
+            .iter()
+            .map(|s| s.parse().unwrap())
+            .collect();
+        assert_eq!(
+            region_of(&regions, "127.0.0.1".parse().unwrap()),
+            Some(regions[0])
+        );
+        assert_eq!(
+            region_of(&regions, "127.0.1.1".parse().unwrap()),
+            Some(regions[1])
+        );
+        assert_eq!(region_of(&regions, "10.0.0.1".parse().unwrap()), None);
+
+        // The local region is the one containing the listen address.
+        assert_eq!(
+            local_region(&regions, "127.0.1.2".parse().unwrap()),
+            regions[1]
+        );
+        // Fallback to the first region when no region contains the listen address.
+        assert_eq!(
+            local_region(&regions, "10.0.0.1".parse().unwrap()),
+            regions[0]
+        );
     }
 }

--- a/src/gen_ip.rs
+++ b/src/gen_ip.rs
@@ -57,30 +57,33 @@ pub fn gen_ipv6<R: Rng>(rng: &mut R, network: Ipv6Net) -> Ipv6Addr {
     network.network().bitor(random.bitand(network.hostmask()))
 }
 
-/// One random probe address per region CIDR.
+/// One random probe address per network CIDR.
 ///
-/// Used for multi-region peer auto-discovery (issue #53): a node probes one random address inside
-/// each configured geographical region every reconciliation round, so discovery spans every region
-/// rather than a single flat CIDR.
-pub fn probe_targets<R: Rng>(rng: &mut R, regions: &[IpNet]) -> Vec<IpAddr> {
-    regions.iter().map(|&net| gen_ip(rng, net)).collect()
+/// Used for multi-network peer auto-discovery (issue #53): a node probes one random address inside
+/// each configured geographical network every reconciliation round, so discovery spans every
+/// network rather than a single flat CIDR.
+pub fn probe_targets<R: Rng>(rng: &mut R, nets: &[IpNet]) -> Vec<IpAddr> {
+    nets.iter().map(|&net| gen_ip(rng, net)).collect()
 }
 
-/// Return the first region in `regions` whose CIDR contains `addr`, if any.
+/// Return the first network in `nets` whose CIDR contains `addr`, if any.
 ///
-/// A peer's geographical region is derived purely from its IP address, so the wire format carries
-/// no region tag (issue #53).
-pub fn region_of(regions: &[IpNet], addr: IpAddr) -> Option<IpNet> {
-    regions.iter().copied().find(|net| net.contains(&addr))
+/// A peer's geographical network is derived purely from its IP address, so the wire format carries
+/// no network tag (issue #53).
+pub fn net_of(nets: &[IpNet], addr: IpAddr) -> Option<IpNet> {
+    nets.iter().copied().find(|net| net.contains(&addr))
 }
 
-/// The region a node belongs to, given the address it listens on.
+/// The host route (`/32` for IPv4, `/128` for IPv6) of a single address.
 ///
-/// It is the first configured region whose CIDR contains `listen_addr`; if none does (a
-/// misconfiguration), it falls back to the first region. `regions` must be non-empty (the local
-/// region is always its first element).
-pub fn local_region(regions: &[IpNet], listen_addr: IpAddr) -> IpNet {
-    region_of(regions, listen_addr).unwrap_or(regions[0])
+/// Used as the local network of last resort: when no configured network contains a node's listen
+/// address (a misconfiguration), the node treats only itself as local (issue #53).
+pub fn host_net(addr: IpAddr) -> IpNet {
+    let prefix_len = match addr {
+        IpAddr::V4(_) => 32,
+        IpAddr::V6(_) => 128,
+    };
+    IpNet::new(addr, prefix_len).expect("host prefix length is always valid")
 }
 
 #[cfg(test)]
@@ -116,47 +119,39 @@ mod tests {
     }
 
     #[test]
-    fn probe_targets_one_per_region() {
+    fn probe_targets_one_per_net() {
         use super::probe_targets;
         let mut rng = rand::rngs::StdRng::seed_from_u64(42);
-        let regions = [
+        let nets = [
             "127.0.0.0/30".parse().unwrap(),
             "127.0.1.0/30".parse().unwrap(),
             "10.0.0.0/8".parse().unwrap(),
         ];
-        let targets = probe_targets(&mut rng, &regions);
-        assert_eq!(targets.len(), regions.len());
-        for (target, region) in targets.iter().zip(regions.iter()) {
-            assert!(region.contains(target), "{region} should contain {target}");
+        let targets = probe_targets(&mut rng, &nets);
+        assert_eq!(targets.len(), nets.len());
+        for (target, net) in targets.iter().zip(nets.iter()) {
+            assert!(net.contains(target), "{net} should contain {target}");
         }
     }
 
     #[test]
-    fn region_classification() {
-        use super::{local_region, region_of};
-        let regions: Vec<_> = ["127.0.0.0/30", "127.0.1.0/30"]
+    fn net_classification() {
+        use super::{host_net, net_of};
+        let nets: Vec<_> = ["127.0.0.0/30", "127.0.1.0/30"]
             .iter()
             .map(|s| s.parse().unwrap())
             .collect();
-        assert_eq!(
-            region_of(&regions, "127.0.0.1".parse().unwrap()),
-            Some(regions[0])
-        );
-        assert_eq!(
-            region_of(&regions, "127.0.1.1".parse().unwrap()),
-            Some(regions[1])
-        );
-        assert_eq!(region_of(&regions, "10.0.0.1".parse().unwrap()), None);
+        // A peer is qualified by the first network whose CIDR contains it.
+        assert_eq!(net_of(&nets, "127.0.0.1".parse().unwrap()), Some(nets[0]));
+        assert_eq!(net_of(&nets, "127.0.1.1".parse().unwrap()), Some(nets[1]));
+        // An address in no declared network is unqualified.
+        assert_eq!(net_of(&nets, "10.0.0.1".parse().unwrap()), None);
 
-        // The local region is the one containing the listen address.
+        // The local-net-of-last-resort is the address' own host route.
         assert_eq!(
-            local_region(&regions, "127.0.1.2".parse().unwrap()),
-            regions[1]
+            host_net("10.0.0.1".parse().unwrap()),
+            "10.0.0.1/32".parse().unwrap()
         );
-        // Fallback to the first region when no region contains the listen address.
-        assert_eq!(
-            local_region(&regions, "10.0.0.1".parse().unwrap()),
-            regions[0]
-        );
+        assert_eq!(host_net("::1".parse().unwrap()), "::1/128".parse().unwrap());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@ pub(crate) mod reconcile_engine;
 pub(crate) mod timeout_wheel;
 
 pub use bounds::{Key, Value};
-pub use discovery::{DiscoverFuture, Discovery, DnsDiscovery};
+pub use discovery::{DiscoverFuture, Discovery, DnsDiscovery, RandomProbe};
 pub use fingerprint::Fingerprint;
 pub use hlc::Hlc;
 pub use hrtree::HRTree;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@
 //! threat model and scope.
 
 pub mod diff;
+pub mod discovery;
 pub mod fingerprint;
 pub mod gen_ip;
 pub mod hlc;
@@ -47,6 +48,7 @@ pub(crate) mod observability;
 pub(crate) mod reconcile_engine;
 pub(crate) mod timeout_wheel;
 
+pub use discovery::{DiscoverFuture, Discovery, DnsDiscovery};
 pub use fingerprint::Fingerprint;
 pub use hlc::Hlc;
 pub use hrtree::HRTree;

--- a/src/mirror.rs
+++ b/src/mirror.rs
@@ -65,7 +65,7 @@ use tracing::{debug, trace, warn};
 use crate::auth;
 use crate::diff::{Diffable, HashRangeQueryable};
 use crate::fingerprint::Fingerprint;
-use crate::gen_ip::gen_ip;
+use crate::gen_ip::{gen_ip, net_of};
 use crate::hlc::Hlc;
 use crate::reconcilable::ValueOnly;
 use crate::reconcile_engine::{send_messages_to, send_to_retry, Message};
@@ -93,7 +93,10 @@ pub struct ReconcileMirror<K, V> {
     tree: Arc<RwLock<HRTree<K, ValueOnly<V>>>>,
     port: u16,
     socket: Arc<UdpSocket>,
-    local_region: IpNet,
+    /// The single network this read-only mirror probes for discovery (issue #53). A mirror is a
+    /// dateless sink, usually seeded onto a dated cluster, so it tracks just one network: the one
+    /// containing its listen address, else the first declared network, else the loopback default.
+    net: IpNet,
     rng: Arc<RwLock<StdRng>>,
     peers: Arc<RwLock<HashMap<IpAddr, Instant>>>,
     authenticator: auth::Authenticator,
@@ -107,7 +110,7 @@ impl<K, V> Clone for ReconcileMirror<K, V> {
             tree: self.tree.clone(),
             port: self.port,
             socket: self.socket.clone(),
-            local_region: self.local_region,
+            net: self.net,
             rng: self.rng.clone(),
             peers: self.peers.clone(),
             authenticator: self.authenticator.clone(),
@@ -142,11 +145,17 @@ impl<
                  datagrams. Set Config::with_cluster_key to match the dated cluster."
             );
         }
+        // A mirror tracks a single network: the one containing its listen address, else the first
+        // declared network, else the historical loopback default.
+        let nets: Vec<IpNet> = config.nets.iter().flatten().copied().collect();
+        let net = net_of(&nets, config.listen_addr)
+            .or_else(|| nets.first().copied())
+            .unwrap_or_else(|| "127.0.0.1/8".parse().unwrap());
         ReconcileMirror {
             tree: Arc::new(RwLock::new(HRTree::<K, ValueOnly<V>>::new())),
             port: config.port,
             socket: Arc::new(socket),
-            local_region: config.local_region,
+            net,
             rng: Arc::new(RwLock::new(StdRng::from_entropy())),
             peers: Arc::new(RwLock::new(HashMap::new())),
             authenticator,
@@ -233,7 +242,7 @@ impl<
         let mut peers = self.get_peers();
         // A random address out of the peer network, for discovery — like the dated store, we do not
         // add it to the known peers; a real peer there will answer and be recorded then.
-        let addr = gen_ip(&mut *self.rng.write(), self.local_region);
+        let addr = gen_ip(&mut *self.rng.write(), self.net);
         peers.push(addr);
         for peer in peers {
             trace!("mirror start_diff {} bytes to {peer}", send_buf.len());
@@ -357,20 +366,11 @@ impl<
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::reconcile_store::{Config, MAX_REGIONS};
+    use crate::reconcile_store::Config;
 
     fn ephemeral_config() -> Config {
-        Config {
-            port: 0,
-            listen_addr: "127.0.0.1".parse().unwrap(),
-            local_region: "127.0.0.1/8".parse().unwrap(),
-            remote_regions: [None; MAX_REGIONS],
-            cross_region_interval: 6,
-            cross_region_fanout: 2,
-            cluster_key: None,
-            node_id: None,
-            encrypt: false,
-        }
+        // Port 0 (ephemeral) on the loopback default network.
+        Config::default()
     }
 
     /// `get` returns the live value, and absent keys are `None`.

--- a/src/mirror.rs
+++ b/src/mirror.rs
@@ -357,13 +357,16 @@ impl<
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::reconcile_store::Config;
+    use crate::reconcile_store::{Config, MAX_REGIONS};
 
     fn ephemeral_config() -> Config {
         Config {
             port: 0,
             listen_addr: "127.0.0.1".parse().unwrap(),
             peer_net: "127.0.0.1/8".parse().unwrap(),
+            regions: [None; MAX_REGIONS],
+            cross_region_interval: 6,
+            remote_fanout: 2,
             cluster_key: None,
             node_id: None,
             encrypt: false,

--- a/src/mirror.rs
+++ b/src/mirror.rs
@@ -93,7 +93,7 @@ pub struct ReconcileMirror<K, V> {
     tree: Arc<RwLock<HRTree<K, ValueOnly<V>>>>,
     port: u16,
     socket: Arc<UdpSocket>,
-    peer_net: IpNet,
+    local_region: IpNet,
     rng: Arc<RwLock<StdRng>>,
     peers: Arc<RwLock<HashMap<IpAddr, Instant>>>,
     authenticator: auth::Authenticator,
@@ -107,7 +107,7 @@ impl<K, V> Clone for ReconcileMirror<K, V> {
             tree: self.tree.clone(),
             port: self.port,
             socket: self.socket.clone(),
-            peer_net: self.peer_net,
+            local_region: self.local_region,
             rng: self.rng.clone(),
             peers: self.peers.clone(),
             authenticator: self.authenticator.clone(),
@@ -146,7 +146,7 @@ impl<
             tree: Arc::new(RwLock::new(HRTree::<K, ValueOnly<V>>::new())),
             port: config.port,
             socket: Arc::new(socket),
-            peer_net: config.peer_net,
+            local_region: config.local_region,
             rng: Arc::new(RwLock::new(StdRng::from_entropy())),
             peers: Arc::new(RwLock::new(HashMap::new())),
             authenticator,
@@ -233,7 +233,7 @@ impl<
         let mut peers = self.get_peers();
         // A random address out of the peer network, for discovery — like the dated store, we do not
         // add it to the known peers; a real peer there will answer and be recorded then.
-        let addr = gen_ip(&mut *self.rng.write(), self.peer_net);
+        let addr = gen_ip(&mut *self.rng.write(), self.local_region);
         peers.push(addr);
         for peer in peers {
             trace!("mirror start_diff {} bytes to {peer}", send_buf.len());
@@ -363,10 +363,10 @@ mod tests {
         Config {
             port: 0,
             listen_addr: "127.0.0.1".parse().unwrap(),
-            peer_net: "127.0.0.1/8".parse().unwrap(),
-            regions: [None; MAX_REGIONS],
+            local_region: "127.0.0.1/8".parse().unwrap(),
+            remote_regions: [None; MAX_REGIONS],
             cross_region_interval: 6,
-            remote_fanout: 2,
+            cross_region_fanout: 2,
             cluster_key: None,
             node_id: None,
             encrypt: false,

--- a/src/mirror.rs
+++ b/src/mirror.rs
@@ -96,7 +96,8 @@ pub struct ReconcileMirror<K, V> {
     /// The single network this read-only mirror probes for discovery (issue #53). A mirror is a
     /// dateless sink, usually seeded onto a dated cluster, so it tracks just one network: the one
     /// containing its listen address, else the first declared network, else the loopback default.
-    net: IpNet,
+    /// Shared so it can be retuned at runtime (see [`set_net`](Self::set_net)).
+    net: Arc<RwLock<IpNet>>,
     rng: Arc<RwLock<StdRng>>,
     peers: Arc<RwLock<HashMap<IpAddr, Instant>>>,
     authenticator: auth::Authenticator,
@@ -110,7 +111,7 @@ impl<K, V> Clone for ReconcileMirror<K, V> {
             tree: self.tree.clone(),
             port: self.port,
             socket: self.socket.clone(),
-            net: self.net,
+            net: self.net.clone(),
             rng: self.rng.clone(),
             peers: self.peers.clone(),
             authenticator: self.authenticator.clone(),
@@ -155,7 +156,7 @@ impl<
             tree: Arc::new(RwLock::new(HRTree::<K, ValueOnly<V>>::new())),
             port: config.port,
             socket: Arc::new(socket),
-            net,
+            net: Arc::new(RwLock::new(net)),
             rng: Arc::new(RwLock::new(StdRng::from_entropy())),
             peers: Arc::new(RwLock::new(HashMap::new())),
             authenticator,
@@ -167,6 +168,16 @@ impl<
     pub fn with_seed(self, peer: IpAddr) -> Self {
         self.peers.write().insert(peer, Instant::now());
         self
+    }
+
+    /// (runtime) Retune the network this mirror probes for discovery, visible to all clones.
+    pub fn set_net(&self, net: IpNet) {
+        *self.net.write() = net;
+    }
+
+    /// The network this mirror currently probes for discovery.
+    pub fn net(&self) -> IpNet {
+        *self.net.read()
     }
 
     /// Register a hook invoked (outside the map lock) just before each inbound value is integrated.
@@ -242,7 +253,8 @@ impl<
         let mut peers = self.get_peers();
         // A random address out of the peer network, for discovery — like the dated store, we do not
         // add it to the known peers; a real peer there will answer and be recorded then.
-        let addr = gen_ip(&mut *self.rng.write(), self.net);
+        let net = *self.net.read();
+        let addr = gen_ip(&mut *self.rng.write(), net);
         peers.push(addr);
         for peer in peers {
             trace!("mirror start_diff {} bytes to {peer}", send_buf.len());

--- a/src/reconcile_engine.rs
+++ b/src/reconcile_engine.rs
@@ -15,6 +15,7 @@ use std::fmt::Debug;
 use std::hash::{Hash, Hasher};
 use std::net::{IpAddr, SocketAddr};
 use std::ops::RangeBounds;
+use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -22,6 +23,7 @@ use bincode::{DefaultOptions, Deserializer, Serializer};
 use ipnet::IpNet;
 use parking_lot::RwLock;
 use rand::rngs::StdRng;
+use rand::seq::SliceRandom;
 use rand::SeedableRng;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use tokio::net::{ToSocketAddrs, UdpSocket};
@@ -32,7 +34,7 @@ use crate::auth;
 use crate::diff::HashRangeQueryable;
 use crate::diff::{Diffable, HashSegment};
 use crate::fingerprint::Fingerprint;
-use crate::gen_ip::gen_ip;
+use crate::gen_ip::{local_region, probe_targets};
 use crate::hlc::{Hlc, HlcClock, Timestamped};
 use crate::observability;
 use crate::reconcilable::{MaybeTombstone, Projectable, Reconcilable};
@@ -83,7 +85,19 @@ pub(crate) struct Inner<K, V: Projectable> {
     pub(crate) projection: Arc<RwLock<HRTree<K, V::Projected>>>,
     port: u16,
     socket: Arc<UdpSocket>,
-    peer_net: IpNet,
+    /// Geographical regions, each a CIDR (issue #53). `regions[0]` is the local `peer_net`,
+    /// followed by every additional remote region. One random address is probed per region each
+    /// round for auto-discovery, and a peer's region is derived from its IP via `IpNet::contains`.
+    regions: Vec<IpNet>,
+    /// The region containing this node's listen address — the one it reconciles with aggressively.
+    local_region: IpNet,
+    /// Send the full anti-entropy comparison to remote-region peers every `cross_region_interval`
+    /// rounds (the [`round`](Self::round) counter); local-region peers are contacted every round.
+    cross_region_interval: u32,
+    /// Max peers contacted per remote region on each cross-region round (bounds WAN fan-out).
+    remote_fanout: usize,
+    /// Monotonic reconciliation-round counter, shared across clones, gating the cross-region cadence.
+    round: Arc<AtomicU32>,
     rng: Arc<RwLock<StdRng>>,
     pub(crate) peers: Arc<RwLock<HashMap<IpAddr, Instant>>>,
     pub(crate) pre_insert: Arc<RwLock<PreInsertCallback<K, V>>>,
@@ -96,6 +110,12 @@ pub(crate) struct Inner<K, V: Projectable> {
     /// it can be garbage-collected. This is what gates tombstone GC on *causal stability* and
     /// prevents a peer that is partitioned for longer than the peer-expiration window from
     /// resurrecting a deleted value on its return.
+    ///
+    /// Multi-region note (issue #53): remote-region members are gossiped to on a slower cadence, so
+    /// their tombstone acknowledgments arrive later and cross-region GC is correspondingly slower —
+    /// but still strictly correct, since GC never proceeds before *every* member has acked. Lowering
+    /// [`Config::cross_region_interval`] or raising [`Config::remote_fanout`] speeds it up at the
+    /// cost of WAN traffic.
     pub(crate) members: Arc<RwLock<HashSet<IpAddr>>>,
     /// Per-tombstone acknowledgments: `key -> (peer -> version token of the tombstone it holds)`.
     pub(crate) tombstone_acks: Arc<RwLock<HashMap<K, HashMap<IpAddr, u64>>>>,
@@ -188,13 +208,21 @@ impl<
         let map = HRTree::<K, V>::new();
         let projection = HRTree::<K, V::Projected>::new();
         let node_id = config.node_id.unwrap_or_else(rand::random);
+        // The local `peer_net` is region 0, followed by every additional configured region.
+        let mut regions = vec![config.peer_net];
+        regions.extend(config.regions.iter().flatten().copied());
+        let local_region = local_region(&regions, config.listen_addr);
         ReconcileEngine {
             inner: Arc::new(Inner {
                 map: Arc::new(RwLock::new(map)),
                 projection: Arc::new(RwLock::new(projection)),
                 port: config.port,
                 socket: Arc::new(socket),
-                peer_net: config.peer_net,
+                regions,
+                local_region,
+                cross_region_interval: config.cross_region_interval,
+                remote_fanout: config.remote_fanout,
+                round: Arc::new(AtomicU32::new(0)),
                 rng: Arc::new(RwLock::new(StdRng::from_entropy())),
                 peers: Arc::new(RwLock::new(HashMap::new())),
                 pre_insert: Arc::new(RwLock::new(Box::new(|_, _| {}))),
@@ -236,6 +264,11 @@ impl<
     /// Mint a fresh Hybrid Logical Clock timestamp for a local write.
     pub fn clock_now(&self) -> Hlc {
         self.clock.now()
+    }
+
+    /// Whether `addr` belongs to this node's local geographical region (issue #53).
+    fn is_local(&self, addr: IpAddr) -> bool {
+        self.local_region.contains(&addr)
     }
 
     fn get_peers(&self) -> Vec<IpAddr> {
@@ -403,16 +436,48 @@ impl<
                 .serialize(&mut Serializer::new(&mut *send_buf, DefaultOptions::new()))
                 .expect("serializing a ComparisonItem into an in-memory buffer cannot fail");
         }
-        let mut peers = self.get_peers();
-        // select a random address out of the peer network
-        // NOTE: the random address might not correspond to a real peer, so we do not add it to the
-        // list of known peers, just to our local copies of the addresses; if a peer exists at this
-        // address, they will eventually send us a message in return, and we will add them to the
-        // list of known peer
-        let addr = gen_ip(&mut *self.rng.write(), self.peer_net);
-        peers.push(addr);
-        // initiate the reconciliation protocol with all the known peers, and a random one
-        for peer in peers {
+        // Geography-aware target selection (issue #53). With a single region this reduces to the
+        // historical behaviour: every known peer is local, so all of them are contacted each round,
+        // plus a single random discovery probe.
+        let round = self.round.fetch_add(1, Ordering::Relaxed);
+        // Treat an interval of 0 as "every round" to avoid a modulo-by-zero.
+        let do_cross_region = round.is_multiple_of(self.cross_region_interval.max(1));
+        let known = self.get_peers();
+
+        // De-duplicate so a discovery probe that happens to hit a known peer is not sent twice.
+        let mut targets: HashSet<IpAddr> = HashSet::new();
+
+        // Discovery: one random probe per region. The probed address might not correspond to a real
+        // peer, so we do NOT add it to the known-peer list; if a peer exists there, it will reply
+        // and be registered then.
+        {
+            let mut rng = self.rng.write();
+            targets.extend(probe_targets(&mut *rng, &self.regions));
+        }
+
+        // Local region: contact every known peer, every round (fast intra-region convergence).
+        for &addr in &known {
+            if self.is_local(addr) {
+                targets.insert(addr);
+            }
+        }
+
+        // Remote regions: only on cross-region rounds, and only a bounded random subset per region,
+        // to keep WAN fan-out bounded without designating any node as a relay/gateway.
+        if do_cross_region {
+            for region in self.regions.iter().filter(|&&r| r != self.local_region) {
+                let mut remote: Vec<IpAddr> = known
+                    .iter()
+                    .copied()
+                    .filter(|addr| region.contains(addr))
+                    .collect();
+                remote.shuffle(&mut *self.rng.write());
+                targets.extend(remote.into_iter().take(self.remote_fanout));
+            }
+        }
+
+        // initiate the reconciliation protocol with the selected peers and discovery probes
+        for peer in targets {
             trace!("start_diff {} bytes to {peer}", send_buf.len());
             send_to_retry(
                 &self.socket,

--- a/src/reconcile_engine.rs
+++ b/src/reconcile_engine.rs
@@ -855,6 +855,29 @@ impl<
             key_acks.remove(&peer);
         }
     }
+
+    /// Register (or refresh) a known peer at runtime, the `&self` counterpart of the
+    /// [`with_seed`](crate::ReconcileStore::with_seed) builder.
+    ///
+    /// Inserting into [`peers`](Self::peers) (re)arms the `PEER_EXPIRATION` window and makes the
+    /// address a gossip target on the next round. This is what a dynamic discovery source (e.g.
+    /// DNS-based Kubernetes discovery) calls each round for every resolved peer. It deliberately
+    /// does **not** touch [`members`](Self::members): membership — which gates tombstone GC — must
+    /// still be *earned* by a genuine authenticated, dated datagram, so an unverified discovered
+    /// address can never block garbage collection.
+    pub(crate) fn seed_peer(&self, peer: IpAddr) {
+        self.peers.write().insert(peer, Instant::now());
+    }
+
+    /// A snapshot of the monotonic membership set (peers that gate tombstone GC).
+    pub(crate) fn members_snapshot(&self) -> HashSet<IpAddr> {
+        self.members.read().clone()
+    }
+
+    /// This node's configured listen address, used by discovery to never decommission itself.
+    pub(crate) fn listen_addr(&self) -> IpAddr {
+        self.listen_addr
+    }
 }
 
 pub(crate) async fn send_to_retry<A: ToSocketAddrs>(

--- a/src/reconcile_engine.rs
+++ b/src/reconcile_engine.rs
@@ -85,8 +85,8 @@ pub(crate) struct Inner<K, V: Projectable> {
     pub(crate) projection: Arc<RwLock<HRTree<K, V::Projected>>>,
     port: u16,
     socket: Arc<UdpSocket>,
-    /// Geographical regions, each a CIDR (issue #53). `regions[0]` is the local `peer_net`,
-    /// followed by every additional remote region. One random address is probed per region each
+    /// Geographical regions, each a CIDR (issue #53). `regions[0]` is the local region
+    /// (`Config::local_region`), followed by every additional remote region. One random address is probed per region each
     /// round for auto-discovery, and a peer's region is derived from its IP via `IpNet::contains`.
     regions: Vec<IpNet>,
     /// The region containing this node's listen address — the one it reconciles with aggressively.
@@ -95,7 +95,7 @@ pub(crate) struct Inner<K, V: Projectable> {
     /// rounds (the [`round`](Self::round) counter); local-region peers are contacted every round.
     cross_region_interval: u32,
     /// Max peers contacted per remote region on each cross-region round (bounds WAN fan-out).
-    remote_fanout: usize,
+    cross_region_fanout: usize,
     /// Monotonic reconciliation-round counter, shared across clones, gating the cross-region cadence.
     round: Arc<AtomicU32>,
     rng: Arc<RwLock<StdRng>>,
@@ -114,7 +114,7 @@ pub(crate) struct Inner<K, V: Projectable> {
     /// Multi-region note (issue #53): remote-region members are gossiped to on a slower cadence, so
     /// their tombstone acknowledgments arrive later and cross-region GC is correspondingly slower —
     /// but still strictly correct, since GC never proceeds before *every* member has acked. Lowering
-    /// [`Config::cross_region_interval`] or raising [`Config::remote_fanout`] speeds it up at the
+    /// [`Config::cross_region_interval`] or raising [`Config::cross_region_fanout`] speeds it up at the
     /// cost of WAN traffic.
     pub(crate) members: Arc<RwLock<HashSet<IpAddr>>>,
     /// Per-tombstone acknowledgments: `key -> (peer -> version token of the tombstone it holds)`.
@@ -208,9 +208,9 @@ impl<
         let map = HRTree::<K, V>::new();
         let projection = HRTree::<K, V::Projected>::new();
         let node_id = config.node_id.unwrap_or_else(rand::random);
-        // The local `peer_net` is region 0, followed by every additional configured region.
-        let mut regions = vec![config.peer_net];
-        regions.extend(config.regions.iter().flatten().copied());
+        // The local region is region 0, followed by every additional configured remote region.
+        let mut regions = vec![config.local_region];
+        regions.extend(config.remote_regions.iter().flatten().copied());
         let local_region = local_region(&regions, config.listen_addr);
         ReconcileEngine {
             inner: Arc::new(Inner {
@@ -221,7 +221,7 @@ impl<
                 regions,
                 local_region,
                 cross_region_interval: config.cross_region_interval,
-                remote_fanout: config.remote_fanout,
+                cross_region_fanout: config.cross_region_fanout,
                 round: Arc::new(AtomicU32::new(0)),
                 rng: Arc::new(RwLock::new(StdRng::from_entropy())),
                 peers: Arc::new(RwLock::new(HashMap::new())),
@@ -472,7 +472,7 @@ impl<
                     .filter(|addr| region.contains(addr))
                     .collect();
                 remote.shuffle(&mut *self.rng.write());
-                targets.extend(remote.into_iter().take(self.remote_fanout));
+                targets.extend(remote.into_iter().take(self.cross_region_fanout));
             }
         }
 

--- a/src/reconcile_engine.rs
+++ b/src/reconcile_engine.rs
@@ -34,7 +34,7 @@ use crate::auth;
 use crate::diff::HashRangeQueryable;
 use crate::diff::{Diffable, HashSegment};
 use crate::fingerprint::Fingerprint;
-use crate::gen_ip::{local_region, probe_targets};
+use crate::gen_ip::{host_net, net_of, probe_targets};
 use crate::hlc::{Hlc, HlcClock, Timestamped};
 use crate::observability;
 use crate::reconcilable::{MaybeTombstone, Projectable, Reconcilable};
@@ -85,18 +85,20 @@ pub(crate) struct Inner<K, V: Projectable> {
     pub(crate) projection: Arc<RwLock<HRTree<K, V::Projected>>>,
     port: u16,
     socket: Arc<UdpSocket>,
-    /// Geographical regions, each a CIDR (issue #53). `regions[0]` is the local region
-    /// (`Config::local_region`), followed by every additional remote region. One random address is probed per region each
-    /// round for auto-discovery, and a peer's region is derived from its IP via `IpNet::contains`.
-    regions: Vec<IpNet>,
-    /// The region containing this node's listen address — the one it reconciles with aggressively.
-    local_region: IpNet,
-    /// Send the full anti-entropy comparison to remote-region peers every `cross_region_interval`
-    /// rounds (the [`round`](Self::round) counter); local-region peers are contacted every round.
-    cross_region_interval: u32,
-    /// Max peers contacted per remote region on each cross-region round (bounds WAN fan-out).
-    cross_region_fanout: usize,
-    /// Monotonic reconciliation-round counter, shared across clones, gating the cross-region cadence.
+    /// The geographical networks the cluster spans, each a CIDR (issue #53). One random address is
+    /// probed per network each round for auto-discovery, and a peer's network is derived from its IP
+    /// via `IpNet::contains`.
+    nets: Vec<IpNet>,
+    /// The network containing this node's listen address — the one it reconciles with aggressively.
+    /// When no configured net contains the listen address, this is the node's own host route, so
+    /// only itself is local (see [`Self::new`]).
+    local_net: IpNet,
+    /// Send the full anti-entropy comparison to remote-network peers every `remote_interval`
+    /// rounds (the [`round`](Self::round) counter); local-network peers are contacted every round.
+    remote_interval: u32,
+    /// Max peers contacted per remote network on each cross-network round (bounds WAN fan-out).
+    remote_fanout: usize,
+    /// Monotonic reconciliation-round counter, shared across clones, gating the cross-network cadence.
     round: Arc<AtomicU32>,
     rng: Arc<RwLock<StdRng>>,
     pub(crate) peers: Arc<RwLock<HashMap<IpAddr, Instant>>>,
@@ -111,10 +113,10 @@ pub(crate) struct Inner<K, V: Projectable> {
     /// prevents a peer that is partitioned for longer than the peer-expiration window from
     /// resurrecting a deleted value on its return.
     ///
-    /// Multi-region note (issue #53): remote-region members are gossiped to on a slower cadence, so
-    /// their tombstone acknowledgments arrive later and cross-region GC is correspondingly slower —
+    /// Multi-network note (issue #53): remote-network members are gossiped to on a slower cadence, so
+    /// their tombstone acknowledgments arrive later and cross-network GC is correspondingly slower —
     /// but still strictly correct, since GC never proceeds before *every* member has acked. Lowering
-    /// [`Config::cross_region_interval`] or raising [`Config::cross_region_fanout`] speeds it up at the
+    /// [`Config::remote_interval`] or raising [`Config::remote_fanout`] speeds it up at the
     /// cost of WAN traffic.
     pub(crate) members: Arc<RwLock<HashSet<IpAddr>>>,
     /// Per-tombstone acknowledgments: `key -> (peer -> version token of the tombstone it holds)`.
@@ -208,20 +210,35 @@ impl<
         let map = HRTree::<K, V>::new();
         let projection = HRTree::<K, V::Projected>::new();
         let node_id = config.node_id.unwrap_or_else(rand::random);
-        // The local region is region 0, followed by every additional configured remote region.
-        let mut regions = vec![config.local_region];
-        regions.extend(config.remote_regions.iter().flatten().copied());
-        let local_region = local_region(&regions, config.listen_addr);
+        // The geographical networks this cluster spans. With none declared, fall back to the
+        // historical flat loopback cluster.
+        let mut nets: Vec<IpNet> = config.nets.iter().flatten().copied().collect();
+        if nets.is_empty() {
+            nets.push("127.0.0.1/8".parse().unwrap());
+        }
+        // Qualify the local network: the one containing our listen address. If none does, this is a
+        // misconfiguration — warn loudly and treat only ourselves as local (host route), so every
+        // peer is remote (throttled) rather than silently mis-qualified.
+        let local_net = net_of(&nets, config.listen_addr).unwrap_or_else(|| {
+            warn!(
+                "listen address {} is contained in none of the configured networks {:?}; cannot \
+                 identify the local network — treating only this node as local, so every peer is \
+                 remote and gossiped to on the throttled cross-network cadence. Declare the network \
+                 that contains {} via Config::with_net.",
+                config.listen_addr, nets, config.listen_addr
+            );
+            host_net(config.listen_addr)
+        });
         ReconcileEngine {
             inner: Arc::new(Inner {
                 map: Arc::new(RwLock::new(map)),
                 projection: Arc::new(RwLock::new(projection)),
                 port: config.port,
                 socket: Arc::new(socket),
-                regions,
-                local_region,
-                cross_region_interval: config.cross_region_interval,
-                cross_region_fanout: config.cross_region_fanout,
+                nets,
+                local_net,
+                remote_interval: config.remote_interval,
+                remote_fanout: config.remote_fanout,
                 round: Arc::new(AtomicU32::new(0)),
                 rng: Arc::new(RwLock::new(StdRng::from_entropy())),
                 peers: Arc::new(RwLock::new(HashMap::new())),
@@ -266,9 +283,9 @@ impl<
         self.clock.now()
     }
 
-    /// Whether `addr` belongs to this node's local geographical region (issue #53).
+    /// Whether `addr` belongs to this node's local geographical network (issue #53).
     fn is_local(&self, addr: IpAddr) -> bool {
-        self.local_region.contains(&addr)
+        self.local_net.contains(&addr)
     }
 
     fn get_peers(&self) -> Vec<IpAddr> {
@@ -436,43 +453,43 @@ impl<
                 .serialize(&mut Serializer::new(&mut *send_buf, DefaultOptions::new()))
                 .expect("serializing a ComparisonItem into an in-memory buffer cannot fail");
         }
-        // Geography-aware target selection (issue #53). With a single region this reduces to the
+        // Geography-aware target selection (issue #53). With a single network this reduces to the
         // historical behaviour: every known peer is local, so all of them are contacted each round,
         // plus a single random discovery probe.
         let round = self.round.fetch_add(1, Ordering::Relaxed);
         // Treat an interval of 0 as "every round" to avoid a modulo-by-zero.
-        let do_cross_region = round.is_multiple_of(self.cross_region_interval.max(1));
+        let do_remote = round.is_multiple_of(self.remote_interval.max(1));
         let known = self.get_peers();
 
         // De-duplicate so a discovery probe that happens to hit a known peer is not sent twice.
         let mut targets: HashSet<IpAddr> = HashSet::new();
 
-        // Discovery: one random probe per region. The probed address might not correspond to a real
+        // Discovery: one random probe per network. The probed address might not correspond to a real
         // peer, so we do NOT add it to the known-peer list; if a peer exists there, it will reply
         // and be registered then.
         {
             let mut rng = self.rng.write();
-            targets.extend(probe_targets(&mut *rng, &self.regions));
+            targets.extend(probe_targets(&mut *rng, &self.nets));
         }
 
-        // Local region: contact every known peer, every round (fast intra-region convergence).
+        // Local network: contact every known peer, every round (fast intra-network convergence).
         for &addr in &known {
             if self.is_local(addr) {
                 targets.insert(addr);
             }
         }
 
-        // Remote regions: only on cross-region rounds, and only a bounded random subset per region,
-        // to keep WAN fan-out bounded without designating any node as a relay/gateway.
-        if do_cross_region {
-            for region in self.regions.iter().filter(|&&r| r != self.local_region) {
+        // Remote networks: only on cross-network rounds, and only a bounded random subset per
+        // network, to keep WAN fan-out bounded without designating any node as a relay/gateway.
+        if do_remote {
+            for net in self.nets.iter().filter(|&&n| n != self.local_net) {
                 let mut remote: Vec<IpAddr> = known
                     .iter()
                     .copied()
-                    .filter(|addr| region.contains(addr))
+                    .filter(|addr| net.contains(addr))
                     .collect();
                 remote.shuffle(&mut *self.rng.write());
-                targets.extend(remote.into_iter().take(self.cross_region_fanout));
+                targets.extend(remote.into_iter().take(self.remote_fanout));
             }
         }
 

--- a/src/reconcile_engine.rs
+++ b/src/reconcile_engine.rs
@@ -15,7 +15,7 @@ use std::fmt::Debug;
 use std::hash::{Hash, Hasher};
 use std::net::{IpAddr, SocketAddr};
 use std::ops::RangeBounds;
-use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::atomic::{AtomicU32, AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -38,11 +38,10 @@ use crate::gen_ip::{host_net, net_of, probe_targets};
 use crate::hlc::{Hlc, HlcClock, Timestamped};
 use crate::observability;
 use crate::reconcilable::{MaybeTombstone, Projectable, Reconcilable};
-use crate::reconcile_store::Config;
+use crate::reconcile_store::{Config, MAX_NETS};
 use crate::HRTree;
 
 const BUFFER_SIZE: usize = 65507;
-const ACTIVITY_TIMEOUT: Duration = Duration::from_secs(1);
 const PEER_EXPIRATION: Duration = Duration::from_secs(60);
 
 const MAX_SENDTO_RETRIES: u32 = 4;
@@ -59,6 +58,27 @@ pub(crate) fn version_hash<V: Hash>(value: &V) -> u64 {
     let mut hasher = DefaultHasher::new();
     value.hash(&mut hasher);
     hasher.finish()
+}
+
+/// Derive a node's **local network** from the declared `nets` and its `listen_addr`.
+///
+/// The local network is whichever declared net contains the listen address — the one a node
+/// reconciles with aggressively (every round). When none does (a misconfiguration), this falls back
+/// to the node's own host route (`/32`-`/128`), so only the node itself is local and every peer is
+/// treated as remote (throttled) rather than silently mis-qualified.
+///
+/// Reused on construction **and** on every runtime mutation of `nets`, so the warning fires only at
+/// those mutation boundaries — never once per reconciliation round.
+fn derive_local_net(nets: &[IpNet], listen_addr: IpAddr) -> IpNet {
+    net_of(nets, listen_addr).unwrap_or_else(|| {
+        warn!(
+            "listen address {listen_addr} is contained in none of the configured networks \
+             {nets:?}; cannot identify the local network — treating only this node as local, so \
+             every peer is remote and reconciled on the throttled cross-network cadence. Declare \
+             the network containing {listen_addr} via Config::with_net or ReconcileStore::add_net.",
+        );
+        host_net(listen_addr)
+    })
 }
 
 /// The internal reconciliation engine at the network level.
@@ -87,17 +107,28 @@ pub(crate) struct Inner<K, V: Projectable> {
     socket: Arc<UdpSocket>,
     /// The geographical networks the cluster spans, each a CIDR (issue #53). One random address is
     /// probed per network each round for auto-discovery, and a peer's network is derived from its IP
-    /// via `IpNet::contains`.
-    nets: Vec<IpNet>,
+    /// via `IpNet::contains`. Shared and mutable at runtime (see [`set_nets`](Self::set_nets)) so the
+    /// topology can be retuned live without recreating the node — the [`run`](Self::run) loop snapshots
+    /// it at the start of each round.
+    nets: Arc<RwLock<Vec<IpNet>>>,
     /// The network containing this node's listen address — the one it reconciles with aggressively.
     /// When no configured net contains the listen address, this is the node's own host route, so
-    /// only itself is local (see [`Self::new`]).
-    local_net: IpNet,
+    /// only itself is local (see [`Self::new`]). **Derived** from [`nets`](Self::nets): recomputed on
+    /// every runtime mutation of `nets` (never set independently), so it can never drift out of sync.
+    local_net: Arc<RwLock<IpNet>>,
+    /// This node's own listen address, kept so [`local_net`](Self::local_net) can be re-derived
+    /// whenever [`nets`](Self::nets) changes at runtime.
+    listen_addr: IpAddr,
     /// Send the full anti-entropy comparison to remote-network peers every `remote_interval`
     /// rounds (the [`round`](Self::round) counter); local-network peers are contacted every round.
-    remote_interval: u32,
+    /// Shared atomic so it can be retuned at runtime.
+    remote_interval: Arc<AtomicU32>,
     /// Max peers contacted per remote network on each cross-network round (bounds WAN fan-out).
-    remote_fanout: usize,
+    /// Shared atomic so it can be retuned at runtime.
+    remote_fanout: Arc<AtomicUsize>,
+    /// How long the [`run`](Self::run) loop waits for inbound activity before initiating a
+    /// reconciliation round — the effective gossip cadence. Shared so it can be retuned at runtime.
+    reconcile_interval: Arc<RwLock<Duration>>,
     /// Monotonic reconciliation-round counter, shared across clones, gating the cross-network cadence.
     round: Arc<AtomicU32>,
     rng: Arc<RwLock<StdRng>>,
@@ -216,29 +247,21 @@ impl<
         if nets.is_empty() {
             nets.push("127.0.0.1/8".parse().unwrap());
         }
-        // Qualify the local network: the one containing our listen address. If none does, this is a
-        // misconfiguration — warn loudly and treat only ourselves as local (host route), so every
-        // peer is remote (throttled) rather than silently mis-qualified.
-        let local_net = net_of(&nets, config.listen_addr).unwrap_or_else(|| {
-            warn!(
-                "listen address {} is contained in none of the configured networks {:?}; cannot \
-                 identify the local network — treating only this node as local, so every peer is \
-                 remote and gossiped to on the throttled cross-network cadence. Declare the network \
-                 that contains {} via Config::with_net.",
-                config.listen_addr, nets, config.listen_addr
-            );
-            host_net(config.listen_addr)
-        });
+        // Qualify the local network from the declared nets (warns + host-route fallback on
+        // misconfiguration). Re-derived identically on every runtime mutation of `nets`.
+        let local_net = derive_local_net(&nets, config.listen_addr);
         ReconcileEngine {
             inner: Arc::new(Inner {
                 map: Arc::new(RwLock::new(map)),
                 projection: Arc::new(RwLock::new(projection)),
                 port: config.port,
                 socket: Arc::new(socket),
-                nets,
-                local_net,
-                remote_interval: config.remote_interval,
-                remote_fanout: config.remote_fanout,
+                nets: Arc::new(RwLock::new(nets)),
+                local_net: Arc::new(RwLock::new(local_net)),
+                listen_addr: config.listen_addr,
+                remote_interval: Arc::new(AtomicU32::new(config.remote_interval)),
+                remote_fanout: Arc::new(AtomicUsize::new(config.remote_fanout)),
+                reconcile_interval: Arc::new(RwLock::new(config.reconcile_interval)),
                 round: Arc::new(AtomicU32::new(0)),
                 rng: Arc::new(RwLock::new(StdRng::from_entropy())),
                 peers: Arc::new(RwLock::new(HashMap::new())),
@@ -283,9 +306,65 @@ impl<
         self.clock.now()
     }
 
-    /// Whether `addr` belongs to this node's local geographical network (issue #53).
-    fn is_local(&self, addr: IpAddr) -> bool {
-        self.local_net.contains(&addr)
+    /// (runtime) Replace the declared networks wholesale and re-derive the local network.
+    pub(crate) fn set_nets(&self, nets: &[IpNet]) {
+        let nets = nets.to_vec();
+        let local = derive_local_net(&nets, self.listen_addr);
+        // local_net is always derived from nets; update it together so a reader never observes a
+        // local net that is inconsistent with the freshly-installed nets for long.
+        *self.local_net.write() = local;
+        *self.nets.write() = nets;
+    }
+
+    /// (runtime) Declare an additional network. Idempotent; returns `false` (and logs) if the
+    /// [`MAX_NETS`](crate::reconcile_store::MAX_NETS) cap is reached.
+    pub(crate) fn add_net(&self, net: IpNet) -> bool {
+        let mut guard = self.nets.write();
+        if guard.contains(&net) {
+            return true;
+        }
+        if guard.len() >= MAX_NETS {
+            warn!("cannot add network {net}: already at the maximum of {MAX_NETS} networks");
+            return false;
+        }
+        guard.push(net);
+        *self.local_net.write() = derive_local_net(&guard, self.listen_addr);
+        true
+    }
+
+    /// (runtime) Stop declaring a network. Returns whether it was present. Anti-entropy repair of
+    /// already-known peers is **not** gated on net membership, so removing a net never orphans a
+    /// real peer — it only stops discovery probes into that range and may reclassify peers from
+    /// local to remote (throttled) cadence.
+    pub(crate) fn remove_net(&self, net: IpNet) -> bool {
+        let mut guard = self.nets.write();
+        let before = guard.len();
+        guard.retain(|n| *n != net);
+        let removed = guard.len() != before;
+        if removed {
+            *self.local_net.write() = derive_local_net(&guard, self.listen_addr);
+        }
+        removed
+    }
+
+    pub(crate) fn nets(&self) -> Vec<IpNet> {
+        self.nets.read().clone()
+    }
+
+    pub(crate) fn local_net(&self) -> IpNet {
+        *self.local_net.read()
+    }
+
+    pub(crate) fn set_remote_interval(&self, interval: u32) {
+        self.remote_interval.store(interval, Ordering::Relaxed);
+    }
+
+    pub(crate) fn set_remote_fanout(&self, fanout: usize) {
+        self.remote_fanout.store(fanout, Ordering::Relaxed);
+    }
+
+    pub(crate) fn set_reconcile_interval(&self, interval: Duration) {
+        *self.reconcile_interval.write() = interval;
     }
 
     fn get_peers(&self) -> Vec<IpAddr> {
@@ -374,11 +453,12 @@ impl<
         // extra byte that easily detect when the buffer is too small
         let mut recv_buf = [0; BUFFER_SIZE + 1];
         let mut send_buf = Vec::new();
-        let recv_timeout = ACTIVITY_TIMEOUT;
         // start the protocol at the beginning
         self.start_reconciliation(&mut send_buf).await;
         // infinite loop
         loop {
+            // Re-read each iteration so the cadence can be retuned at runtime.
+            let recv_timeout = *self.reconcile_interval.read();
             match timeout(recv_timeout, self.socket.recv_from(&mut recv_buf)).await {
                 Err(_) => {
                     // timeout
@@ -456,9 +536,16 @@ impl<
         // Geography-aware target selection (issue #53). With a single network this reduces to the
         // historical behaviour: every known peer is local, so all of them are contacted each round,
         // plus a single random discovery probe.
+        //
+        // Snapshot the runtime-tunable topology/throttle once per round, so a concurrent mutation
+        // cannot tear a round and we never hold a lock across the sends below.
+        let nets = self.nets.read().clone();
+        let local = *self.local_net.read();
+        let remote_interval = self.remote_interval.load(Ordering::Relaxed).max(1);
+        let remote_fanout = self.remote_fanout.load(Ordering::Relaxed);
         let round = self.round.fetch_add(1, Ordering::Relaxed);
         // Treat an interval of 0 as "every round" to avoid a modulo-by-zero.
-        let do_remote = round.is_multiple_of(self.remote_interval.max(1));
+        let do_remote = round.is_multiple_of(remote_interval);
         let known = self.get_peers();
 
         // De-duplicate so a discovery probe that happens to hit a known peer is not sent twice.
@@ -469,27 +556,37 @@ impl<
         // and be registered then.
         {
             let mut rng = self.rng.write();
-            targets.extend(probe_targets(&mut *rng, &self.nets));
+            targets.extend(probe_targets(&mut *rng, &nets));
         }
 
         // Local network: contact every known peer, every round (fast intra-network convergence).
         for &addr in &known {
-            if self.is_local(addr) {
+            if local.contains(&addr) {
                 targets.insert(addr);
             }
         }
 
-        // Remote networks: only on cross-network rounds, and only a bounded random subset per
-        // network, to keep WAN fan-out bounded without designating any node as a relay/gateway.
+        // Remote peers: only on cross-network rounds, a bounded random subset per network — PLUS an
+        // `unclassified` bucket for known peers matching no declared network. Anti-entropy repair is
+        // deliberately **decoupled from net membership**: a peer learned by actual contact is never
+        // excluded from repair regardless of the declared topology. Nets only steer discovery and the
+        // local/remote throttle split, so changing the topology at runtime can never orphan a real
+        // peer from repair (worst case: suboptimal WAN traffic, never silent divergence). Fan-out is
+        // applied per bucket to keep WAN traffic bounded without designating any node as a relay.
         if do_remote {
-            for net in self.nets.iter().filter(|&&n| n != self.local_net) {
-                let mut remote: Vec<IpAddr> = known
-                    .iter()
-                    .copied()
-                    .filter(|addr| net.contains(addr))
-                    .collect();
-                remote.shuffle(&mut *self.rng.write());
-                targets.extend(remote.into_iter().take(self.remote_fanout));
+            let remote_nets: Vec<IpNet> = nets.iter().copied().filter(|&n| n != local).collect();
+            let mut buckets: HashMap<Option<usize>, Vec<IpAddr>> = HashMap::new();
+            for &addr in &known {
+                if local.contains(&addr) {
+                    continue; // already contacted every round above
+                }
+                let bucket = remote_nets.iter().position(|n| n.contains(&addr));
+                buckets.entry(bucket).or_default().push(addr);
+            }
+            let mut rng = self.rng.write();
+            for (_, mut peers) in buckets {
+                peers.shuffle(&mut *rng);
+                targets.extend(peers.into_iter().take(remote_fanout));
             }
         }
 

--- a/src/reconcile_engine.rs
+++ b/src/reconcile_engine.rs
@@ -34,8 +34,9 @@ use crate::auth;
 use crate::bounds::{Key, Value};
 use crate::diff::HashRangeQueryable;
 use crate::diff::{Diffable, HashSegment};
+use crate::discovery::{Discovery, RandomProbe};
 use crate::fingerprint::Fingerprint;
-use crate::gen_ip::{host_net, net_of, probe_targets};
+use crate::gen_ip::{host_net, net_of};
 use crate::hlc::{Hlc, HlcClock, Timestamped};
 use crate::observability;
 use crate::reconcilable::{MaybeTombstone, Projectable, Reconcilable};
@@ -133,6 +134,11 @@ pub(crate) struct Inner<K, V: Projectable> {
     /// Monotonic reconciliation-round counter, shared across clones, gating the cross-network cadence.
     round: Arc<AtomicU32>,
     rng: Arc<RwLock<StdRng>>,
+    /// Speculative peer discovery, behind the [`Discovery`] port. Defaults to [`RandomProbe`] (one
+    /// random address per declared network each round); consulted once per reconciliation round and
+    /// shares this engine's live `nets` and `rng`. Its results are one-shot targets, never seeded as
+    /// known peers — see [`start_reconciliation`](Self::start_reconciliation).
+    probe: Arc<dyn Discovery>,
     pub(crate) peers: Arc<RwLock<HashMap<IpAddr, Instant>>>,
     pub(crate) pre_insert: Arc<RwLock<PreInsertCallback<K, V>>>,
     /// Per-datagram authentication policy; carries the cluster key when enabled.
@@ -238,20 +244,27 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
         // Qualify the local network from the declared nets (warns + host-route fallback on
         // misconfiguration). Re-derived identically on every runtime mutation of `nets`.
         let local_net = derive_local_net(&nets, config.listen_addr);
+        // `nets` and `rng` are shared with the default speculative `RandomProbe` discovery, so a
+        // runtime topology change is immediately reflected in what it probes.
+        let nets = Arc::new(RwLock::new(nets));
+        let rng = Arc::new(RwLock::new(StdRng::from_entropy()));
+        let probe: Arc<dyn Discovery> =
+            Arc::new(RandomProbe::new(Arc::clone(&nets), Arc::clone(&rng)));
         ReconcileEngine {
             inner: Arc::new(Inner {
                 map: Arc::new(RwLock::new(map)),
                 projection: Arc::new(RwLock::new(projection)),
                 port: config.port,
                 socket: Arc::new(socket),
-                nets: Arc::new(RwLock::new(nets)),
+                nets,
                 local_net: Arc::new(RwLock::new(local_net)),
                 listen_addr: config.listen_addr,
                 remote_interval: Arc::new(AtomicU32::new(config.remote_interval)),
                 remote_fanout: Arc::new(AtomicUsize::new(config.remote_fanout)),
                 reconcile_interval: Arc::new(RwLock::new(config.reconcile_interval)),
                 round: Arc::new(AtomicU32::new(0)),
-                rng: Arc::new(RwLock::new(StdRng::from_entropy())),
+                rng,
+                probe,
                 peers: Arc::new(RwLock::new(HashMap::new())),
                 pre_insert: Arc::new(RwLock::new(Box::new(|_, _| {}))),
                 authenticator,
@@ -539,13 +552,12 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
         // De-duplicate so a discovery probe that happens to hit a known peer is not sent twice.
         let mut targets: HashSet<IpAddr> = HashSet::new();
 
-        // Discovery: one random probe per network. The probed address might not correspond to a real
-        // peer, so we do NOT add it to the known-peer list; if a peer exists there, it will reply
-        // and be registered then.
-        {
-            let mut rng = self.rng.write();
-            targets.extend(probe_targets(&mut *rng, &nets));
-        }
+        // Speculative discovery through the `Discovery` port (default: one random probe per network,
+        // see `RandomProbe`). The probed address might not correspond to a real peer, so we do NOT
+        // add it to the known-peer list; if a peer exists there, it will reply and be registered
+        // then. An authoritative source (e.g. DNS) instead drives the store's seed/decommission loop
+        // and is not consulted here. A transient failure simply yields no extra targets this round.
+        targets.extend(self.probe.discover().await.unwrap_or_default());
 
         // Local network: contact every known peer, every round (fast intra-network convergence).
         for &addr in &known {

--- a/src/reconcile_store.rs
+++ b/src/reconcile_store.rs
@@ -186,8 +186,8 @@ impl<K: Key, V: Value> ReconcileStore<K, V> {
         self.engine.seed_peer(peer);
     }
 
-    /// Attach a dynamic peer-discovery source, replacing the engine's random per-network probing as
-    /// the way peers are found.
+    /// Attach an **authoritative** peer-discovery source (e.g. [`DnsDiscovery`]) that maintains the
+    /// known-peer set, on top of the engine's default speculative [`RandomProbe`](crate::RandomProbe).
     ///
     /// While the store is [`run`](Self::run)ning, a background task calls
     /// [`Discovery::discover`] every
@@ -197,7 +197,16 @@ impl<K: Key, V: Value> ReconcileStore<K, V> {
     /// rounds — decommissions it (see [`forget_peer`](Self::forget_peer)) so its tombstones stop
     /// gating garbage collection. See [`with_dns_discovery`](Self::with_dns_discovery) for the
     /// Kubernetes-native default.
+    ///
+    /// The source must be [authoritative](crate::Discovery::is_authoritative): an absence is read as
+    /// a vanished peer and drives decommissioning. A speculative source like
+    /// [`RandomProbe`](crate::RandomProbe) belongs in the engine's per-round probe, not here.
     pub fn with_discovery(mut self, discovery: Arc<dyn Discovery>) -> Self {
+        debug_assert!(
+            discovery.is_authoritative(),
+            "with_discovery expects an authoritative source; a speculative prober would be seeded \
+             as permanent known peers and its absences would wrongly decommission members"
+        );
         self.discovery = Some(discovery);
         self
     }

--- a/src/reconcile_store.rs
+++ b/src/reconcile_store.rs
@@ -385,11 +385,37 @@ impl<
     }
 }
 
+/// Maximum number of **additional** (remote) geographical regions a [`Config`] can declare,
+/// beyond the local [`peer_net`](Config::peer_net). A fixed-size array keeps [`Config`] `Copy`;
+/// eight regions is generous for real geographical deployments.
+pub const MAX_REGIONS: usize = 8;
+
 #[derive(Clone, Copy)]
 pub struct Config {
     pub port: u16,
     pub listen_addr: IpAddr,
+    /// CIDR of the **local** geographical region: the subnet this node reconciles with
+    /// aggressively (every round) and probes for auto-discovery. With a single region this is the
+    /// whole cluster network (the historical behaviour).
     pub peer_net: IpNet,
+    /// Additional **remote** geographical regions, each a CIDR (issue #53). Empty slots are `None`.
+    ///
+    /// Set through [`with_region`](Config::with_region) / [`with_regions`](Config::with_regions).
+    /// A node auto-discovers peers in every region (one random probe per region per round) but
+    /// only gossips the full anti-entropy comparison to remote-region peers on a slower cadence
+    /// and to a bounded random subset, so cross-region (WAN) traffic stays bounded. A peer's
+    /// region is derived purely from its IP address (`IpNet::contains`), so the wire format is
+    /// unchanged. With no remote region declared, behaviour is identical to a flat single-CIDR
+    /// cluster.
+    pub regions: [Option<IpNet>; MAX_REGIONS],
+    /// Send the full anti-entropy comparison to remote-region peers every `cross_region_interval`
+    /// reconciliation rounds (default `6`). Local-region peers are always contacted every round.
+    /// Lowering this speeds cross-region convergence (and tombstone GC) at the cost of WAN traffic.
+    pub cross_region_interval: u32,
+    /// Maximum number of peers contacted per remote region on each cross-region round (default
+    /// `2`). Bounds WAN fan-out without designating any node as a relay/gateway. Raising it speeds
+    /// cross-region convergence (and tombstone GC) at the cost of WAN traffic.
+    pub remote_fanout: usize,
     /// Optional shared cluster secret enabling per-datagram MAC authentication.
     ///
     /// When `None` (the default), the protocol is **unauthenticated**: any host able to send a
@@ -420,6 +446,9 @@ impl Default for Config {
             port: 0,
             listen_addr: "127.0.0.1".parse().unwrap(),
             peer_net: "127.0.0.1/8".parse().unwrap(),
+            regions: [None; MAX_REGIONS],
+            cross_region_interval: 6,
+            remote_fanout: 2,
             cluster_key: None,
             node_id: None,
             encrypt: false,
@@ -437,6 +466,50 @@ impl Config {
     }
     pub fn with_peer_net(mut self, peer_net: IpNet) -> Self {
         self.peer_net = peer_net;
+        self
+    }
+
+    /// Declare an additional remote geographical region by its CIDR (issue #53).
+    ///
+    /// The node auto-discovers peers in this region and reconciles with them over WAN-bounded,
+    /// geography-aware gossip (see [`regions`](Config::regions)). Chainable to add several regions.
+    ///
+    /// # Panics
+    ///
+    /// Panics if more than [`MAX_REGIONS`] additional regions are declared.
+    pub fn with_region(mut self, net: IpNet) -> Self {
+        let slot = self
+            .regions
+            .iter_mut()
+            .find(|slot| slot.is_none())
+            .unwrap_or_else(|| panic!("at most {MAX_REGIONS} additional regions are supported"));
+        *slot = Some(net);
+        self
+    }
+
+    /// Declare several additional remote regions at once (see [`with_region`](Config::with_region)).
+    ///
+    /// # Panics
+    ///
+    /// Panics if the total number of additional regions exceeds [`MAX_REGIONS`].
+    pub fn with_regions(mut self, nets: &[IpNet]) -> Self {
+        for &net in nets {
+            self = self.with_region(net);
+        }
+        self
+    }
+
+    /// Set how often (in reconciliation rounds) the full anti-entropy comparison is sent to
+    /// remote-region peers (default `6`). See [`cross_region_interval`](Config::cross_region_interval).
+    pub fn with_cross_region_interval(mut self, interval: u32) -> Self {
+        self.cross_region_interval = interval;
+        self
+    }
+
+    /// Set the maximum number of peers contacted per remote region on each cross-region round
+    /// (default `2`). See [`remote_fanout`](Config::remote_fanout).
+    pub fn with_remote_fanout(mut self, fanout: usize) -> Self {
+        self.remote_fanout = fanout;
         self
     }
 
@@ -493,7 +566,10 @@ mod reconcile_store_tests {
     use std::time::Duration;
 
     use crate::reconcile_engine::version_hash;
-    use crate::{reconcile_store::Config, FileSnapshot, ReconcileStore};
+    use crate::{
+        reconcile_store::{Config, MAX_REGIONS},
+        FileSnapshot, ReconcileStore,
+    };
 
     /// A config bound to an ephemeral UDP port on loopback, so persistence tests can construct
     /// stores without colliding on a fixed port.
@@ -502,6 +578,9 @@ mod reconcile_store_tests {
             port: 0,
             listen_addr: "127.0.0.1".parse().unwrap(),
             peer_net: "127.0.0.1/8".parse().unwrap(),
+            regions: [None; MAX_REGIONS],
+            cross_region_interval: 6,
+            remote_fanout: 2,
             cluster_key: None,
             node_id: None,
             encrypt: false,
@@ -518,6 +597,9 @@ mod reconcile_store_tests {
             port: 8090,
             listen_addr: "127.0.0.45".parse().unwrap(),
             peer_net: "127.0.0.45/32".parse().unwrap(),
+            regions: [None; MAX_REGIONS],
+            cross_region_interval: 6,
+            remote_fanout: 2,
             cluster_key: None,
             node_id: None,
             encrypt: false,

--- a/src/reconcile_store.rs
+++ b/src/reconcile_store.rs
@@ -317,6 +317,67 @@ impl<
         self.engine.decommission_peer(peer);
     }
 
+    /// (runtime) Replace the declared geographical networks, retuning the gossip topology **without
+    /// recreating the node**. The local network is re-derived automatically (whichever new net
+    /// contains the listen address). See [`Config::nets`].
+    ///
+    /// Topology is per-node and coordination-free (the wire format carries no network tag), and is
+    /// safe to change live: anti-entropy *repair* of already-known peers is **not** gated on net
+    /// membership, so reshaping the topology never orphans a real peer from repair — it only changes
+    /// which addresses are probed for discovery and the local/remote throttle split. Worst case is
+    /// suboptimal WAN traffic, never silent divergence.
+    pub fn set_nets(&self, nets: &[IpNet]) {
+        self.engine.set_nets(nets);
+    }
+
+    /// (runtime) Declare an additional network (e.g. opening a new region). Idempotent; returns
+    /// `false` (and logs) if the [`MAX_NETS`] cap is already reached. The local network is re-derived.
+    pub fn add_net(&self, net: IpNet) -> bool {
+        self.engine.add_net(net)
+    }
+
+    /// (runtime) Stop declaring a network (e.g. decommissioning a region). Returns whether it was
+    /// present. Known peers keep being repaired regardless (see [`set_nets`](Self::set_nets)); to
+    /// also reclaim a region quickly elsewhere, prefer adding the new net **before** removing the old
+    /// so discovery keeps the cluster well-connected throughout the migration.
+    pub fn remove_net(&self, net: IpNet) -> bool {
+        self.engine.remove_net(net)
+    }
+
+    /// The currently declared networks.
+    pub fn nets(&self) -> Vec<IpNet> {
+        self.engine.nets()
+    }
+
+    /// The current local network (the declared net containing the listen address, else the host
+    /// route — see [`Config::nets`]).
+    pub fn local_net(&self) -> IpNet {
+        self.engine.local_net()
+    }
+
+    /// (runtime) Retune how often (in rounds) remote-network peers are reconciled. See
+    /// [`Config::remote_interval`].
+    pub fn set_remote_interval(&self, interval: u32) {
+        self.engine.set_remote_interval(interval);
+    }
+
+    /// (runtime) Retune the bounded number of peers contacted per remote network each cross-network
+    /// round. See [`Config::remote_fanout`].
+    pub fn set_remote_fanout(&self, fanout: usize) {
+        self.engine.set_remote_fanout(fanout);
+    }
+
+    /// (runtime) Retune the tombstone expiry timeout in place, visible to all clones. The runtime
+    /// counterpart of the [`with_tombstone_timeout`](Self::with_tombstone_timeout) builder.
+    pub fn set_tombstone_timeout(&self, timeout: Duration) {
+        self.tombstones.set_timeout(timeout);
+    }
+
+    /// (runtime) Retune the reconciliation cadence in place. See [`Config::reconcile_interval`].
+    pub fn set_reconcile_interval(&self, interval: Duration) {
+        self.engine.set_reconcile_interval(interval);
+    }
+
     /// Garbage-collect tombstones, **gated on causal stability**.
     ///
     /// A tombstone is removed from the map only once it is both older than the configured
@@ -439,6 +500,11 @@ pub struct Config {
     /// default), a set cluster key authenticates plaintext datagrams with a MAC; when `true`, the
     /// same key is used to authenticate *and* encrypt them with XChaCha20-Poly1305.
     pub encrypt: bool,
+    /// How long the reconciliation loop waits for inbound activity before initiating a round — the
+    /// effective gossip cadence (default 1 s). A shorter interval converges faster at the cost of
+    /// more traffic. Retunable at runtime via
+    /// [`set_reconcile_interval`](crate::ReconcileStore::set_reconcile_interval).
+    pub reconcile_interval: Duration,
     // may include other options in the future: tombstone_ttl, metrics, etc.
 }
 impl Default for Config {
@@ -452,6 +518,7 @@ impl Default for Config {
             cluster_key: None,
             node_id: None,
             encrypt: false,
+            reconcile_interval: Duration::from_secs(1),
         }
     }
 }
@@ -507,6 +574,15 @@ impl Config {
     /// (default `2`). See [`remote_fanout`](Config::remote_fanout).
     pub fn with_remote_fanout(mut self, fanout: usize) -> Self {
         self.remote_fanout = fanout;
+        self
+    }
+
+    /// Set the reconciliation cadence: how long the loop waits for inbound activity before
+    /// initiating a round (default 1 s). See [`reconcile_interval`](Config::reconcile_interval).
+    /// Retunable at runtime via
+    /// [`ReconcileStore::set_reconcile_interval`](crate::ReconcileStore::set_reconcile_interval).
+    pub fn with_reconcile_interval(mut self, interval: Duration) -> Self {
+        self.reconcile_interval = interval;
         self
     }
 
@@ -580,6 +656,7 @@ mod reconcile_store_tests {
             cluster_key: None,
             node_id: None,
             encrypt: false,
+            reconcile_interval: Duration::from_secs(1),
         }
     }
 

--- a/src/reconcile_store.rs
+++ b/src/reconcile_store.rs
@@ -385,37 +385,38 @@ impl<
     }
 }
 
-/// Maximum number of **additional** (remote) geographical regions a [`Config`] can declare,
-/// beyond the local [`local_region`](Config::local_region). A fixed-size array keeps [`Config`] `Copy`;
-/// eight regions is generous for real geographical deployments.
-pub const MAX_REGIONS: usize = 8;
+/// Maximum number of geographical networks (CIDRs) a [`Config`] can declare. A fixed-size array
+/// keeps [`Config`] `Copy`; eight networks is generous for real geographical deployments.
+pub const MAX_NETS: usize = 8;
 
 #[derive(Clone, Copy)]
 pub struct Config {
     pub port: u16,
     pub listen_addr: IpAddr,
-    /// CIDR of the **local** geographical region: the subnet this node reconciles with
-    /// aggressively (every round) and probes for auto-discovery. With a single region this is the
-    /// whole cluster network (the historical behaviour).
-    pub local_region: IpNet,
-    /// Additional **remote** geographical regions, each a CIDR (issue #53). Empty slots are `None`.
+    /// The geographical networks the cluster spans, each a CIDR (issue #53). Empty slots are `None`.
     ///
-    /// Set through [`with_remote_region`](Config::with_remote_region) / [`with_remote_regions`](Config::with_remote_regions).
-    /// A node auto-discovers peers in every region (one random probe per region per round) but
-    /// only gossips the full anti-entropy comparison to remote-region peers on a slower cadence
-    /// and to a bounded random subset, so cross-region (WAN) traffic stays bounded. A peer's
-    /// region is derived purely from its IP address (`IpNet::contains`), so the wire format is
-    /// unchanged. With no remote region declared, behaviour is identical to a flat single-CIDR
-    /// cluster.
-    pub remote_regions: [Option<IpNet>; MAX_REGIONS],
-    /// Send the full anti-entropy comparison to remote-region peers every `cross_region_interval`
-    /// reconciliation rounds (default `6`). Local-region peers are always contacted every round.
-    /// Lowering this speeds cross-region convergence (and tombstone GC) at the cost of WAN traffic.
-    pub cross_region_interval: u32,
-    /// Maximum number of peers contacted per remote region on each cross-region round (default
+    /// Declare every network with [`with_net`](Config::with_net); a *network* is just an address
+    /// range, sized to your topology (a whole cloud region, an availability zone, or a single
+    /// subnet). This node's **local** network is whichever declared net contains
+    /// [`listen_addr`](Self::listen_addr); all others are **remote**. (If none contains it, the node
+    /// logs a loud warning and treats only itself as local — see [`ReconcileStore::new`].)
+    ///
+    /// A node auto-discovers peers in every network (one random probe per network per round) but
+    /// gossips the full anti-entropy comparison to local-network peers every round and to
+    /// remote-network peers only every [`remote_interval`](Self::remote_interval) rounds, to a
+    /// bounded [`remote_fanout`](Self::remote_fanout) subset — so cross-network (WAN) traffic stays
+    /// bounded. A peer's network is derived purely from its IP (`IpNet::contains`), so the wire
+    /// format is unchanged. With no network declared, the node uses the loopback default and behaves
+    /// like a flat single-CIDR cluster (the historical behaviour).
+    pub nets: [Option<IpNet>; MAX_NETS],
+    /// Send the full anti-entropy comparison to remote-network peers every `remote_interval`
+    /// reconciliation rounds (default `6`). Local-network peers are always contacted every round.
+    /// Lowering this speeds cross-network convergence (and tombstone GC) at the cost of WAN traffic.
+    pub remote_interval: u32,
+    /// Maximum number of peers contacted per remote network on each cross-network round (default
     /// `2`). Bounds WAN fan-out without designating any node as a relay/gateway. Raising it speeds
-    /// cross-region convergence (and tombstone GC) at the cost of WAN traffic.
-    pub cross_region_fanout: usize,
+    /// cross-network convergence (and tombstone GC) at the cost of WAN traffic.
+    pub remote_fanout: usize,
     /// Optional shared cluster secret enabling per-datagram MAC authentication.
     ///
     /// When `None` (the default), the protocol is **unauthenticated**: any host able to send a
@@ -445,10 +446,9 @@ impl Default for Config {
         Config {
             port: 0,
             listen_addr: "127.0.0.1".parse().unwrap(),
-            local_region: "127.0.0.1/8".parse().unwrap(),
-            remote_regions: [None; MAX_REGIONS],
-            cross_region_interval: 6,
-            cross_region_fanout: 2,
+            nets: [None; MAX_NETS],
+            remote_interval: 6,
+            remote_fanout: 2,
             cluster_key: None,
             node_id: None,
             encrypt: false,
@@ -464,52 +464,49 @@ impl Config {
         self.listen_addr = listen_addr;
         self
     }
-    pub fn with_local_region(mut self, local_region: IpNet) -> Self {
-        self.local_region = local_region;
-        self
-    }
-
-    /// Declare an additional remote geographical region by its CIDR (issue #53).
+    /// Declare a geographical network the cluster spans, by its CIDR (issue #53).
     ///
-    /// The node auto-discovers peers in this region and reconciles with them over WAN-bounded,
-    /// geography-aware gossip (see [`remote_regions`](Config::remote_regions)). Chainable to add several regions.
+    /// Call once per network — **including this node's own**. The node's local network is whichever
+    /// declared net contains [`listen_addr`](Config::listen_addr); the rest are remote and gossiped
+    /// to over WAN-bounded, geography-aware anti-entropy (see [`nets`](Config::nets)). With none
+    /// declared, the node uses the loopback default (a flat single-CIDR cluster).
     ///
     /// # Panics
     ///
-    /// Panics if more than [`MAX_REGIONS`] additional regions are declared.
-    pub fn with_remote_region(mut self, net: IpNet) -> Self {
+    /// Panics if more than [`MAX_NETS`] networks are declared.
+    pub fn with_net(mut self, net: IpNet) -> Self {
         let slot = self
-            .remote_regions
+            .nets
             .iter_mut()
             .find(|slot| slot.is_none())
-            .unwrap_or_else(|| panic!("at most {MAX_REGIONS} additional regions are supported"));
+            .unwrap_or_else(|| panic!("at most {MAX_NETS} networks are supported"));
         *slot = Some(net);
         self
     }
 
-    /// Declare several additional remote regions at once (see [`with_remote_region`](Config::with_remote_region)).
+    /// Declare several networks at once (see [`with_net`](Config::with_net)).
     ///
     /// # Panics
     ///
-    /// Panics if the total number of additional regions exceeds [`MAX_REGIONS`].
-    pub fn with_remote_regions(mut self, nets: &[IpNet]) -> Self {
+    /// Panics if the total number of networks exceeds [`MAX_NETS`].
+    pub fn with_nets(mut self, nets: &[IpNet]) -> Self {
         for &net in nets {
-            self = self.with_remote_region(net);
+            self = self.with_net(net);
         }
         self
     }
 
     /// Set how often (in reconciliation rounds) the full anti-entropy comparison is sent to
-    /// remote-region peers (default `6`). See [`cross_region_interval`](Config::cross_region_interval).
-    pub fn with_cross_region_interval(mut self, interval: u32) -> Self {
-        self.cross_region_interval = interval;
+    /// remote-network peers (default `6`). See [`remote_interval`](Config::remote_interval).
+    pub fn with_remote_interval(mut self, interval: u32) -> Self {
+        self.remote_interval = interval;
         self
     }
 
-    /// Set the maximum number of peers contacted per remote region on each cross-region round
-    /// (default `2`). See [`cross_region_fanout`](Config::cross_region_fanout).
-    pub fn with_cross_region_fanout(mut self, fanout: usize) -> Self {
-        self.cross_region_fanout = fanout;
+    /// Set the maximum number of peers contacted per remote network on each cross-network round
+    /// (default `2`). See [`remote_fanout`](Config::remote_fanout).
+    pub fn with_remote_fanout(mut self, fanout: usize) -> Self {
+        self.remote_fanout = fanout;
         self
     }
 
@@ -567,7 +564,7 @@ mod reconcile_store_tests {
 
     use crate::reconcile_engine::version_hash;
     use crate::{
-        reconcile_store::{Config, MAX_REGIONS},
+        reconcile_store::{Config, MAX_NETS},
         FileSnapshot, ReconcileStore,
     };
 
@@ -577,10 +574,9 @@ mod reconcile_store_tests {
         Config {
             port: 0,
             listen_addr: "127.0.0.1".parse().unwrap(),
-            local_region: "127.0.0.1/8".parse().unwrap(),
-            remote_regions: [None; MAX_REGIONS],
-            cross_region_interval: 6,
-            cross_region_fanout: 2,
+            nets: [None; MAX_NETS],
+            remote_interval: 6,
+            remote_fanout: 2,
             cluster_key: None,
             node_id: None,
             encrypt: false,
@@ -589,21 +585,13 @@ mod reconcile_store_tests {
 
     #[tokio::test]
     async fn tombstones_expiration() {
-        let config = Config {
-            // A dedicated port (and a singleton peer net) isolates this test from the
-            // integration tests: peer discovery probes random addresses in the peer net on
-            // this port, so an overlapping port lets a concurrently-running test's node inject
-            // updates here.
-            port: 8090,
-            listen_addr: "127.0.0.45".parse().unwrap(),
-            local_region: "127.0.0.45/32".parse().unwrap(),
-            remote_regions: [None; MAX_REGIONS],
-            cross_region_interval: 6,
-            cross_region_fanout: 2,
-            cluster_key: None,
-            node_id: None,
-            encrypt: false,
-        };
+        // A dedicated port (and a singleton /32 net) isolates this test from the integration
+        // tests: peer discovery probes random addresses in the net on this port, so an overlapping
+        // port lets a concurrently-running test's node inject updates here.
+        let config = Config::default()
+            .with_port(8090)
+            .with_listen_addr("127.0.0.45".parse().unwrap())
+            .with_net("127.0.0.45/32".parse().unwrap());
         let store = ReconcileStore::<i32, i32>::new(config)
             .await
             .with_tombstone_timeout(Duration::from_millis(1));

--- a/src/reconcile_store.rs
+++ b/src/reconcile_store.rs
@@ -386,7 +386,7 @@ impl<
 }
 
 /// Maximum number of **additional** (remote) geographical regions a [`Config`] can declare,
-/// beyond the local [`peer_net`](Config::peer_net). A fixed-size array keeps [`Config`] `Copy`;
+/// beyond the local [`local_region`](Config::local_region). A fixed-size array keeps [`Config`] `Copy`;
 /// eight regions is generous for real geographical deployments.
 pub const MAX_REGIONS: usize = 8;
 
@@ -397,17 +397,17 @@ pub struct Config {
     /// CIDR of the **local** geographical region: the subnet this node reconciles with
     /// aggressively (every round) and probes for auto-discovery. With a single region this is the
     /// whole cluster network (the historical behaviour).
-    pub peer_net: IpNet,
+    pub local_region: IpNet,
     /// Additional **remote** geographical regions, each a CIDR (issue #53). Empty slots are `None`.
     ///
-    /// Set through [`with_region`](Config::with_region) / [`with_regions`](Config::with_regions).
+    /// Set through [`with_remote_region`](Config::with_remote_region) / [`with_remote_regions`](Config::with_remote_regions).
     /// A node auto-discovers peers in every region (one random probe per region per round) but
     /// only gossips the full anti-entropy comparison to remote-region peers on a slower cadence
     /// and to a bounded random subset, so cross-region (WAN) traffic stays bounded. A peer's
     /// region is derived purely from its IP address (`IpNet::contains`), so the wire format is
     /// unchanged. With no remote region declared, behaviour is identical to a flat single-CIDR
     /// cluster.
-    pub regions: [Option<IpNet>; MAX_REGIONS],
+    pub remote_regions: [Option<IpNet>; MAX_REGIONS],
     /// Send the full anti-entropy comparison to remote-region peers every `cross_region_interval`
     /// reconciliation rounds (default `6`). Local-region peers are always contacted every round.
     /// Lowering this speeds cross-region convergence (and tombstone GC) at the cost of WAN traffic.
@@ -415,7 +415,7 @@ pub struct Config {
     /// Maximum number of peers contacted per remote region on each cross-region round (default
     /// `2`). Bounds WAN fan-out without designating any node as a relay/gateway. Raising it speeds
     /// cross-region convergence (and tombstone GC) at the cost of WAN traffic.
-    pub remote_fanout: usize,
+    pub cross_region_fanout: usize,
     /// Optional shared cluster secret enabling per-datagram MAC authentication.
     ///
     /// When `None` (the default), the protocol is **unauthenticated**: any host able to send a
@@ -445,10 +445,10 @@ impl Default for Config {
         Config {
             port: 0,
             listen_addr: "127.0.0.1".parse().unwrap(),
-            peer_net: "127.0.0.1/8".parse().unwrap(),
-            regions: [None; MAX_REGIONS],
+            local_region: "127.0.0.1/8".parse().unwrap(),
+            remote_regions: [None; MAX_REGIONS],
             cross_region_interval: 6,
-            remote_fanout: 2,
+            cross_region_fanout: 2,
             cluster_key: None,
             node_id: None,
             encrypt: false,
@@ -464,22 +464,22 @@ impl Config {
         self.listen_addr = listen_addr;
         self
     }
-    pub fn with_peer_net(mut self, peer_net: IpNet) -> Self {
-        self.peer_net = peer_net;
+    pub fn with_local_region(mut self, local_region: IpNet) -> Self {
+        self.local_region = local_region;
         self
     }
 
     /// Declare an additional remote geographical region by its CIDR (issue #53).
     ///
     /// The node auto-discovers peers in this region and reconciles with them over WAN-bounded,
-    /// geography-aware gossip (see [`regions`](Config::regions)). Chainable to add several regions.
+    /// geography-aware gossip (see [`remote_regions`](Config::remote_regions)). Chainable to add several regions.
     ///
     /// # Panics
     ///
     /// Panics if more than [`MAX_REGIONS`] additional regions are declared.
-    pub fn with_region(mut self, net: IpNet) -> Self {
+    pub fn with_remote_region(mut self, net: IpNet) -> Self {
         let slot = self
-            .regions
+            .remote_regions
             .iter_mut()
             .find(|slot| slot.is_none())
             .unwrap_or_else(|| panic!("at most {MAX_REGIONS} additional regions are supported"));
@@ -487,14 +487,14 @@ impl Config {
         self
     }
 
-    /// Declare several additional remote regions at once (see [`with_region`](Config::with_region)).
+    /// Declare several additional remote regions at once (see [`with_remote_region`](Config::with_remote_region)).
     ///
     /// # Panics
     ///
     /// Panics if the total number of additional regions exceeds [`MAX_REGIONS`].
-    pub fn with_regions(mut self, nets: &[IpNet]) -> Self {
+    pub fn with_remote_regions(mut self, nets: &[IpNet]) -> Self {
         for &net in nets {
-            self = self.with_region(net);
+            self = self.with_remote_region(net);
         }
         self
     }
@@ -507,9 +507,9 @@ impl Config {
     }
 
     /// Set the maximum number of peers contacted per remote region on each cross-region round
-    /// (default `2`). See [`remote_fanout`](Config::remote_fanout).
-    pub fn with_remote_fanout(mut self, fanout: usize) -> Self {
-        self.remote_fanout = fanout;
+    /// (default `2`). See [`cross_region_fanout`](Config::cross_region_fanout).
+    pub fn with_cross_region_fanout(mut self, fanout: usize) -> Self {
+        self.cross_region_fanout = fanout;
         self
     }
 
@@ -577,10 +577,10 @@ mod reconcile_store_tests {
         Config {
             port: 0,
             listen_addr: "127.0.0.1".parse().unwrap(),
-            peer_net: "127.0.0.1/8".parse().unwrap(),
-            regions: [None; MAX_REGIONS],
+            local_region: "127.0.0.1/8".parse().unwrap(),
+            remote_regions: [None; MAX_REGIONS],
             cross_region_interval: 6,
-            remote_fanout: 2,
+            cross_region_fanout: 2,
             cluster_key: None,
             node_id: None,
             encrypt: false,
@@ -596,10 +596,10 @@ mod reconcile_store_tests {
             // updates here.
             port: 8090,
             listen_addr: "127.0.0.45".parse().unwrap(),
-            peer_net: "127.0.0.45/32".parse().unwrap(),
-            regions: [None; MAX_REGIONS],
+            local_region: "127.0.0.45/32".parse().unwrap(),
+            remote_regions: [None; MAX_REGIONS],
             cross_region_interval: 6,
-            remote_fanout: 2,
+            cross_region_fanout: 2,
             cluster_key: None,
             node_id: None,
             encrypt: false,

--- a/src/reconcile_store.rs
+++ b/src/reconcile_store.rs
@@ -9,6 +9,7 @@
 //! Provides the [`ReconcileStore`], a wrapper to a key-value map
 //! to enable reconciliation between different instances over a network.
 
+use std::collections::{HashMap, HashSet};
 use std::fmt::Debug;
 use std::hash::Hash;
 use std::net::IpAddr;
@@ -20,8 +21,9 @@ use chrono::{DateTime, Utc};
 use ipnet::IpNet;
 use parking_lot::{MappedRwLockReadGuard, RwLockReadGuard};
 use serde::{de::DeserializeOwned, Serialize};
-use tracing::{info, instrument, warn};
+use tracing::{debug, info, instrument, warn};
 
+use crate::discovery::{Discovery, DnsDiscovery};
 use crate::fingerprint::Fingerprint;
 use crate::hlc::Hlc;
 use crate::persistence::{DatedEntries, InMemoryPersistence, PersistedState, Persistence};
@@ -33,6 +35,13 @@ const TOMBSTONE_CLEARING: Duration = Duration::from_secs(1);
 
 /// How often the background task writes a full snapshot to the persistence backend.
 const SNAPSHOT_INTERVAL: Duration = Duration::from_secs(5);
+
+/// Default cadence of the dynamic-discovery task (see [`ReconcileStore::with_discovery_interval`]).
+const DEFAULT_DISCOVERY_INTERVAL: Duration = Duration::from_secs(5);
+
+/// Default number of consecutive discovery rounds a member may be absent before it is
+/// decommissioned (see [`ReconcileStore::with_discovery_miss_threshold`]).
+const DEFAULT_DISCOVERY_MISS_THRESHOLD: u32 = 3;
 
 /// Core service wrapping a key-value map to enable reconciliation between different instances over a network.
 ///
@@ -57,6 +66,14 @@ where
     /// Durable backend. Always present (the trait is mandatory); defaults to the non-durable
     /// [`InMemoryPersistence`], swapped out via [`with_persistence`](ReconcileStore::with_persistence).
     persistence: Arc<dyn Persistence<K, V>>,
+    /// Optional dynamic peer-discovery source (e.g. Kubernetes DNS). When `None` (the default),
+    /// discovery falls back entirely to the per-network random probing in the engine; when set, a
+    /// background task injects the discovered peers and decommissions vanished ones.
+    discovery: Option<Arc<dyn Discovery>>,
+    /// How often the discovery task resolves the peer set.
+    discovery_interval: Duration,
+    /// Consecutive missed discovery rounds before a vanished member is decommissioned.
+    discovery_miss_threshold: u32,
 }
 
 impl<K, V> Clone for ReconcileStore<K, V>
@@ -70,6 +87,9 @@ where
             engine: self.engine.clone(),
             tombstones: self.tombstones.clone(),
             persistence: self.persistence.clone(),
+            discovery: self.discovery.clone(),
+            discovery_interval: self.discovery_interval,
+            discovery_miss_threshold: self.discovery_miss_threshold,
         }
     }
 }
@@ -85,6 +105,9 @@ impl<
             engine: ReconcileEngine::<K, (Hlc, Option<V>)>::new(config).await,
             tombstones: TimeoutWheel::new(),
             persistence: Arc::new(InMemoryPersistence::default()),
+            discovery: None,
+            discovery_interval: DEFAULT_DISCOVERY_INTERVAL,
+            discovery_miss_threshold: DEFAULT_DISCOVERY_MISS_THRESHOLD,
         };
         svc.add_pre_insert(|_, _| {});
         svc
@@ -152,6 +175,58 @@ impl<
     pub fn with_seed(self, peer: IpAddr) -> Self {
         let now = Instant::now();
         self.engine.peers.write().insert(peer, now);
+        self
+    }
+
+    /// Register (or refresh) a known peer **at runtime**, the `&self` counterpart of
+    /// [`with_seed`](Self::with_seed).
+    ///
+    /// This re-arms the peer-expiration window and makes the address a gossip target on the next
+    /// round. It is what a dynamic discovery source feeds into the store; it never grants
+    /// causal-stability membership (which a peer must still earn via an authenticated dated
+    /// datagram), so injecting an unverified address can never block tombstone garbage collection.
+    pub fn seed_peer(&self, peer: IpAddr) {
+        self.engine.seed_peer(peer);
+    }
+
+    /// Attach a dynamic peer-discovery source, replacing the engine's random per-network probing as
+    /// the way peers are found.
+    ///
+    /// While the store is [`run`](Self::run)ning, a background task calls
+    /// [`Discovery::discover`] every
+    /// [`discovery_interval`](Self::with_discovery_interval), seeds every returned address as a
+    /// known peer, and — after a member has been absent for
+    /// [`discovery_miss_threshold`](Self::with_discovery_miss_threshold) consecutive successful
+    /// rounds — decommissions it (see [`forget_peer`](Self::forget_peer)) so its tombstones stop
+    /// gating garbage collection. See [`with_dns_discovery`](Self::with_dns_discovery) for the
+    /// Kubernetes-native default.
+    pub fn with_discovery(mut self, discovery: Arc<dyn Discovery>) -> Self {
+        self.discovery = Some(discovery);
+        self
+    }
+
+    /// Discover peers by resolving a DNS name — the Kubernetes-native default.
+    ///
+    /// Point `name` at a **headless** `Service` (`clusterIP: None`): its DNS name resolves to one
+    /// address record per ready pod, so the store learns every peer with a single lookup, with no
+    /// Kubernetes API client and no RBAC. `port` is the reconciliation UDP port. Shorthand for
+    /// [`with_discovery`](Self::with_discovery) with a [`DnsDiscovery`].
+    pub fn with_dns_discovery(self, name: impl Into<String>, port: u16) -> Self {
+        self.with_discovery(Arc::new(DnsDiscovery::new(name, port)))
+    }
+
+    /// Set how often the discovery task resolves the peer set (default 5 s). Only relevant when a
+    /// discovery source is configured via [`with_discovery`](Self::with_discovery).
+    pub fn with_discovery_interval(mut self, interval: Duration) -> Self {
+        self.discovery_interval = interval;
+        self
+    }
+
+    /// Set how many consecutive successful discovery rounds a previously-seen member may be absent
+    /// before it is decommissioned (default 3). A higher value tolerates longer DNS blips / rolling
+    /// restarts at the cost of holding tombstones (and their GC gate) longer.
+    pub fn with_discovery_miss_threshold(mut self, threshold: u32) -> Self {
+        self.discovery_miss_threshold = threshold;
         self
     }
 
@@ -409,15 +484,81 @@ impl<
         }
     }
 
+    /// Drive the dynamic discovery source: inject discovered peers and decommission vanished ones.
+    ///
+    /// Returns immediately (a no-op) when no discovery source is configured, so the default
+    /// random-probing behaviour is unchanged. Otherwise, every
+    /// [`discovery_interval`](Self::with_discovery_interval):
+    ///
+    /// - On a **successful** resolution, every returned address (except this node's own) is seeded
+    ///   as a known peer, re-arming its expiration and feeding it to the next gossip round.
+    /// - A previously-seen **member** that is now absent has its miss count incremented; once it
+    ///   reaches [`discovery_miss_threshold`](Self::with_discovery_miss_threshold) it is
+    ///   decommissioned, releasing the causal-stability gate it held on tombstone GC.
+    /// - A **failed** resolution (DNS blip) is skipped entirely — it never counts as a miss — so a
+    ///   transient resolver hiccup cannot decommission a healthy peer.
+    ///
+    /// Only `members` are considered for decommissioning: membership is what gates tombstone GC, it
+    /// is earned through a real authenticated datagram, and discovery never writes to it — so a
+    /// spoofable or never-contacted address can neither block nor be the subject of GC release.
+    async fn discover_periodically(&self) {
+        let Some(discovery) = self.discovery.clone() else {
+            return; // no discovery source: leave peer-finding to the engine's per-net probing
+        };
+        let own_addr = self.engine.listen_addr();
+        // Consecutive missed rounds per member, and the set of addresses discovery has ever
+        // reported (so we only grace-decommission members we actually discovered, never peers
+        // learned by other means).
+        let mut miss_counts: HashMap<IpAddr, u32> = HashMap::new();
+        let mut seen_ever: HashSet<IpAddr> = HashSet::new();
+        loop {
+            tokio::time::sleep(self.discovery_interval).await;
+            let resolved = match discovery.discover().await {
+                Ok(addrs) => addrs,
+                Err(err) => {
+                    // Transient failure: do not touch miss counts, do not decommission anyone.
+                    debug!("discovery round failed, skipping: {err}");
+                    continue;
+                }
+            };
+            let current: HashSet<IpAddr> = resolved
+                .into_iter()
+                .filter(|addr| *addr != own_addr)
+                .collect();
+            // 1) Refresh every currently-present peer.
+            for addr in &current {
+                seen_ever.insert(*addr);
+                self.engine.seed_peer(*addr);
+                miss_counts.remove(addr);
+            }
+            // 2) Grace-account members that were discovered before but are now absent.
+            for member in self.engine.members_snapshot() {
+                if member == own_addr || current.contains(&member) || !seen_ever.contains(&member) {
+                    continue;
+                }
+                let misses = miss_counts.entry(member).or_insert(0);
+                *misses += 1;
+                if *misses >= self.discovery_miss_threshold {
+                    info!("decommissioning vanished peer {member} after {misses} missed discovery rounds");
+                    self.engine.decommission_peer(member);
+                    miss_counts.remove(&member);
+                    seen_ever.remove(&member);
+                }
+            }
+        }
+    }
+
     #[instrument(name = "reconcile.store", skip_all)]
     pub async fn run(self) {
         info!("reconcile store starting");
         let tombstones = self.clone();
         let snapshots = self.clone();
+        let discovery = self.clone();
         tokio::join!(
             self.engine.run(),
             tombstones.clear_expired_tombstones(),
             snapshots.snapshot_periodically(),
+            discovery.discover_periodically(),
         );
     }
 }
@@ -810,5 +951,136 @@ mod reconcile_store_tests {
             !restarted.engine.is_tombstone_stable(&1, version),
             "restart dropped causal-stability state: tombstone would be GC'd and could resurrect"
         );
+    }
+
+    use std::sync::Mutex;
+
+    use crate::discovery::{DiscoverFuture, Discovery};
+
+    /// A scriptable discovery source for the grace/decommission tests. The test thread swaps the
+    /// response while the discovery loop runs.
+    #[derive(Clone)]
+    struct FakeDiscovery {
+        resp: Arc<Mutex<FakeResp>>,
+    }
+
+    #[derive(Clone)]
+    enum FakeResp {
+        /// A successful resolution returning this peer set.
+        Present(Vec<IpAddr>),
+        /// A transient failure (DNS blip).
+        Blip,
+    }
+
+    impl FakeDiscovery {
+        fn new(initial: FakeResp) -> Self {
+            FakeDiscovery {
+                resp: Arc::new(Mutex::new(initial)),
+            }
+        }
+        fn set(&self, resp: FakeResp) {
+            *self.resp.lock().unwrap() = resp;
+        }
+    }
+
+    impl Discovery for FakeDiscovery {
+        fn discover(&self) -> DiscoverFuture<'_> {
+            let resp = self.resp.lock().unwrap().clone();
+            Box::pin(async move {
+                match resp {
+                    FakeResp::Present(addrs) => Ok(addrs),
+                    FakeResp::Blip => Err(std::io::Error::new(std::io::ErrorKind::Other, "blip")),
+                }
+            })
+        }
+    }
+
+    fn discovery_config() -> Config {
+        // A real, bindable loopback address (the engine binds a socket in `new`) on an ephemeral
+        // port. No `with_net`, mirroring the Kubernetes setup where discovery is purely DNS-driven.
+        Config::default()
+            .with_port(0)
+            .with_listen_addr("127.0.0.1".parse().unwrap())
+    }
+
+    /// A member that vanishes from discovery for `miss_threshold` consecutive successful rounds is
+    /// decommissioned; the node never decommissions itself even when absent from the result.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn discovery_decommissions_vanished_member_but_not_self() {
+        let own: IpAddr = "127.0.0.1".parse().unwrap();
+        let member: IpAddr = "127.0.0.200".parse().unwrap();
+
+        let fake = FakeDiscovery::new(FakeResp::Present(vec![member]));
+        let store = ReconcileStore::<i32, i32>::new(discovery_config())
+            .await
+            .with_discovery(Arc::new(fake.clone()))
+            .with_discovery_interval(Duration::from_millis(20))
+            .with_discovery_miss_threshold(3);
+
+        // Seed membership as if both had been contacted via dated datagrams.
+        store.engine.members.write().insert(own);
+        store.engine.members.write().insert(member);
+
+        let loop_store = store.clone();
+        let handle = tokio::spawn(async move { loop_store.discover_periodically().await });
+
+        // While the member is present in discovery it must not be decommissioned.
+        tokio::time::sleep(Duration::from_millis(120)).await;
+        assert!(
+            store.engine.members.read().contains(&member),
+            "present member was wrongly decommissioned"
+        );
+
+        // The member vanishes; after the miss threshold it is decommissioned, but self is kept.
+        fake.set(FakeResp::Present(vec![]));
+        tokio::time::sleep(Duration::from_millis(300)).await;
+        assert!(
+            !store.engine.members.read().contains(&member),
+            "vanished member was not decommissioned after the grace period"
+        );
+        assert!(
+            store.engine.members.read().contains(&own),
+            "node decommissioned itself"
+        );
+
+        handle.abort();
+    }
+
+    /// A transient discovery failure (DNS blip) must never decommission a member, however long it
+    /// lasts; only a successful resolution that omits the member counts toward the grace threshold.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn discovery_blip_does_not_decommission() {
+        let member: IpAddr = "127.0.0.201".parse().unwrap();
+
+        // Report the member present once so it enters `seen_ever`, then fail forever.
+        let fake = FakeDiscovery::new(FakeResp::Present(vec![member]));
+        let store = ReconcileStore::<i32, i32>::new(discovery_config())
+            .await
+            .with_discovery(Arc::new(fake.clone()))
+            .with_discovery_interval(Duration::from_millis(20))
+            .with_discovery_miss_threshold(3);
+        store.engine.members.write().insert(member);
+
+        let loop_store = store.clone();
+        let handle = tokio::spawn(async move { loop_store.discover_periodically().await });
+
+        // Let the member be observed present at least once, then switch to permanent blips.
+        tokio::time::sleep(Duration::from_millis(60)).await;
+        fake.set(FakeResp::Blip);
+        tokio::time::sleep(Duration::from_millis(300)).await;
+        assert!(
+            store.engine.members.read().contains(&member),
+            "a transient discovery failure wrongly decommissioned a member"
+        );
+
+        // Sanity: a genuine absence still decommissions, proving the mechanism is live.
+        fake.set(FakeResp::Present(vec![]));
+        tokio::time::sleep(Duration::from_millis(300)).await;
+        assert!(
+            !store.engine.members.read().contains(&member),
+            "member was not decommissioned once it genuinely vanished"
+        );
+
+        handle.abort();
     }
 }

--- a/src/timeout_wheel.rs
+++ b/src/timeout_wheel.rs
@@ -11,7 +11,8 @@ const DEFAULT_TIMEOUT: Duration = Duration::from_secs(60);
 pub(crate) struct TimeoutWheel<T: Clone + Hash + std::cmp::Eq> {
     wheel: Arc<RwLock<BTreeMap<DateTime<Utc>, T>>>,
     map: Arc<RwLock<HashMap<T, DateTime<Utc>>>>,
-    timeout: Duration,
+    /// Shared so the expiry timeout can be retuned at runtime (see [`set_timeout`](Self::set_timeout)).
+    timeout: Arc<RwLock<Duration>>,
 }
 
 impl<T: Clone + Hash + std::cmp::Eq> TimeoutWheel<T> {
@@ -19,13 +20,18 @@ impl<T: Clone + Hash + std::cmp::Eq> TimeoutWheel<T> {
         TimeoutWheel {
             wheel: Arc::new(RwLock::new(BTreeMap::new())),
             map: Arc::new(RwLock::new(HashMap::new())),
-            timeout: DEFAULT_TIMEOUT,
+            timeout: Arc::new(RwLock::new(DEFAULT_TIMEOUT)),
         }
     }
 
-    pub fn with_timeout(mut self, timeout: Duration) -> Self {
-        self.timeout = timeout;
+    pub fn with_timeout(self, timeout: Duration) -> Self {
+        *self.timeout.write().unwrap() = timeout;
         self
+    }
+
+    /// (runtime) Retune the expiry timeout in place, visible to all clones.
+    pub fn set_timeout(&self, timeout: Duration) {
+        *self.timeout.write().unwrap() = timeout;
     }
 
     pub fn insert(&self, e: T, instant: DateTime<Utc>) {
@@ -40,11 +46,12 @@ impl<T: Clone + Hash + std::cmp::Eq> TimeoutWheel<T> {
     /// it, so the caller needs to peek expired candidates without dropping the tracking.
     pub fn expired(&self) -> Vec<T> {
         let now = Utc::now();
+        let timeout = *self.timeout.read().unwrap();
         self.wheel
             .read()
             .unwrap()
             .iter()
-            .take_while(|(instant, _)| **instant + self.timeout < now)
+            .take_while(|(instant, _)| **instant + timeout < now)
             .map(|(_, value)| value.clone())
             .collect()
     }

--- a/tests/discovery.rs
+++ b/tests/discovery.rs
@@ -1,0 +1,119 @@
+// Copyright 2023 Developers of the reconcile project.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! End-to-end test of dynamic discovery through the public `run()` path: a peer that disappears
+//! from the discovery source is decommissioned after the grace period, releasing the causal
+//! stability gate that was holding back a tombstone's garbage collection.
+
+use std::net::IpAddr;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use reconcile::discovery::{DiscoverFuture, Discovery};
+use reconcile::{reconcile_store::Config, ReconcileStore};
+
+async fn wait_until<F: FnMut() -> bool>(mut f: F) -> bool {
+    for _ in 0..200 {
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        if f() {
+            return true;
+        }
+    }
+    false
+}
+
+macro_rules! assert_until {
+    ( $x:expr ) => {
+        assert!(wait_until(|| $x).await, stringify!($x))
+    };
+}
+
+/// A discovery source whose returned peer set the test mutates at runtime.
+#[derive(Clone)]
+struct ScriptedDiscovery {
+    addrs: Arc<Mutex<Vec<IpAddr>>>,
+}
+
+impl ScriptedDiscovery {
+    fn new(initial: Vec<IpAddr>) -> Self {
+        ScriptedDiscovery {
+            addrs: Arc::new(Mutex::new(initial)),
+        }
+    }
+    fn set(&self, addrs: Vec<IpAddr>) {
+        *self.addrs.lock().unwrap() = addrs;
+    }
+}
+
+impl Discovery for ScriptedDiscovery {
+    fn discover(&self) -> DiscoverFuture<'_> {
+        let addrs = self.addrs.lock().unwrap().clone();
+        Box::pin(async move { Ok(addrs) })
+    }
+}
+
+/// A peer that vanishes from discovery is decommissioned after the grace period, which lets a
+/// tombstone it had not acknowledged finally be garbage-collected.
+#[tokio::test(flavor = "multi_thread")]
+async fn vanished_peer_is_decommissioned_and_tombstone_collected() {
+    let port = 8097; // dedicated port isolates this test's random probing from the others
+    let net = "127.0.0.1/8".parse().unwrap();
+    let addr1: IpAddr = "127.0.0.86".parse().unwrap();
+    let addr2: IpAddr = "127.0.0.87".parse().unwrap();
+    let cfg1 = Config::default()
+        .with_port(port)
+        .with_listen_addr(addr1)
+        .with_net(net);
+    let cfg2 = Config::default()
+        .with_port(port)
+        .with_listen_addr(addr2)
+        .with_net(net);
+
+    // store1 finds peers through discovery (which initially reports store2 present).
+    let discovery = ScriptedDiscovery::new(vec![addr2]);
+    let store1 = ReconcileStore::<i32, i32>::new(cfg1)
+        .await
+        .with_seed(addr2)
+        .with_tombstone_timeout(Duration::from_millis(50))
+        .with_discovery(Arc::new(discovery.clone()))
+        .with_discovery_interval(Duration::from_millis(20))
+        .with_discovery_miss_threshold(3);
+    let store2 = ReconcileStore::<i32, i32>::new(cfg2)
+        .await
+        .with_seed(addr1)
+        .with_tombstone_timeout(Duration::from_millis(50));
+
+    let task1 = tokio::spawn(store1.clone().run());
+    let task2 = tokio::spawn(store2.clone().run());
+
+    // Establish mutual membership by exchanging a value in each direction.
+    store1.insert(1, 11);
+    assert_until!(store2.get(&1).as_deref() == Some(&11));
+    store2.insert(2, 22);
+    assert_until!(store1.get(&2).as_deref() == Some(&22));
+
+    // Partition store2 but keep reporting it present in discovery: its tombstone gate holds.
+    task2.abort();
+    store1.remove(&1);
+    assert!(store1.get(&1).is_none());
+    let hash_with_tombstone = store1.fingerprint(..);
+
+    tokio::time::sleep(Duration::from_millis(1500)).await;
+    assert_eq!(
+        store1.fingerprint(..),
+        hash_with_tombstone,
+        "tombstone collected while the peer was still reported present (resurrection hazard)"
+    );
+
+    // The peer now disappears from discovery: after the grace period it is decommissioned and the
+    // tombstone becomes causally stable, so GC proceeds.
+    discovery.set(vec![]);
+    assert_until!(store1.fingerprint(..) != hash_with_tombstone);
+
+    task1.abort();
+}

--- a/tests/mirror.rs
+++ b/tests/mirror.rs
@@ -41,7 +41,7 @@ macro_rules! assert_until {
 #[tokio::test(flavor = "multi_thread")]
 async fn mirror_converges_with_dated_store() {
     let port = 8086;
-    let peer_net = "127.0.0.1/8".parse().unwrap();
+    let local_region = "127.0.0.1/8".parse().unwrap();
     let dated_addr = "127.0.0.90".parse().unwrap();
     let mirror_addr = "127.0.0.91".parse().unwrap();
 
@@ -49,7 +49,7 @@ async fn mirror_converges_with_dated_store() {
         Config::default()
             .with_port(port)
             .with_listen_addr(dated_addr)
-            .with_peer_net(peer_net),
+            .with_local_region(local_region),
     )
     .await;
     // Seed the mirror with the dated store's address: the mirror *drives* reconciliation over the
@@ -58,7 +58,7 @@ async fn mirror_converges_with_dated_store() {
         Config::default()
             .with_port(port)
             .with_listen_addr(mirror_addr)
-            .with_peer_net(peer_net),
+            .with_local_region(local_region),
     )
     .await
     .with_seed(dated_addr);
@@ -105,7 +105,7 @@ async fn mirror_converges_with_dated_store() {
 #[tokio::test(flavor = "multi_thread")]
 async fn mirror_does_not_block_tombstone_gc() {
     let port = 8087;
-    let peer_net = "127.0.0.1/8".parse().unwrap();
+    let local_region = "127.0.0.1/8".parse().unwrap();
     let dated_addr = "127.0.0.92".parse().unwrap();
     let mirror_addr = "127.0.0.93".parse().unwrap();
 
@@ -114,7 +114,7 @@ async fn mirror_does_not_block_tombstone_gc() {
         Config::default()
             .with_port(port)
             .with_listen_addr(dated_addr)
-            .with_peer_net(peer_net),
+            .with_local_region(local_region),
     )
     .await
     .with_tombstone_timeout(Duration::from_millis(50));
@@ -122,7 +122,7 @@ async fn mirror_does_not_block_tombstone_gc() {
         Config::default()
             .with_port(port)
             .with_listen_addr(mirror_addr)
-            .with_peer_net(peer_net),
+            .with_local_region(local_region),
     )
     .await
     .with_seed(dated_addr);

--- a/tests/mirror.rs
+++ b/tests/mirror.rs
@@ -41,7 +41,7 @@ macro_rules! assert_until {
 #[tokio::test(flavor = "multi_thread")]
 async fn mirror_converges_with_dated_store() {
     let port = 8086;
-    let local_region = "127.0.0.1/8".parse().unwrap();
+    let net = "127.0.0.1/8".parse().unwrap();
     let dated_addr = "127.0.0.90".parse().unwrap();
     let mirror_addr = "127.0.0.91".parse().unwrap();
 
@@ -49,7 +49,7 @@ async fn mirror_converges_with_dated_store() {
         Config::default()
             .with_port(port)
             .with_listen_addr(dated_addr)
-            .with_local_region(local_region),
+            .with_net(net),
     )
     .await;
     // Seed the mirror with the dated store's address: the mirror *drives* reconciliation over the
@@ -58,7 +58,7 @@ async fn mirror_converges_with_dated_store() {
         Config::default()
             .with_port(port)
             .with_listen_addr(mirror_addr)
-            .with_local_region(local_region),
+            .with_net(net),
     )
     .await
     .with_seed(dated_addr);
@@ -105,7 +105,7 @@ async fn mirror_converges_with_dated_store() {
 #[tokio::test(flavor = "multi_thread")]
 async fn mirror_does_not_block_tombstone_gc() {
     let port = 8087;
-    let local_region = "127.0.0.1/8".parse().unwrap();
+    let net = "127.0.0.1/8".parse().unwrap();
     let dated_addr = "127.0.0.92".parse().unwrap();
     let mirror_addr = "127.0.0.93".parse().unwrap();
 
@@ -114,7 +114,7 @@ async fn mirror_does_not_block_tombstone_gc() {
         Config::default()
             .with_port(port)
             .with_listen_addr(dated_addr)
-            .with_local_region(local_region),
+            .with_net(net),
     )
     .await
     .with_tombstone_timeout(Duration::from_millis(50));
@@ -122,7 +122,7 @@ async fn mirror_does_not_block_tombstone_gc() {
         Config::default()
             .with_port(port)
             .with_listen_addr(mirror_addr)
-            .with_local_region(local_region),
+            .with_net(net),
     )
     .await
     .with_seed(dated_addr);

--- a/tests/observability.rs
+++ b/tests/observability.rs
@@ -26,7 +26,7 @@ fn local_config() -> Config {
     Config::default()
         .with_port(0) // ephemeral port: avoids clashing with the other integration tests
         .with_listen_addr("127.0.0.1".parse().unwrap())
-        .with_local_region("127.0.0.1/8".parse().unwrap())
+        .with_net("127.0.0.1/8".parse().unwrap())
 }
 
 /// Keep every `tracing` callsite "hot" for the whole test binary.

--- a/tests/observability.rs
+++ b/tests/observability.rs
@@ -26,7 +26,7 @@ fn local_config() -> Config {
     Config::default()
         .with_port(0) // ephemeral port: avoids clashing with the other integration tests
         .with_listen_addr("127.0.0.1".parse().unwrap())
-        .with_peer_net("127.0.0.1/8".parse().unwrap())
+        .with_local_region("127.0.0.1/8".parse().unwrap())
 }
 
 /// Keep every `tracing` callsite "hot" for the whole test binary.

--- a/tests/service.rs
+++ b/tests/service.rs
@@ -572,8 +572,10 @@ async fn cross_region_reconciliation() {
 }
 
 /// Issue #53: a node auto-discovers a peer in another region purely from the region's CIDR, with no
-/// seed. Discovery probes one random address per region each round; over a /30 (4 addresses) this
-/// converges quickly.
+/// seed. Discovery probes one random address per region each round. To keep the test deterministic
+/// (rather than relying on a random probe landing on the peer within a subnet), each node declares
+/// the *other node's exact address* as a remote region (a /32), so the per-region discovery probe
+/// reliably targets the peer. The local region stays a /30 so local-region probing is unaffected.
 #[tokio::test(flavor = "multi_thread")]
 async fn cross_region_discovery_without_seed() {
     let port = 8086;
@@ -581,18 +583,21 @@ async fn cross_region_discovery_without_seed() {
     let region_b = "127.0.3.0/30".parse().unwrap();
     let addr1 = "127.0.2.1".parse().unwrap();
     let addr2 = "127.0.3.1".parse().unwrap();
+    // Each node's remote region is the peer's exact address, so its discovery probe always hits it.
+    let remote_of_1 = "127.0.3.1/32".parse().unwrap();
+    let remote_of_2 = "127.0.2.1/32".parse().unwrap();
     let cfg1 = Config::default()
         .with_port(port)
         .with_listen_addr(addr1)
         .with_peer_net(region_a)
-        .with_region(region_b)
+        .with_region(remote_of_1)
         .with_cross_region_interval(1)
         .with_remote_fanout(1);
     let cfg2 = Config::default()
         .with_port(port)
         .with_listen_addr(addr2)
         .with_peer_net(region_b)
-        .with_region(region_a)
+        .with_region(remote_of_2)
         .with_cross_region_interval(1)
         .with_remote_fanout(1);
 

--- a/tests/service.rs
+++ b/tests/service.rs
@@ -616,3 +616,165 @@ async fn cross_net_discovery_without_seed() {
     task1.abort();
     task2.abort();
 }
+
+/// Runtime topology injection: a network declared **while the loop is running** must take effect
+/// without recreating the node. Two nodes start declaring only their own network and with no seed,
+/// so discovery never probes the peer and they cannot converge. Injecting the peer's network with
+/// [`add_net`](ReconcileStore::add_net) makes per-network discovery reach the peer and they converge,
+/// proving the running reconciliation loop observes the mutation.
+#[tokio::test(flavor = "multi_thread")]
+async fn runtime_add_net_enables_discovery_and_convergence() {
+    let port = 8087;
+    let net_a = "127.0.4.0/30".parse().unwrap();
+    let net_b = "127.0.5.0/30".parse().unwrap();
+    let addr1 = "127.0.4.1".parse().unwrap();
+    let addr2 = "127.0.5.1".parse().unwrap();
+    // The peer's exact address as a /32, so the per-network discovery probe reliably hits it.
+    let peer2_host = "127.0.5.1/32".parse().unwrap();
+    let peer1_host = "127.0.4.1/32".parse().unwrap();
+    // Each node initially declares ONLY its own network. Fast cadence to converge quickly.
+    let cfg1 = Config::default()
+        .with_port(port)
+        .with_listen_addr(addr1)
+        .with_net(net_a)
+        .with_remote_interval(1)
+        .with_remote_fanout(1);
+    let cfg2 = Config::default()
+        .with_port(port)
+        .with_listen_addr(addr2)
+        .with_net(net_b)
+        .with_remote_interval(1)
+        .with_remote_fanout(1);
+
+    // No seed: the nodes can only meet through per-network discovery probes.
+    let store1 = ReconcileStore::new(cfg1).await;
+    store1.insert("k".to_string(), "v".to_string());
+    let start_hash = store1.fingerprint(..);
+    let store2 = ReconcileStore::<String, String>::new(cfg2).await;
+
+    let task2 = tokio::spawn(store2.clone().run());
+    let task1 = tokio::spawn(store1.clone().run());
+
+    // Without the peer's network declared, discovery never reaches it, so no convergence.
+    assert!(
+        !wait_until(|| store2.fingerprint(..) == start_hash).await,
+        "nodes converged before the peer network was declared"
+    );
+
+    // Inject the peer network at runtime on both nodes — discovery now probes the peer.
+    store1.add_net(peer2_host);
+    store2.add_net(peer1_host);
+
+    // The running loops pick up the new network and converge.
+    assert_until!(store2.fingerprint(..) == start_hash);
+
+    task1.abort();
+    task2.abort();
+}
+
+/// Repair is decoupled from net membership: a peer learned by contact (here, seeded) is reconciled
+/// even when its address is in **none** of the declared networks (the `unclassified` bucket). Both
+/// nodes declare a single network that contains *neither* node's address, so each node's local net
+/// falls back to its own host route and the peer is unclassified — yet they still converge. This is
+/// the guarantee that makes runtime topology changes unable to cause silent divergence.
+#[tokio::test(flavor = "multi_thread")]
+async fn unclassified_peer_is_still_reconciled() {
+    let port = 8088;
+    // A declared network that contains neither node.
+    let foreign_net = "127.0.7.0/30".parse().unwrap();
+    let addr1 = "127.0.6.1".parse().unwrap();
+    let addr2 = "127.0.6.2".parse().unwrap();
+    let cfg1 = Config::default()
+        .with_port(port)
+        .with_listen_addr(addr1)
+        .with_net(foreign_net)
+        .with_remote_interval(1)
+        .with_remote_fanout(1);
+    let cfg2 = Config::default()
+        .with_port(port)
+        .with_listen_addr(addr2)
+        .with_net(foreign_net)
+        .with_remote_interval(1)
+        .with_remote_fanout(1);
+
+    // Seeded so each knows the other, even though neither address is in any declared network.
+    let store1 = ReconcileStore::new(cfg1).await.with_seed(addr2);
+    store1.insert("k".to_string(), "v".to_string());
+    let start_hash = store1.fingerprint(..);
+    let store2 = ReconcileStore::<String, String>::new(cfg2)
+        .await
+        .with_seed(addr1);
+
+    // Local net of last resort is each node's own host route (peer is not local).
+    assert_eq!(store1.local_net(), "127.0.6.1/32".parse().unwrap());
+
+    let task2 = tokio::spawn(store2.clone().run());
+    let task1 = tokio::spawn(store1.clone().run());
+
+    // Converges purely through the unclassified-peer repair bucket.
+    assert_until!(store2.fingerprint(..) == start_hash);
+
+    task1.abort();
+    task2.abort();
+}
+
+/// The runtime topology API mutates shared state and re-derives the local network consistently, and
+/// the scalar knob setters do not panic. Pure API-level checks (no run loop needed).
+#[tokio::test]
+async fn runtime_config_setters() {
+    let addr = "127.0.8.1".parse().unwrap();
+    let net_c = "127.0.8.0/30".parse().unwrap(); // contains addr
+    let net_d = "127.0.9.0/30".parse().unwrap(); // does not contain addr
+    let host_route = "127.0.8.1/32".parse().unwrap();
+
+    // Port 0 = ephemeral, so this never collides with the networked tests above.
+    let store = ReconcileStore::<i32, i32>::new(
+        Config::default()
+            .with_port(0)
+            .with_listen_addr(addr)
+            .with_net(net_c),
+    )
+    .await;
+    assert_eq!(store.nets(), vec![net_c]);
+    assert_eq!(store.local_net(), net_c);
+
+    // add_net: appends, leaves local net unchanged, and is idempotent.
+    assert!(store.add_net(net_d));
+    assert_eq!(store.local_net(), net_c);
+    assert_eq!(store.nets(), vec![net_c, net_d]);
+    assert!(store.add_net(net_d));
+    assert_eq!(store.nets().len(), 2, "add_net must be idempotent");
+
+    // remove_net: removing the local net re-derives it to the host route fallback.
+    assert!(store.remove_net(net_c));
+    assert_eq!(store.nets(), vec![net_d]);
+    assert_eq!(store.local_net(), host_route);
+    assert!(
+        !store.remove_net(net_c),
+        "removing an absent net returns false"
+    );
+
+    // set_nets: wholesale replacement re-derives the local net.
+    store.set_nets(&[net_c]);
+    assert_eq!(store.nets(), vec![net_c]);
+    assert_eq!(store.local_net(), net_c);
+
+    // add_net enforces the MAX_NETS cap (no-op + false beyond it).
+    for i in 0..(reconcile::reconcile_store::MAX_NETS - 1) {
+        let n = format!("127.1.{i}.0/30").parse().unwrap();
+        assert!(store.add_net(n));
+    }
+    assert_eq!(store.nets().len(), reconcile::reconcile_store::MAX_NETS);
+    let overflow = "127.2.0.0/30".parse().unwrap();
+    assert!(
+        !store.add_net(overflow),
+        "add_net past MAX_NETS must return false"
+    );
+    assert_eq!(store.nets().len(), reconcile::reconcile_store::MAX_NETS);
+
+    // Scalar knob setters: smoke (no getters, must not panic).
+    store.set_remote_interval(3);
+    store.set_remote_fanout(5);
+    store.set_reconcile_interval(Duration::from_millis(200));
+    store.set_tombstone_timeout(Duration::from_millis(500));
+}

--- a/tests/service.rs
+++ b/tests/service.rs
@@ -523,3 +523,90 @@ async fn encrypted_node_with_wrong_key_is_rejected() {
     task2.abort();
     task1.abort();
 }
+
+/// Issue #53: two nodes in distinct geographical regions converge over cross-region anti-entropy.
+///
+/// Regions are simulated by two disjoint /30 subnets inside the loopback range, each node living in
+/// one of them and declaring the other as a remote region. A dedicated port isolates the test.
+#[tokio::test(flavor = "multi_thread")]
+async fn cross_region_reconciliation() {
+    let port = 8085;
+    let region_a = "127.0.0.0/30".parse().unwrap();
+    let region_b = "127.0.1.0/30".parse().unwrap();
+    let addr1 = "127.0.0.1".parse().unwrap();
+    let addr2 = "127.0.1.1".parse().unwrap();
+    // Each node is local to its own region and declares the other as a remote region. A short
+    // cross-region cadence keeps the test fast.
+    let cfg1 = Config::default()
+        .with_port(port)
+        .with_listen_addr(addr1)
+        .with_peer_net(region_a)
+        .with_region(region_b)
+        .with_cross_region_interval(1)
+        .with_remote_fanout(1);
+    let cfg2 = Config::default()
+        .with_port(port)
+        .with_listen_addr(addr2)
+        .with_peer_net(region_b)
+        .with_region(region_a)
+        .with_cross_region_interval(1)
+        .with_remote_fanout(1);
+
+    let store1 = ReconcileStore::new(cfg1).await.with_seed(addr2);
+    store1.insert("key".to_string(), "value".to_string());
+    let start_hash = store1.fingerprint(..);
+    let store2 = ReconcileStore::<String, String>::new(cfg2)
+        .await
+        .with_seed(addr1);
+    assert_eq!(store2.fingerprint(..), Fingerprint::ZERO);
+
+    let task2 = tokio::spawn(store2.clone().run());
+    let task1 = tokio::spawn(store1.clone().run());
+
+    // The remote-region peer eventually receives the value over cross-region anti-entropy.
+    assert_until!(store2.get(&"key".to_string()).as_deref() == Some(&"value".to_string()));
+    assert_until!(store2.fingerprint(..) == start_hash);
+
+    task1.abort();
+    task2.abort();
+}
+
+/// Issue #53: a node auto-discovers a peer in another region purely from the region's CIDR, with no
+/// seed. Discovery probes one random address per region each round; over a /30 (4 addresses) this
+/// converges quickly.
+#[tokio::test(flavor = "multi_thread")]
+async fn cross_region_discovery_without_seed() {
+    let port = 8086;
+    let region_a = "127.0.2.0/30".parse().unwrap();
+    let region_b = "127.0.3.0/30".parse().unwrap();
+    let addr1 = "127.0.2.1".parse().unwrap();
+    let addr2 = "127.0.3.1".parse().unwrap();
+    let cfg1 = Config::default()
+        .with_port(port)
+        .with_listen_addr(addr1)
+        .with_peer_net(region_a)
+        .with_region(region_b)
+        .with_cross_region_interval(1)
+        .with_remote_fanout(1);
+    let cfg2 = Config::default()
+        .with_port(port)
+        .with_listen_addr(addr2)
+        .with_peer_net(region_b)
+        .with_region(region_a)
+        .with_cross_region_interval(1)
+        .with_remote_fanout(1);
+
+    // No `with_seed`: the two nodes must find each other purely through per-region discovery probes.
+    let store1 = ReconcileStore::new(cfg1).await;
+    store1.insert("k".to_string(), "v".to_string());
+    let start_hash = store1.fingerprint(..);
+    let store2 = ReconcileStore::<String, String>::new(cfg2).await;
+
+    let task2 = tokio::spawn(store2.clone().run());
+    let task1 = tokio::spawn(store1.clone().run());
+
+    assert_until!(store2.fingerprint(..) == start_hash);
+
+    task1.abort();
+    task2.abort();
+}

--- a/tests/service.rs
+++ b/tests/service.rs
@@ -30,17 +30,17 @@ macro_rules! assert_until {
 #[tokio::test(flavor = "multi_thread")]
 async fn test() {
     let port = 8080;
-    let peer_net = "127.0.0.1/8".parse().unwrap();
+    let local_region = "127.0.0.1/8".parse().unwrap();
     let addr1 = "127.0.0.44".parse().unwrap();
     let addr2 = "127.0.0.45".parse().unwrap();
     let cfg1 = Config::default()
         .with_port(port)
         .with_listen_addr(addr1)
-        .with_peer_net(peer_net);
+        .with_local_region(local_region);
     let cfg2 = Config::default()
         .with_port(port)
         .with_listen_addr(addr2)
-        .with_peer_net(peer_net);
+        .with_local_region(local_region);
 
     // create tree1 with many values
     let mut rng = rand::rngs::StdRng::seed_from_u64(42);
@@ -152,19 +152,19 @@ async fn test() {
 #[tokio::test(flavor = "multi_thread")]
 async fn authenticated_nodes_converge() {
     let port = 8081;
-    let peer_net = "127.0.0.1/8".parse().unwrap();
+    let local_region = "127.0.0.1/8".parse().unwrap();
     let addr1 = "127.0.0.46".parse().unwrap();
     let addr2 = "127.0.0.47".parse().unwrap();
     let key = [0x42u8; 32];
     let cfg1 = Config::default()
         .with_port(port)
         .with_listen_addr(addr1)
-        .with_peer_net(peer_net)
+        .with_local_region(local_region)
         .with_cluster_key(key);
     let cfg2 = Config::default()
         .with_port(port)
         .with_listen_addr(addr2)
-        .with_peer_net(peer_net)
+        .with_local_region(local_region)
         .with_cluster_key(key);
 
     let mut rng = rand::rngs::StdRng::seed_from_u64(42);
@@ -206,19 +206,19 @@ async fn authenticated_nodes_converge() {
 #[tokio::test(flavor = "multi_thread")]
 async fn concurrent_writes_converge() {
     let port = 8083;
-    let peer_net = "127.0.0.1/8".parse().unwrap();
+    let local_region = "127.0.0.1/8".parse().unwrap();
     let addr1 = "127.0.0.80".parse().unwrap();
     let addr2 = "127.0.0.81".parse().unwrap();
     // Fixed, distinct node ids give a deterministic conflict winner (the higher id).
     let cfg1 = Config::default()
         .with_port(port)
         .with_listen_addr(addr1)
-        .with_peer_net(peer_net)
+        .with_local_region(local_region)
         .with_node_id(1);
     let cfg2 = Config::default()
         .with_port(port)
         .with_listen_addr(addr2)
-        .with_peer_net(peer_net)
+        .with_local_region(local_region)
         .with_node_id(2);
 
     let store1 = ReconcileStore::<String, String>::new(cfg1)
@@ -262,17 +262,17 @@ async fn tombstone_is_retained_until_peer_acknowledges() {
     // address in 127.0.0.0/8 on this port, so sharing a port lets concurrently-running tests
     // cross-talk and pollute each other's stores.
     let port = 8084;
-    let peer_net = "127.0.0.1/8".parse().unwrap();
+    let local_region = "127.0.0.1/8".parse().unwrap();
     let addr1 = "127.0.0.72".parse().unwrap();
     let addr2 = "127.0.0.73".parse().unwrap();
     let cfg1 = Config::default()
         .with_port(port)
         .with_listen_addr(addr1)
-        .with_peer_net(peer_net);
+        .with_local_region(local_region);
     let cfg2 = Config::default()
         .with_port(port)
         .with_listen_addr(addr2)
-        .with_peer_net(peer_net);
+        .with_local_region(local_region);
 
     // Aggressive wall-clock expiry so that, without causal-stability gating, the tombstone
     // would be GC'd almost immediately.
@@ -329,17 +329,17 @@ async fn tombstone_is_retained_until_peer_acknowledges() {
 async fn deleted_value_is_not_resurrected_by_returning_peer() {
     // Dedicated port for test isolation (see `tombstone_is_retained_until_peer_acknowledges`).
     let port = 8085;
-    let peer_net = "127.0.0.1/8".parse().unwrap();
+    let local_region = "127.0.0.1/8".parse().unwrap();
     let addr1 = "127.0.0.70".parse().unwrap();
     let addr2 = "127.0.0.71".parse().unwrap();
     let cfg1 = Config::default()
         .with_port(port)
         .with_listen_addr(addr1)
-        .with_peer_net(peer_net);
+        .with_local_region(local_region);
     let cfg2 = Config::default()
         .with_port(port)
         .with_listen_addr(addr2)
-        .with_peer_net(peer_net);
+        .with_local_region(local_region);
 
     let store1 = ReconcileStore::<i32, i32>::new(cfg1)
         .await
@@ -398,17 +398,17 @@ async fn deleted_value_is_not_resurrected_by_returning_peer() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_malformed_datagram_does_not_crash() {
     let port = 8082;
-    let peer_net = "127.0.0.1/8".parse().unwrap();
+    let local_region = "127.0.0.1/8".parse().unwrap();
     let addr1 = "127.0.0.46".parse().unwrap();
     let addr2 = "127.0.0.47".parse().unwrap();
     let cfg1 = Config::default()
         .with_port(port)
         .with_listen_addr(addr1)
-        .with_peer_net(peer_net);
+        .with_local_region(local_region);
     let cfg2 = Config::default()
         .with_port(port)
         .with_listen_addr(addr2)
-        .with_peer_net(peer_net);
+        .with_local_region(local_region);
 
     let store1 = ReconcileStore::new(cfg1).await.with_seed(addr2);
     let store2 = ReconcileStore::new(cfg2).await.with_seed(addr1);
@@ -437,20 +437,20 @@ async fn test_malformed_datagram_does_not_crash() {
 #[tokio::test(flavor = "multi_thread")]
 async fn encrypted_nodes_converge() {
     let port = 8083;
-    let peer_net = "127.0.0.1/8".parse().unwrap();
+    let local_region = "127.0.0.1/8".parse().unwrap();
     let addr1 = "127.0.0.48".parse().unwrap();
     let addr2 = "127.0.0.49".parse().unwrap();
     let key = [0x42u8; 32];
     let cfg1 = Config::default()
         .with_port(port)
         .with_listen_addr(addr1)
-        .with_peer_net(peer_net)
+        .with_local_region(local_region)
         .with_cluster_key(key)
         .with_encryption();
     let cfg2 = Config::default()
         .with_port(port)
         .with_listen_addr(addr2)
-        .with_peer_net(peer_net)
+        .with_local_region(local_region)
         .with_cluster_key(key)
         .with_encryption();
 
@@ -488,19 +488,19 @@ async fn encrypted_nodes_converge() {
 #[tokio::test(flavor = "multi_thread")]
 async fn encrypted_node_with_wrong_key_is_rejected() {
     let port = 8084;
-    let peer_net = "127.0.0.1/8".parse().unwrap();
+    let local_region = "127.0.0.1/8".parse().unwrap();
     let addr1 = "127.0.0.50".parse().unwrap();
     let addr2 = "127.0.0.51".parse().unwrap();
     let cfg1 = Config::default()
         .with_port(port)
         .with_listen_addr(addr1)
-        .with_peer_net(peer_net)
+        .with_local_region(local_region)
         .with_cluster_key([0x42u8; 32])
         .with_encryption();
     let cfg2 = Config::default()
         .with_port(port)
         .with_listen_addr(addr2)
-        .with_peer_net(peer_net)
+        .with_local_region(local_region)
         .with_cluster_key([0x99u8; 32]) // different key
         .with_encryption();
 
@@ -540,17 +540,17 @@ async fn cross_region_reconciliation() {
     let cfg1 = Config::default()
         .with_port(port)
         .with_listen_addr(addr1)
-        .with_peer_net(region_a)
-        .with_region(region_b)
+        .with_local_region(region_a)
+        .with_remote_region(region_b)
         .with_cross_region_interval(1)
-        .with_remote_fanout(1);
+        .with_cross_region_fanout(1);
     let cfg2 = Config::default()
         .with_port(port)
         .with_listen_addr(addr2)
-        .with_peer_net(region_b)
-        .with_region(region_a)
+        .with_local_region(region_b)
+        .with_remote_region(region_a)
         .with_cross_region_interval(1)
-        .with_remote_fanout(1);
+        .with_cross_region_fanout(1);
 
     let store1 = ReconcileStore::new(cfg1).await.with_seed(addr2);
     store1.insert("key".to_string(), "value".to_string());
@@ -589,17 +589,17 @@ async fn cross_region_discovery_without_seed() {
     let cfg1 = Config::default()
         .with_port(port)
         .with_listen_addr(addr1)
-        .with_peer_net(region_a)
-        .with_region(remote_of_1)
+        .with_local_region(region_a)
+        .with_remote_region(remote_of_1)
         .with_cross_region_interval(1)
-        .with_remote_fanout(1);
+        .with_cross_region_fanout(1);
     let cfg2 = Config::default()
         .with_port(port)
         .with_listen_addr(addr2)
-        .with_peer_net(region_b)
-        .with_region(remote_of_2)
+        .with_local_region(region_b)
+        .with_remote_region(remote_of_2)
         .with_cross_region_interval(1)
-        .with_remote_fanout(1);
+        .with_cross_region_fanout(1);
 
     // No `with_seed`: the two nodes must find each other purely through per-region discovery probes.
     let store1 = ReconcileStore::new(cfg1).await;

--- a/tests/service.rs
+++ b/tests/service.rs
@@ -30,17 +30,17 @@ macro_rules! assert_until {
 #[tokio::test(flavor = "multi_thread")]
 async fn test() {
     let port = 8080;
-    let local_region = "127.0.0.1/8".parse().unwrap();
+    let net = "127.0.0.1/8".parse().unwrap();
     let addr1 = "127.0.0.44".parse().unwrap();
     let addr2 = "127.0.0.45".parse().unwrap();
     let cfg1 = Config::default()
         .with_port(port)
         .with_listen_addr(addr1)
-        .with_local_region(local_region);
+        .with_net(net);
     let cfg2 = Config::default()
         .with_port(port)
         .with_listen_addr(addr2)
-        .with_local_region(local_region);
+        .with_net(net);
 
     // create tree1 with many values
     let mut rng = rand::rngs::StdRng::seed_from_u64(42);
@@ -152,19 +152,19 @@ async fn test() {
 #[tokio::test(flavor = "multi_thread")]
 async fn authenticated_nodes_converge() {
     let port = 8081;
-    let local_region = "127.0.0.1/8".parse().unwrap();
+    let net = "127.0.0.1/8".parse().unwrap();
     let addr1 = "127.0.0.46".parse().unwrap();
     let addr2 = "127.0.0.47".parse().unwrap();
     let key = [0x42u8; 32];
     let cfg1 = Config::default()
         .with_port(port)
         .with_listen_addr(addr1)
-        .with_local_region(local_region)
+        .with_net(net)
         .with_cluster_key(key);
     let cfg2 = Config::default()
         .with_port(port)
         .with_listen_addr(addr2)
-        .with_local_region(local_region)
+        .with_net(net)
         .with_cluster_key(key);
 
     let mut rng = rand::rngs::StdRng::seed_from_u64(42);
@@ -206,19 +206,19 @@ async fn authenticated_nodes_converge() {
 #[tokio::test(flavor = "multi_thread")]
 async fn concurrent_writes_converge() {
     let port = 8083;
-    let local_region = "127.0.0.1/8".parse().unwrap();
+    let net = "127.0.0.1/8".parse().unwrap();
     let addr1 = "127.0.0.80".parse().unwrap();
     let addr2 = "127.0.0.81".parse().unwrap();
     // Fixed, distinct node ids give a deterministic conflict winner (the higher id).
     let cfg1 = Config::default()
         .with_port(port)
         .with_listen_addr(addr1)
-        .with_local_region(local_region)
+        .with_net(net)
         .with_node_id(1);
     let cfg2 = Config::default()
         .with_port(port)
         .with_listen_addr(addr2)
-        .with_local_region(local_region)
+        .with_net(net)
         .with_node_id(2);
 
     let store1 = ReconcileStore::<String, String>::new(cfg1)
@@ -262,17 +262,17 @@ async fn tombstone_is_retained_until_peer_acknowledges() {
     // address in 127.0.0.0/8 on this port, so sharing a port lets concurrently-running tests
     // cross-talk and pollute each other's stores.
     let port = 8084;
-    let local_region = "127.0.0.1/8".parse().unwrap();
+    let net = "127.0.0.1/8".parse().unwrap();
     let addr1 = "127.0.0.72".parse().unwrap();
     let addr2 = "127.0.0.73".parse().unwrap();
     let cfg1 = Config::default()
         .with_port(port)
         .with_listen_addr(addr1)
-        .with_local_region(local_region);
+        .with_net(net);
     let cfg2 = Config::default()
         .with_port(port)
         .with_listen_addr(addr2)
-        .with_local_region(local_region);
+        .with_net(net);
 
     // Aggressive wall-clock expiry so that, without causal-stability gating, the tombstone
     // would be GC'd almost immediately.
@@ -329,17 +329,17 @@ async fn tombstone_is_retained_until_peer_acknowledges() {
 async fn deleted_value_is_not_resurrected_by_returning_peer() {
     // Dedicated port for test isolation (see `tombstone_is_retained_until_peer_acknowledges`).
     let port = 8085;
-    let local_region = "127.0.0.1/8".parse().unwrap();
+    let net = "127.0.0.1/8".parse().unwrap();
     let addr1 = "127.0.0.70".parse().unwrap();
     let addr2 = "127.0.0.71".parse().unwrap();
     let cfg1 = Config::default()
         .with_port(port)
         .with_listen_addr(addr1)
-        .with_local_region(local_region);
+        .with_net(net);
     let cfg2 = Config::default()
         .with_port(port)
         .with_listen_addr(addr2)
-        .with_local_region(local_region);
+        .with_net(net);
 
     let store1 = ReconcileStore::<i32, i32>::new(cfg1)
         .await
@@ -398,17 +398,17 @@ async fn deleted_value_is_not_resurrected_by_returning_peer() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_malformed_datagram_does_not_crash() {
     let port = 8082;
-    let local_region = "127.0.0.1/8".parse().unwrap();
+    let net = "127.0.0.1/8".parse().unwrap();
     let addr1 = "127.0.0.46".parse().unwrap();
     let addr2 = "127.0.0.47".parse().unwrap();
     let cfg1 = Config::default()
         .with_port(port)
         .with_listen_addr(addr1)
-        .with_local_region(local_region);
+        .with_net(net);
     let cfg2 = Config::default()
         .with_port(port)
         .with_listen_addr(addr2)
-        .with_local_region(local_region);
+        .with_net(net);
 
     let store1 = ReconcileStore::new(cfg1).await.with_seed(addr2);
     let store2 = ReconcileStore::new(cfg2).await.with_seed(addr1);
@@ -437,20 +437,20 @@ async fn test_malformed_datagram_does_not_crash() {
 #[tokio::test(flavor = "multi_thread")]
 async fn encrypted_nodes_converge() {
     let port = 8083;
-    let local_region = "127.0.0.1/8".parse().unwrap();
+    let net = "127.0.0.1/8".parse().unwrap();
     let addr1 = "127.0.0.48".parse().unwrap();
     let addr2 = "127.0.0.49".parse().unwrap();
     let key = [0x42u8; 32];
     let cfg1 = Config::default()
         .with_port(port)
         .with_listen_addr(addr1)
-        .with_local_region(local_region)
+        .with_net(net)
         .with_cluster_key(key)
         .with_encryption();
     let cfg2 = Config::default()
         .with_port(port)
         .with_listen_addr(addr2)
-        .with_local_region(local_region)
+        .with_net(net)
         .with_cluster_key(key)
         .with_encryption();
 
@@ -488,19 +488,19 @@ async fn encrypted_nodes_converge() {
 #[tokio::test(flavor = "multi_thread")]
 async fn encrypted_node_with_wrong_key_is_rejected() {
     let port = 8084;
-    let local_region = "127.0.0.1/8".parse().unwrap();
+    let net = "127.0.0.1/8".parse().unwrap();
     let addr1 = "127.0.0.50".parse().unwrap();
     let addr2 = "127.0.0.51".parse().unwrap();
     let cfg1 = Config::default()
         .with_port(port)
         .with_listen_addr(addr1)
-        .with_local_region(local_region)
+        .with_net(net)
         .with_cluster_key([0x42u8; 32])
         .with_encryption();
     let cfg2 = Config::default()
         .with_port(port)
         .with_listen_addr(addr2)
-        .with_local_region(local_region)
+        .with_net(net)
         .with_cluster_key([0x99u8; 32]) // different key
         .with_encryption();
 
@@ -524,33 +524,33 @@ async fn encrypted_node_with_wrong_key_is_rejected() {
     task1.abort();
 }
 
-/// Issue #53: two nodes in distinct geographical regions converge over cross-region anti-entropy.
+/// Issue #53: two nodes in distinct geographical networks converge over cross-network anti-entropy.
 ///
-/// Regions are simulated by two disjoint /30 subnets inside the loopback range, each node living in
-/// one of them and declaring the other as a remote region. A dedicated port isolates the test.
+/// Networks are simulated by two disjoint /30 subnets inside the loopback range, each node living in
+/// one of them and declaring both. A dedicated port isolates the test.
 #[tokio::test(flavor = "multi_thread")]
-async fn cross_region_reconciliation() {
+async fn cross_net_reconciliation() {
     let port = 8085;
-    let region_a = "127.0.0.0/30".parse().unwrap();
-    let region_b = "127.0.1.0/30".parse().unwrap();
+    let net_a = "127.0.0.0/30".parse().unwrap();
+    let net_b = "127.0.1.0/30".parse().unwrap();
     let addr1 = "127.0.0.1".parse().unwrap();
     let addr2 = "127.0.1.1".parse().unwrap();
-    // Each node is local to its own region and declares the other as a remote region. A short
-    // cross-region cadence keeps the test fast.
+    // Each node is local to its own network and declares the other as a remote one. A short
+    // cross-network cadence keeps the test fast.
     let cfg1 = Config::default()
         .with_port(port)
         .with_listen_addr(addr1)
-        .with_local_region(region_a)
-        .with_remote_region(region_b)
-        .with_cross_region_interval(1)
-        .with_cross_region_fanout(1);
+        .with_net(net_a)
+        .with_net(net_b)
+        .with_remote_interval(1)
+        .with_remote_fanout(1);
     let cfg2 = Config::default()
         .with_port(port)
         .with_listen_addr(addr2)
-        .with_local_region(region_b)
-        .with_remote_region(region_a)
-        .with_cross_region_interval(1)
-        .with_cross_region_fanout(1);
+        .with_net(net_b)
+        .with_net(net_a)
+        .with_remote_interval(1)
+        .with_remote_fanout(1);
 
     let store1 = ReconcileStore::new(cfg1).await.with_seed(addr2);
     store1.insert("key".to_string(), "value".to_string());
@@ -563,7 +563,7 @@ async fn cross_region_reconciliation() {
     let task2 = tokio::spawn(store2.clone().run());
     let task1 = tokio::spawn(store1.clone().run());
 
-    // The remote-region peer eventually receives the value over cross-region anti-entropy.
+    // The remote-network peer eventually receives the value over cross-network anti-entropy.
     assert_until!(store2.get(&"key".to_string()).as_deref() == Some(&"value".to_string()));
     assert_until!(store2.fingerprint(..) == start_hash);
 
@@ -571,37 +571,38 @@ async fn cross_region_reconciliation() {
     task2.abort();
 }
 
-/// Issue #53: a node auto-discovers a peer in another region purely from the region's CIDR, with no
-/// seed. Discovery probes one random address per region each round. To keep the test deterministic
-/// (rather than relying on a random probe landing on the peer within a subnet), each node declares
-/// the *other node's exact address* as a remote region (a /32), so the per-region discovery probe
-/// reliably targets the peer. The local region stays a /30 so local-region probing is unaffected.
+/// Issue #53: a node auto-discovers a peer in another network purely from the network's CIDR, with
+/// no seed. Discovery probes one random address per network each round. To keep the test
+/// deterministic (rather than relying on a random probe landing on the peer within a subnet), each
+/// node declares the *other node's exact address* as a network (a /32), so the per-network discovery
+/// probe reliably targets the peer. The local network stays a /30 so local-network probing is
+/// unaffected.
 #[tokio::test(flavor = "multi_thread")]
-async fn cross_region_discovery_without_seed() {
+async fn cross_net_discovery_without_seed() {
     let port = 8086;
-    let region_a = "127.0.2.0/30".parse().unwrap();
-    let region_b = "127.0.3.0/30".parse().unwrap();
+    let net_a = "127.0.2.0/30".parse().unwrap();
+    let net_b = "127.0.3.0/30".parse().unwrap();
     let addr1 = "127.0.2.1".parse().unwrap();
     let addr2 = "127.0.3.1".parse().unwrap();
-    // Each node's remote region is the peer's exact address, so its discovery probe always hits it.
-    let remote_of_1 = "127.0.3.1/32".parse().unwrap();
-    let remote_of_2 = "127.0.2.1/32".parse().unwrap();
+    // Each node declares the peer's exact address as a network, so its discovery probe always hits it.
+    let peer2_host = "127.0.3.1/32".parse().unwrap();
+    let peer1_host = "127.0.2.1/32".parse().unwrap();
     let cfg1 = Config::default()
         .with_port(port)
         .with_listen_addr(addr1)
-        .with_local_region(region_a)
-        .with_remote_region(remote_of_1)
-        .with_cross_region_interval(1)
-        .with_cross_region_fanout(1);
+        .with_net(net_a)
+        .with_net(peer2_host)
+        .with_remote_interval(1)
+        .with_remote_fanout(1);
     let cfg2 = Config::default()
         .with_port(port)
         .with_listen_addr(addr2)
-        .with_local_region(region_b)
-        .with_remote_region(remote_of_2)
-        .with_cross_region_interval(1)
-        .with_cross_region_fanout(1);
+        .with_net(net_b)
+        .with_net(peer1_host)
+        .with_remote_interval(1)
+        .with_remote_fanout(1);
 
-    // No `with_seed`: the two nodes must find each other purely through per-region discovery probes.
+    // No `with_seed`: the two nodes must find each other purely through per-network discovery probes.
     let store1 = ReconcileStore::new(cfg1).await;
     store1.insert("k".to_string(), "v".to_string());
     let start_hash = store1.fingerprint(..);


### PR DESCRIPTION
Two complementary additions for running a `reconcile` cluster at scale, plus the rebase onto current `master`.

Closes #53. Advances #147 (F10): a concrete, cloud-native discovery path that sidesteps the random IP-scan (bounded-fan-out SWIM/HyParView membership remains open).

---

## 1. Geography-aware gossip across multiple locations (#53)

A single cluster can span several geographical locations, each **just an address range** (a CIDR — a cloud region, an AZ, or a subnet). Gossip stays **decentralized**: no relay/gateway nodes (which would be a SPOF and a centralization point).

- **`Config`** (additive, backward-compatible): `nets: [Option<IpNet>; MAX_NETS]`, `remote_interval` (default `6`), `remote_fanout` (default `2`), `reconcile_interval` (default `1 s`); builders `with_net` / `with_nets` / `with_remote_interval` / `with_remote_fanout` / `with_reconcile_interval`. The **local** net is whichever declared net contains `listen_addr`; all others are remote.
- **Discovery** probes one random address **per net** each round, so peers in every location are auto-discovered (instead of a single flat CIDR).
- **Anti-entropy** contacts all **local**-net peers every round (unchanged fast intra-region convergence) but **remote**-net peers only every `remote_interval` rounds and to at most `remote_fanout` peers per net — bounding WAN fan-out.
- **No wire-format change**: a peer's net is derived purely from its IP (`IpNet::contains`); a single-net cluster behaves exactly as before, all defaults preserved.
- **Repair is decoupled from net membership**: every non-local known peer is bucketed per declared net, **plus an `unclassified` bucket** for peers matching no declared net, each throttled by `remote_fanout`. A peer learned by actual contact is therefore **never orphaned from repair**, whatever the declared topology — nets only steer *discovery* and the local/remote throttle split.
- **Tombstone GC**: cross-net acks arrive later, so cross-net GC is slower but **strictly correct** (never collects before *every* member has acked).

### Runtime reconfiguration

Topology and gossip knobs are retunable **live**, without recreating the node (which would rebind the socket and lose its identity). `&self` setters on `ReconcileStore`: `set_nets` / `add_net` / `remove_net` / `nets` / `local_net` (local net auto-derived on every change), `set_remote_interval` / `set_remote_fanout`, `set_reconcile_interval`, `set_tombstone_timeout`; plus `ReconcileMirror::set_net` / `net`. Migration guidance: `add_net(new)` before `remove_net(old)`. Nets are **not** a security boundary (authentication remains the cluster key); only declare ranges you operate.

> **Naming.** The concept is `net`/`nets`, matching its value type `ipnet::IpNet` (and the `std::net` / `IpAddr` / `Ipv4Net` ecosystem vocabulary). `cidr` was rejected (it names the notation, not the concept); `network` was rejected too, as it would read `network: IpNet` everywhere — a name/type mismatch with the very `IpNet` type we keep because it is the de-facto standard.

---

## 2. Kubernetes-native peer discovery (DNS)

Random per-net probing does not fit Kubernetes, where pod IPs are ephemeral and drawn from a large cluster CIDR — a random probe almost never hits a live pod. This adds a discovery source that resolves a **headless `Service`** (one address record per ready pod), the canonical StatefulSet pattern, with **no Kubernetes API access and no RBAC**.

- **`Discovery` port** (`src/discovery.rs`) — boxed-future trait (no `async_trait` dependency). **All** discovery now goes through it, via two adapters: the default **`RandomProbe`** (speculative, one random address per declared net each round — the historical auto-discovery) and **`DnsDiscovery`** (authoritative, over `tokio::net::lookup_host`; zero new dependencies). `is_authoritative()` distinguishes them. A `dns-hickory` feature is reserved for a future SRV/musl-robust adapter.
- **`ReconcileStore`** builders: `with_discovery` / `with_dns_discovery` / `with_discovery_interval` (default 5 s) / `with_discovery_miss_threshold` (default 3). A background task (joined in `run()`) seeds every resolved address as a known peer and, after a member has been **absent for the miss threshold of consecutive successful rounds**, decommissions it so its tombstones stop gating GC. A transient resolver failure is **skipped, never counted as a miss**.
- **Correctness**: discovery only ever feeds the `peers` (gossip-target) set, **never `members`** — membership (which gates tombstone GC) is still *earned* via an authenticated dated datagram, so an unverified/spoofable address can neither block nor release GC. Builds directly on the *unclassified-bucket* guarantee above: discovered pod IPs are always reconciled even with **no `with_net`** declared.
- **Self-identity** comes from the downward API (no library coupling): `POD_IP` → `with_listen_addr`, `POD_NAME` → a stable `with_node_id`.

### Ops artifacts

- Production multi-stage **`Dockerfile`** (distroless glibc so `getaddrinfo`/`lookup_host` is reliable), building the example with the `metrics-prometheus` endpoint.
- Env-driven **`examples/k8s_node.rs`**.
- **`deploy/k8s/`** manifests: headless `Service`, `StatefulSet` (downward-API env, cluster key from a `Secret`, readiness/liveness on `/metrics`), `ConfigMap`, example `Secret`.

---

## 3. Rebase onto `master`

Merged current `master` — the #140 step-1 refactor (`Key`/`Value` supertrait bundles, `pub(crate)` reconciliation internals + the `internal-testing`/`testing` seam, refactored benches) and the #159 `Hlc` → `Timestamp` rename. Conflicts resolved in `lib.rs`, `Cargo.toml`, `reconcile_store.rs`, `reconcile_engine.rs`, `mirror.rs`, and `benches/bench.rs`.

---

## Tests & verification

- `gen_ip` unit tests for net classification and per-net probe targets.
- Integration tests in `tests/service.rs` (two-net reconciliation, with and without seeds; runtime `add_net`; `unclassified_peer_is_still_reconciled`; runtime setters).
- Discovery tests: unit (`RandomProbe` speculative/in-net, grace/decommission, self-exclusion, blip tolerance, DNS smoke) and an end-to-end `tests/discovery.rs` driving `run()` and observing tombstone GC after a peer vanishes.
- Docs: README "Multiple geographical locations" + "Kubernetes (DNS-based discovery)" sections, `ARCHITECTURE.md` `Discovery` port, `PROGRESS.md` #53 / F10.

Green locally (matching CI): `cargo fmt --check`; `cargo clippy --all --features internal-testing -D warnings` and `--all-features`; `cargo test --all --features internal-testing` and `--all-features` (incl. doctests); `cargo doc --all --all-features`; `cargo build --example k8s_node --features metrics-prometheus`; `cargo build --benches --features internal-testing`.