### PR TITLE
refactor(hlc): extract the Clock port; engine reads time through it (#142)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -42,7 +42,7 @@ converge. The design rests on five mechanisms:
 | `fingerprint.rs` | 256-bit additive fingerprint (`[u64; 4]`, per-element BLAKE3, add/sub mod 2²⁵⁶). |
 | `diff.rs` | Anti-entropy algorithm (`start_diff`, `diff_round`) and its wire types. |
 | `reconcilable.rs` | Value/tombstone semantics and the conflict-resolution policy. |
-| `hlc.rs` | Hybrid Logical Clock: timestamp type, ordering, and the clock that mints/observes stamps. |
+| `clock.rs` | Hybrid Logical Clock: timestamp type, ordering, and the clock that mints/observes stamps. |
 | `auth.rs` | Per-datagram message authentication (MAC). |
 | `persistence.rs` | Durability boundary: load/save a snapshot of the dated map. |
 | `reconcile_engine.rs` | Network orchestration: UDP socket, (de)serialisation, peer discovery, gossip. |
@@ -66,7 +66,7 @@ The infrastructure dependencies are concentrated in two places:
 
 | Module | Infrastructure imported directly | `file:line` |
 |---|---|---|
-| `hlc.rs` | `chrono::Utc` — physical time read inside the domain | `hlc.rs:35` |
+| `clock.rs` | `chrono::Utc` — physical time read inside the domain | `clock.rs:35` |
 | `reconcile_engine.rs` | `tokio::net::UdpSocket`, `tokio::time`, `bincode`, `rand::StdRng`, `ipnet` | `reconcile_engine.rs:21-28,67` |
 | `reconcile_store.rs` | `chrono`, `ipnet` | `reconcile_store.rs:19-20` |
 
@@ -89,7 +89,7 @@ Seven traits exist. They fall into three groups:
   real implementation (`HRTree`). They are exposed through `pub mod diff` (`lib.rs:30`), placing the
   protocol mechanism on the crate's public surface.
 - **Value-shape helpers (4).** `MaybeTombstone` (`reconcilable.rs:43`), `Reconcilable`
-  (`reconcilable.rs:27`) and `Timestamped` (`hlc.rs:171`) each carry a single implementation over a
+  (`reconcilable.rs:27`) and `Timestamped` (`clock.rs:171`) each carry a single implementation over a
   tuple — the stored cell is represented as `(Timestamp, Option<V>)`. `Mac` (`auth.rs:92`) selects a MAC
   backend chosen at compile time.
 
@@ -158,7 +158,7 @@ Four outbound ports, each removing one concrete infrastructure dependency from t
 // The HLC algorithm stays in the domain; only physical time crosses the boundary.
 // The port returns the concrete `Timestamp` rather than a generic associated type: it is the
 // only stamp in use, alternate causality schemes (vector clocks / CRDT) are out of scope
-// (see hlc.rs), and the tombstone wheel, version_hash and the serde format are already
+// (see clock.rs), and the tombstone wheel, version_hash and the serde format are already
 // coupled to its shape — a generic timestamp would leak that shape while adding a type
 // parameter to the engine, store and Config. Only the physical-time read crosses the boundary.
 pub trait Clock: Send + Sync + 'static {
@@ -214,7 +214,7 @@ pub trait Discovery: Send + Sync + 'static {
 
 | Port | Default adapter | Backed by |
 |---|---|---|
-| `Clock` | `HlcClock` (its `now`/`observe`, `hlc.rs:121,146`, already match the port) | system time |
+| `Clock` | `HlcClock` (its `now`/`observe`, `clock.rs:121,146`, already match the port) | system time |
 | `Transport` | `UdpTransport(Arc<UdpSocket>)` | tokio / UDP |
 | `Codec` | `BincodeCodec(DefaultOptions)` | bincode |
 | `Persistence` | `FileSnapshot`, `InMemory` | file / memory |
@@ -324,7 +324,7 @@ without a compile error — the guarantee a single crate cannot provide.
 | `Projectable` / `ValueOnly<V>` (dateless mirror) | `Entry::project` → `State<V>` (the projection cell *is* `State`) |
 | `HashRangeQueryable`, `Diffable` (public) | inherent `HRTree` methods + `pub(crate)` diff functions |
 | `pub mod diff` exposing wire types | `pub(crate)` `HashSegment` / `DiffRange` |
-| `chrono::Utc` read in `hlc.rs` | `Clock` port; `HlcClock` adapter holds the time read |
+| `chrono::Utc` read in `clock.rs` | `Clock` port; `HlcClock` adapter holds the time read |
 | `UdpSocket` in `reconcile_engine.rs` | `Transport` port; `UdpTransport` adapter |
 | `bincode` in `reconcile_engine.rs` | `Codec` port; `BincodeCodec` adapter |
 | `Persistence` | unchanged (the model port) |
@@ -341,7 +341,7 @@ correctness and security guarantees tracked in [`PROGRESS.md`](./PROGRESS.md).
 
 1. **Fingerprint format & arithmetic** — `[u64; 4]`, per-element BLAKE3, add/sub mod 2²⁵⁶; the
    golden vectors in `fingerprint.rs` hold.
-2. **HLC total order** `(wall_ms, counter, node_id)` (`hlc.rs:44-54`) — the derived ordering *is* the
+2. **HLC total order** `(wall_ms, counter, node_id)` (`clock.rs:44-54`) — the derived ordering *is* the
    conflict order; the `Clock` port mints `Timestamp` directly, preserving it, and merge uses strict `>`.
 3. **Size-not-hash emptiness/equality** in `diff_round` (`diff.rs:135-141`).
 4. **Malformed-bound / inverted-range hardening** in `diff_round` (`diff.rs:100-134`).

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -10,8 +10,9 @@
 > - **Issue [#138](https://github.com/Akvize/reconcile-rs/issues/138)** — execution tracking of the
 >   architecture migration (one sub-issue per phase).
 
-- **Last updated:** 2026-06-03
-- **Baseline:** `master` @ `b7daa7f`
+- **Last updated:** 2026-06-09
+- **Baseline:** `master` @ `054057d` (step 1 via #155, `Hlc`→`Timestamp` rename via #159); step 3 on
+  `claude/issue-142-clock-port`
 - **Manifest:** `0.0.0-git` (unpublished; API and wire/on-disk formats may still change)
 
 ---
@@ -123,6 +124,17 @@ into `State<V>` and is guarded by invariant 8 below; the `Codec` port carries a 
 `BincodeCodec` adapter sets `with_limit` (partially closing
 [#151](https://github.com/Akvize/reconcile-rs/issues/151)); the `Transport`/`Codec` ports live in
 `reconcile-net` (the `Clock`/`Persistence` ports in `reconcile-core`).
+
+Progress:
+- ✅ Step 1 — bound bundles & encapsulation ([#140](https://github.com/Akvize/reconcile-rs/issues/140), PR #155).
+- ◐ Step 2 — dissolve the diff traits ([#141](https://github.com/Akvize/reconcile-rs/issues/141), PR #156, in review).
+- ✅ Step 3 — `Clock` port ([#142](https://github.com/Akvize/reconcile-rs/issues/142)): `pub trait Clock`
+  (`now`/`observe`, returning the concrete `Timestamp`) is the domain's time seam; `HlcClock` is the
+  default adapter owning the single `chrono` read; the engine holds it as `Arc<dyn Clock>` (object-safe,
+  no clock type parameter on the engine/store/`Config`) and mints/observes only through it. A
+  deterministic `ManualClock` test adapter makes HLC behaviour reproducible without wall-clock time.
+  Iso-functional; invariant 2 (HLC total order) preserved.
+- ◯ Steps 4–6 — `Entry`/`State` → `Transport`/`Codec` → workspace split.
 
 ---
 

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -40,7 +40,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// The fields are compared in declaration order, so the derived [`Ord`] is exactly the
 /// total order `(wall_ms, counter, node_id)` used to resolve conflicts. See the
-/// [module documentation](crate::hlc) for the rationale.
+/// [module documentation](crate::clock) for the rationale.
 #[derive(
     Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize, Default,
 )]

--- a/src/hlc.rs
+++ b/src/hlc.rs
@@ -87,12 +87,27 @@ fn phys_now_ms() -> u64 {
     Utc::now().timestamp_millis().max(0) as u64
 }
 
-/// A per-node Hybrid Logical Clock.
+/// The domain's **clock port**: the seam through which the reconciliation engine reads time.
 ///
-/// Generates locally-monotonic [`Timestamp`]s with [`now`](HlcClock::now) and advances
-/// past timestamps received from peers with [`observe`](HlcClock::observe). The clock is
+/// The Hybrid Logical Clock algorithm stays in the domain; an adapter behind this port performs
+/// the single physical-time read (`HlcClock` is the default adapter, a test adapter can be a
+/// deterministic stub). Pinning the timestamp to [`Timestamp`] — rather than a generic associated type —
+/// keeps the port object-safe and avoids leaking a clock type parameter into the engine, store and
+/// `Config` (`ARCHITECTURE.md` §3.4); the engine therefore holds the port as `Arc<dyn Clock>`.
+pub trait Clock: Send + Sync + 'static {
+    /// Mint a strictly-monotonic local timestamp for a write or an outgoing message.
+    fn now(&self) -> Timestamp;
+    /// Advance the clock past a timestamp received from a peer, so that a subsequent
+    /// [`now`](Clock::now) is ordered after it (this is what prevents lost updates under skew).
+    fn observe(&self, remote: Timestamp);
+}
+
+/// A per-node Hybrid Logical Clock — the default [`Clock`] adapter.
+///
+/// Generates locally-monotonic [`Timestamp`]s with [`now`](Clock::now) and advances
+/// past timestamps received from peers with [`observe`](Clock::observe). The clock is
 /// internally synchronized, so a single instance is shared (cloned) across all tasks of a
-/// node.
+/// node. It owns the only physical-time read in the crate (`phys_now_ms`).
 #[derive(Debug)]
 pub(crate) struct HlcClock {
     node_id: u64,
@@ -113,12 +128,14 @@ impl HlcClock {
             }),
         }
     }
+}
 
+impl Clock for HlcClock {
     /// Mint a fresh timestamp for a local event (a write or an outgoing message).
     ///
     /// The returned timestamp is strictly greater than every timestamp previously produced
     /// or observed by this clock, ensuring local monotonicity.
-    pub fn now(&self) -> Timestamp {
+    fn now(&self) -> Timestamp {
         let pt = phys_now_ms();
         let mut last = self.last.lock();
         let next = if pt > last.wall_ms {
@@ -140,10 +157,10 @@ impl HlcClock {
 
     /// Advance the clock to account for a timestamp received from a peer.
     ///
-    /// After observing `remote`, a subsequent [`now`](HlcClock::now) is guaranteed to be
+    /// After observing `remote`, a subsequent [`now`](Clock::now) is guaranteed to be
     /// greater than `remote`, so a local write following the receipt of a remote value is
     /// ordered after it. This is what prevents lost updates under clock skew.
-    pub fn observe(&self, remote: Timestamp) {
+    fn observe(&self, remote: Timestamp) {
         let pt = phys_now_ms();
         let mut last = self.last.lock();
         let max_wall = pt.max(last.wall_ms).max(remote.wall_ms);
@@ -176,6 +193,47 @@ pub trait Timestamped {
 impl<V> Timestamped for (Timestamp, V) {
     fn timestamp(&self) -> Timestamp {
         self.0
+    }
+}
+
+/// Deterministic [`Clock`] adapter for tests: no physical-time read at all.
+///
+/// [`now`](Clock::now) bumps the logical counter; [`observe`](Clock::observe) jumps to a strictly
+/// greater stamp. Stamps are therefore fully reproducible, which is what lets engine/HLC tests be
+/// deterministic without real wall-clock time — the testability the [`Clock`] port exists to give.
+#[cfg(test)]
+#[derive(Debug)]
+pub(crate) struct ManualClock {
+    node_id: u64,
+    last: Mutex<Timestamp>,
+}
+
+#[cfg(test)]
+impl ManualClock {
+    pub(crate) fn new(node_id: u64) -> ManualClock {
+        ManualClock {
+            node_id,
+            last: Mutex::new(Timestamp::new(0, 0, node_id)),
+        }
+    }
+}
+
+#[cfg(test)]
+impl Clock for ManualClock {
+    fn now(&self) -> Timestamp {
+        let mut last = self.last.lock();
+        let next = Timestamp::new(last.wall_ms(), last.counter() + 1, self.node_id);
+        *last = next;
+        next
+    }
+
+    fn observe(&self, remote: Timestamp) {
+        let mut last = self.last.lock();
+        if remote > *last {
+            // Adopt the remote wall/counter (under our own node_id) so the next `now` is ordered
+            // strictly after `remote`.
+            *last = Timestamp::new(remote.wall_ms(), remote.counter(), self.node_id);
+        }
     }
 }
 
@@ -231,5 +289,19 @@ mod tests {
         // And it is consistent with the field priority: wall dominates counter dominates id.
         assert!(Timestamp::new(100, 1, 1) > Timestamp::new(100, 0, 2));
         assert!(Timestamp::new(101, 0, 1) > Timestamp::new(100, 9, 9));
+    }
+
+    #[test]
+    fn manual_clock_is_deterministic() {
+        // The test adapter reads no wall clock, so the stamp sequence is fully reproducible.
+        let clock = ManualClock::new(7);
+        assert_eq!(clock.now(), Timestamp::new(0, 1, 7));
+        assert_eq!(clock.now(), Timestamp::new(0, 2, 7));
+        // Observing a future remote stamp jumps the clock; the next mint is ordered after it.
+        let remote = Timestamp::new(50, 4, 9);
+        clock.observe(remote);
+        let local = clock.now();
+        assert_eq!(local, Timestamp::new(50, 5, 7));
+        assert!(local > remote);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,9 +28,9 @@
 //! threat model and scope.
 
 pub mod bounds;
+pub mod clock;
 pub mod discovery;
 pub mod fingerprint;
-pub mod hlc;
 pub mod hrtree;
 pub mod mirror;
 pub mod persistence;
@@ -53,9 +53,9 @@ pub(crate) mod reconcile_engine;
 pub(crate) mod timeout_wheel;
 
 pub use bounds::{Key, Value};
+pub use clock::{Clock, Timestamp};
 pub use discovery::{DiscoverFuture, Discovery, DnsDiscovery, RandomProbe};
 pub use fingerprint::Fingerprint;
-pub use hlc::Timestamp;
 pub use hrtree::HRTree;
 // The `hrtree_iter` module is `pub(crate)`, but these iterator types appear in public `HRTree`
 // method return types, so they must stay publicly reachable. A `pub` type re-exported from a

--- a/src/mirror.rs
+++ b/src/mirror.rs
@@ -64,10 +64,10 @@ use tracing::{debug, trace, warn};
 
 use crate::auth;
 use crate::bounds::Key;
+use crate::clock::Timestamp;
 use crate::diff::{Diffable, HashRangeQueryable};
 use crate::fingerprint::Fingerprint;
 use crate::gen_ip::{gen_ip, net_of};
-use crate::hlc::Timestamp;
 use crate::reconcilable::ValueOnly;
 use crate::reconcile_engine::{send_messages_to, send_to_retry, Message};
 use crate::reconcile_store::Config;

--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -44,7 +44,7 @@ use std::sync::Mutex;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
-use crate::hlc::Timestamp;
+use crate::clock::Timestamp;
 
 /// The store's keyed entries in their internal dated, tombstone-aware form: each key maps to a
 /// `(timestamp, Option<V>)`, where a `None` payload is a tombstone.

--- a/src/reconcilable.rs
+++ b/src/reconcilable.rs
@@ -13,7 +13,7 @@ use std::hash::Hash;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
-use crate::hlc::Timestamp;
+use crate::clock::Timestamp;
 
 /// Values stored in a map to be synced by the [`ReconcileStore`](crate::reconcile_store::ReconcileStore)
 /// have to be [`Reconcilable`] to ensure safe conflict handling.
@@ -28,7 +28,7 @@ pub trait Reconcilable {
 /// converges to the same value (Strong Eventual Consistency). Two *distinct* writes can
 /// never share an `Timestamp` (the same node bumps the counter, different nodes differ on
 /// `node_id`), so the equal-timestamp branch only fires for identical values. See the
-/// [`hlc`](crate::hlc) module for why the previous physical-clock scheme was unsafe.
+/// [`clock`](crate::clock) module for why the previous physical-clock scheme was unsafe.
 impl<V: Clone> Reconcilable for (Timestamp, V) {
     fn reconcile(&self, other: &Self) -> Self {
         if other.0 > self.0 {

--- a/src/reconcile_engine.rs
+++ b/src/reconcile_engine.rs
@@ -32,12 +32,12 @@ use tracing::{debug, error, info, instrument, trace, warn};
 
 use crate::auth;
 use crate::bounds::{Key, Value};
+use crate::clock::{Clock, HlcClock, Timestamp, Timestamped};
 use crate::diff::HashRangeQueryable;
 use crate::diff::{Diffable, HashSegment};
 use crate::discovery::{Discovery, RandomProbe};
 use crate::fingerprint::Fingerprint;
 use crate::gen_ip::{host_net, net_of};
-use crate::hlc::{Clock, HlcClock, Timestamp, Timestamped};
 use crate::observability;
 use crate::reconcilable::{MaybeTombstone, Projectable, Reconcilable};
 use crate::reconcile_store::{Config, MAX_NETS};
@@ -1009,7 +1009,7 @@ mod auth_attack {
     use tokio::net::UdpSocket;
 
     use super::Message;
-    use crate::hlc::Timestamp;
+    use crate::clock::Timestamp;
     use crate::{auth, reconcile_store::Config, ReconcileStore};
 
     /// Serialize the F3 attack payload: an `Update` with a far-future timestamp that, if merged,
@@ -1069,7 +1069,7 @@ mod auth_attack {
 mod causal_stability {
     use std::net::IpAddr;
 
-    use crate::hlc::Timestamp;
+    use crate::clock::Timestamp;
     use crate::reconcile_engine::{version_hash, ReconcileEngine};
     use crate::reconcile_store::Config;
 
@@ -1157,11 +1157,11 @@ mod causal_stability {
 mod clock_port {
     use std::sync::Arc;
 
-    use crate::hlc::{ManualClock, Timestamp};
+    use crate::clock::{ManualClock, Timestamp};
     use crate::reconcile_engine::ReconcileEngine;
     use crate::reconcile_store::Config;
 
-    /// The engine mints timestamps only through the injected [`Clock`](crate::hlc::Clock) port, so
+    /// The engine mints timestamps only through the injected [`Clock`](crate::clock::Clock) port, so
     /// a deterministic adapter makes `clock_now()` fully reproducible — no wall-clock time involved.
     /// This is the engine-level testability the port exists to provide.
     #[tokio::test]

--- a/src/reconcile_engine.rs
+++ b/src/reconcile_engine.rs
@@ -37,7 +37,7 @@ use crate::diff::{Diffable, HashSegment};
 use crate::discovery::{Discovery, RandomProbe};
 use crate::fingerprint::Fingerprint;
 use crate::gen_ip::{host_net, net_of};
-use crate::hlc::{HlcClock, Timestamp, Timestamped};
+use crate::hlc::{Clock, HlcClock, Timestamp, Timestamped};
 use crate::observability;
 use crate::reconcilable::{MaybeTombstone, Projectable, Reconcilable};
 use crate::reconcile_store::{Config, MAX_NETS};
@@ -159,9 +159,11 @@ pub(crate) struct Inner<K, V: Projectable> {
     pub(crate) members: Arc<RwLock<HashSet<IpAddr>>>,
     /// Per-tombstone acknowledgments: `key -> (peer -> version token of the tombstone it holds)`.
     pub(crate) tombstone_acks: Arc<RwLock<HashMap<K, HashMap<IpAddr, u64>>>>,
-    /// This node's Hybrid Logical Clock, shared across all clones so that every write and
-    /// every received timestamp advances the same clock.
-    clock: Arc<HlcClock>,
+    /// This node's clock, reached only through the [`Clock`] port so the engine never reads
+    /// physical time itself ([`HlcClock`] is the default adapter; a test injects a deterministic
+    /// stub via [`new_with_clock`](ReconcileEngine::new_with_clock)). Shared across all clones so
+    /// that every write and every received timestamp advances the same clock.
+    clock: Arc<dyn Clock>,
 }
 
 impl<K, V: Projectable> Clone for ReconcileEngine<K, V> {
@@ -215,6 +217,21 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
     ReconcileEngine<K, V>
 {
     pub async fn new(config: Config) -> Self {
+        // Default adapter for the `Clock` port: the chrono-backed Hybrid Logical Clock. This is the
+        // only place the engine names a concrete clock; everything else goes through `dyn Clock`.
+        let node_id = config.node_id.unwrap_or_else(rand::random);
+        let clock: Arc<dyn Clock> = Arc::new(HlcClock::new(node_id));
+        Self::build(config, clock).await
+    }
+
+    /// Construct an engine over an explicit [`Clock`] adapter. Test-only seam: a deterministic
+    /// clock (`ManualClock`) makes HLC behaviour reproducible without real wall-clock time.
+    #[cfg(test)]
+    pub(crate) async fn new_with_clock(config: Config, clock: Arc<dyn Clock>) -> Self {
+        Self::build(config, clock).await
+    }
+
+    async fn build(config: Config, clock: Arc<dyn Clock>) -> Self {
         let socket = UdpSocket::bind(SocketAddr::new(config.listen_addr, config.port))
             .await
             .unwrap();
@@ -234,7 +251,6 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
         }
         let map = HRTree::<K, V>::new();
         let projection = HRTree::<K, V::Projected>::new();
-        let node_id = config.node_id.unwrap_or_else(rand::random);
         // The geographical networks this cluster spans. With none declared, fall back to the
         // historical flat loopback cluster.
         let mut nets: Vec<IpNet> = config.nets.iter().flatten().copied().collect();
@@ -270,7 +286,7 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
                 authenticator,
                 members: Arc::new(RwLock::new(HashSet::new())),
                 tombstone_acks: Arc::new(RwLock::new(HashMap::new())),
-                clock: Arc::new(HlcClock::new(node_id)),
+                clock,
             }),
         }
     }
@@ -1134,5 +1150,30 @@ mod causal_stability {
         // Forgetting the tombstone clears its bookkeeping.
         eng.forget_tombstone(&key);
         assert!(eng.tombstone_acks.read().get(&key).is_none());
+    }
+}
+
+#[cfg(test)]
+mod clock_port {
+    use std::sync::Arc;
+
+    use crate::hlc::{ManualClock, Timestamp};
+    use crate::reconcile_engine::ReconcileEngine;
+    use crate::reconcile_store::Config;
+
+    /// The engine mints timestamps only through the injected [`Clock`](crate::hlc::Clock) port, so
+    /// a deterministic adapter makes `clock_now()` fully reproducible — no wall-clock time involved.
+    /// This is the engine-level testability the port exists to provide.
+    #[tokio::test]
+    async fn engine_mints_through_the_injected_clock() {
+        let config = Config::default()
+            .with_port(8080)
+            .with_listen_addr("127.0.0.70".parse().unwrap());
+        let clock = Arc::new(ManualClock::new(42));
+        let eng: ReconcileEngine<i32, (Timestamp, Option<i32>)> =
+            ReconcileEngine::new_with_clock(config, clock).await;
+
+        assert_eq!(eng.clock_now(), Timestamp::new(0, 1, 42));
+        assert_eq!(eng.clock_now(), Timestamp::new(0, 2, 42));
     }
 }

--- a/src/reconcile_store.rs
+++ b/src/reconcile_store.rs
@@ -24,9 +24,9 @@ use serde::{de::DeserializeOwned, Serialize};
 use tracing::{debug, info, instrument, warn};
 
 use crate::bounds::{Key, Value};
+use crate::clock::Timestamp;
 use crate::discovery::{Discovery, DnsDiscovery};
 use crate::fingerprint::Fingerprint;
-use crate::hlc::Timestamp;
 use crate::persistence::{DatedEntries, InMemoryPersistence, PersistedState, Persistence};
 use crate::reconcilable::Projectable;
 use crate::reconcile_engine::{version_hash, ReconcileEngine};


### PR DESCRIPTION
Step 3 of the hexagonal migration (`ARCHITECTURE.md` §3.4, tracking #138). Closes #142.

Rebased onto `master` after the `Hlc`→`Timestamp` rename (#159) merged, so this PR speaks `Timestamp` throughout. Independent of #156 (step 2): per #142 it depends only on step 1.

## What

Define the domain's **clock port** and make the engine read time only through it.

- **`pub trait Clock { fn now(&self) -> Timestamp; fn observe(&self, remote: Timestamp); }`** (in `hlc.rs`). The port returns the concrete `Timestamp` (no generic associated type), so it is **object-safe**.
- **`HlcClock` is the production adapter** implementing `Clock`; it owns the single `chrono::Utc::now()` read in the crate. The only other adapter is the deterministic test stub `ManualClock` — both necessarily mint `Timestamp` (the port abstracts the *time source*, not the timestamp type).
- **Engine holds `Arc<dyn Clock>`**, not `Arc<HlcClock>`. It mints (`clock_now`) and advances (`observe`) only through the trait — it never reads physical time itself. `dyn` (rather than a generic `C: Clock`) keeps a clock type parameter out of the engine, store and `Config`, exactly the concern called out in `ARCHITECTURE.md` §3.4.
- **Test injection.** A `#[cfg(test)]` `ReconcileEngine::new_with_clock(config, Arc<dyn Clock>)` seam, plus the `ManualClock` adapter, make HLC behaviour reproducible without wall-clock time. New unit tests: `hlc::tests::manual_clock_is_deterministic` and `reconcile_engine::clock_port::engine_mints_through_the_injected_clock`.

## Out of scope

The tombstone timeout wheel's wall-clock aging (`timeout_wheel.rs` / `reconcile_store.rs` still use `chrono`) is a separate time dependency, confined later by the workspace split (step 6). This step is specifically the HLC clock port.

## Safety

Iso-functional. Invariant 2 (HLC total order `(wall_ms, counter, node_id)`, strict `>` merge) is unchanged — the `Clock` port mints `Timestamp` directly. No wire/on-disk format change.

Green locally after rebase: `cargo build`, `clippy --all-targets --features internal-testing -- -D warnings`, `cargo fmt --check`, `cargo test --features internal-testing` (incl. the two new clock tests), `cargo doc` with `-D warnings`.

## One design call worth a look

`Arc<dyn Clock>` vs a generic `C: Clock` type parameter. I chose `dyn` to avoid threading a clock type parameter through `ReconcileEngine` / `ReconcileStore` / `Config` (per §3.4); `now`/`observe` are off the hot path, so the dynamic-dispatch cost is negligible. Happy to switch to a generic if you'd rather pay the API surface for monomorphization.

https://claude.ai/code/session_01HBF2ECF1B8VuvE765XaZyG