### PR TITLE
refactor: rename the timestamp type `Hlc` → `Timestamp`

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -23,7 +23,7 @@ converge. The design rests on five mechanisms:
 - **Anti-entropy protocol** — two peers compare fingerprints over shrinking key ranges (`diff`) and
   exchange only the divergent entries. Equality and emptiness are decided by interval **size**, not
   by hash, to stay collision-safe.
-- **Causality & conflict resolution** — each value is stamped with a Hybrid Logical Clock (`Hlc`);
+- **Causality & conflict resolution** — each value is stamped with a Hybrid Logical Clock timestamp (`Timestamp`);
   conflicts resolve by **last-write-wins** over the HLC total order `(wall_ms, counter, node_id)`.
 - **Deletion** — removals are **tombstones**; they are garbage-collected only once causally stable
   (every monotonic cluster member has acknowledged the exact version), which prevents resurrection.
@@ -90,12 +90,12 @@ Seven traits exist. They fall into three groups:
   protocol mechanism on the crate's public surface.
 - **Value-shape helpers (4).** `MaybeTombstone` (`reconcilable.rs:43`), `Reconcilable`
   (`reconcilable.rs:27`) and `Timestamped` (`hlc.rs:171`) each carry a single implementation over a
-  tuple — the stored cell is represented as `(Hlc, Option<V>)`. `Mac` (`auth.rs:92`) selects a MAC
+  tuple — the stored cell is represented as `(Timestamp, Option<V>)`. `Mac` (`auth.rs:92`) selects a MAC
   backend chosen at compile time.
 
 Two consequences of the value-shape representation:
 
-- The internal tuple `(Hlc, Option<V>)` leaks onto the public surface — into the
+- The internal tuple `(Timestamp, Option<V>)` leaks onto the public surface — into the
   `add_pre_insert` hook (`reconcile_store.rs:171`) and into `PersistedState` (`persistence.rs:51`).
 - The generic constraints are spelled out in full at every implementation site (a nine-bound key
   constraint and an eleven-bound value constraint, e.g. `reconcile_engine.rs:122-135`,
@@ -135,7 +135,7 @@ Two rules follow:
         ▲                       │                    DOMAIN  (hexagon interior)              │
         │  driving port         │  anti-entropy algorithm · conflict policy (LWW)            │
         └───────────────────────│  tombstone lifecycle · HRTree + Fingerprint (mechanism)    │
-                                │  Hlc · Entry / State (value types)  —  no tokio / bincode  │
+                                │  Timestamp · Entry / State (value types)  —  no tokio / bincode  │
                                 └──────────────────────────────────────────────────────────┘
 ```
 
@@ -147,7 +147,7 @@ The interior contains, with no infrastructure dependency:
 - the conflict-resolution policy (last-write-wins over the HLC order),
 - the tombstone lifecycle and the causal-stability garbage-collection rule,
 - the `HRTree` and `Fingerprint` (the storage and range-hash mechanism),
-- the value types `Hlc`, `Entry`, `State`.
+- the value types `Timestamp`, `Entry`, `State`.
 
 ### 3.4 Ports
 
@@ -156,14 +156,14 @@ Four outbound ports, each removing one concrete infrastructure dependency from t
 ```rust
 // Clock — abstracts the time source (replaces the direct chrono::Utc read).
 // The HLC algorithm stays in the domain; only physical time crosses the boundary.
-// Timestamp is pinned to Hlc rather than a generic associated type: Hlc is the only
-// stamp in use, alternate causality schemes (vector clocks / CRDT) are out of scope
+// The port returns the concrete `Timestamp` rather than a generic associated type: it is the
+// only stamp in use, alternate causality schemes (vector clocks / CRDT) are out of scope
 // (see hlc.rs), and the tombstone wheel, version_hash and the serde format are already
-// Hlc-coupled — a generic Timestamp would leak its shape while adding a type parameter
-// to the engine, store and Config. Only the physical-time read crosses the boundary.
+// coupled to its shape — a generic timestamp would leak that shape while adding a type
+// parameter to the engine, store and Config. Only the physical-time read crosses the boundary.
 pub trait Clock: Send + Sync + 'static {
-    fn now(&self) -> Hlc;           // mint a strictly-monotonic local stamp
-    fn observe(&self, remote: Hlc);  // advance past a peer's stamp (causality)
+    fn now(&self) -> Timestamp;           // mint a strictly-monotonic local stamp
+    fn observe(&self, remote: Timestamp);  // advance past a peer's stamp (causality)
 }
 
 // Transport — abstracts datagram I/O (replaces tokio::net::UdpSocket).
@@ -215,7 +215,7 @@ sockets or wall-clock time.
 
 ### 3.6 Domain types and conflict policy
 
-A single, intention-revealing type represents a stored cell, replacing the `(Hlc, Option<V>)` tuple
+A single, intention-revealing type represents a stored cell, replacing the `(Timestamp, Option<V>)` tuple
 and the three value-shape helper traits:
 
 ```rust
@@ -280,7 +280,7 @@ compiler:
 
 ```
 reconcile-core   // DOMAIN + PORTS: Clock, Persistence (traits);
-                 //   Entry / State, Hlc, Fingerprint, HRTree, the diff algorithm, LWW.
+                 //   Entry / State, Timestamp, Fingerprint, HRTree, the diff algorithm, LWW.
                  //   no infrastructure deps (no tokio, bincode, chrono-IO, ipnet, runtime rand);
                  //   serde + blake3, plus the dependency-light tracing / metrics facades.
 reconcile-net    // ADAPTERS + I/O PORTS: Transport, Codec (traits); UdpTransport, BincodeCodec,
@@ -294,7 +294,7 @@ The `Clock` and `Persistence` ports are defined in `reconcile-core` (the domain-
 injects them). The **`Transport` and `Codec` ports are defined in `reconcile-net`**, not the core:
 they are consumed by the UDP driver, which lives in `reconcile-net`, and the diff/merge domain does
 no I/O — this also keeps `async_trait` out of the core. The chrono-reading `HlcClock` adapter lives
-in `reconcile` (the `Hlc` *type* and the pure HLC advance stay in the core, so the core carries no
+in `reconcile` (the `Timestamp` *type* and the pure HLC advance stay in the core, so the core carries no
 `chrono`). Adapters depend on `reconcile-core`; infrastructure cannot be imported into the core
 without a compile error — the guarantee a single crate cannot provide.
 
@@ -304,7 +304,7 @@ without a compile error — the guarantee a single crate cannot provide.
 
 | Current | Target |
 |---|---|
-| `(Hlc, Option<V>)` tuple | `Entry<Hlc, V>` + `State<V>` domain type |
+| `(Timestamp, Option<V>)` tuple | `Entry<Timestamp, V>` + `State<V>` domain type |
 | `MaybeTombstone`, `Timestamped` | inherent `Entry` methods / field access |
 | `Reconcilable` (LWW over tuple) | `Entry::merge` (LWW), optional `Resolve` policy seam |
 | `Projectable` / `ValueOnly<V>` (dateless mirror) | `Entry::project` → `State<V>` (the projection cell *is* `State`) |
@@ -327,7 +327,7 @@ correctness and security guarantees tracked in [`PROGRESS.md`](./PROGRESS.md).
 1. **Fingerprint format & arithmetic** — `[u64; 4]`, per-element BLAKE3, add/sub mod 2²⁵⁶; the
    golden vectors in `fingerprint.rs` hold.
 2. **HLC total order** `(wall_ms, counter, node_id)` (`hlc.rs:44-54`) — the derived ordering *is* the
-   conflict order; the `Clock` port mints `Hlc` directly, preserving it, and merge uses strict `>`.
+   conflict order; the `Clock` port mints `Timestamp` directly, preserving it, and merge uses strict `>`.
 3. **Size-not-hash emptiness/equality** in `diff_round` (`diff.rs:135-141`).
 4. **Malformed-bound / inverted-range hardening** in `diff_round` (`diff.rs:100-134`).
 5. **Authenticate before deserialise** — the MAC is verified on raw bytes before the codec runs; the
@@ -354,7 +354,7 @@ the wire and on-disk formats (acceptable while the formats are unstable).
    `diff_round` verbatim to `pub(crate)` functions over `HRTree`.
 3. **`Clock` port** — extract `Clock`; `HlcClock` becomes its adapter and holds the physical-time
    read; the domain becomes time-source-free.
-4. **`Entry` / `State` domain type** — replace `(Hlc, Option<V>)`; dissolve `MaybeTombstone` /
+4. **`Entry` / `State` domain type** — replace `(Timestamp, Option<V>)`; dissolve `MaybeTombstone` /
    `Timestamped`; fold `Reconcilable` into `Entry::merge`; update the public hook and
    `PersistedState`. *Changes the wire and on-disk formats.*
 5. **`Transport` & `Codec` ports** — extract both; `UdpTransport` / `BincodeCodec` adapters; the

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -110,8 +110,8 @@ bound bundles & encapsulation → dissolve diff traits → `Clock` port → `Ent
 `Entry`/`State` step (wire/on-disk format), and all preserve the invariants below.
 
 Refinements adopted after a `file:line` review of the sequence (see issue
-[#138](https://github.com/Akvize/reconcile-rs/issues/138)): the `Clock` port pins `Timestamp` to
-`Hlc` (no generic associated type); the `Entry`/`State` step also dissolves `Projectable`/`ValueOnly`
+[#138](https://github.com/Akvize/reconcile-rs/issues/138)): the `Clock` port returns the concrete
+`Timestamp` (no generic associated type); the `Entry`/`State` step also dissolves `Projectable`/`ValueOnly`
 into `State<V>` and is guarded by invariant 8 below; the `Codec` port carries a decode cap and the
 `BincodeCodec` adapter sets `with_limit` (partially closing
 [#151](https://github.com/Akvize/reconcile-rs/issues/151)); the `Transport`/`Codec` ports live in

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ in your dependency's `features`).
 
 ## Read-only mirror (`ReconcileMirror`)
 
-For fleets with many *passive read replicas*, the per-value `Hlc` timestamp a dated `ReconcileStore`
+For fleets with many *passive read replicas*, the per-value `Timestamp` a dated `ReconcileStore`
 keeps (for last-write-wins and the issue-#109 tombstone machinery) is pure overhead — a replica that
 only consumes values never needs it. `ReconcileMirror` is a **dateless, read-only mirror** that
 stores only the value (`ValueOnly<V>`, ~24 bytes lighter per entry for a small payload) and still
@@ -276,8 +276,8 @@ corresponding key-value pairs are exchanged and conflicts are resolved.
 ## Conflict resolution
 
 Conflicts are resolved with last-write-wins (LWW), but keyed on a **Hybrid Logical Clock**
-(`Hlc`, after Kulkarni et al. 2014) rather than a raw wall clock. Each value carries an
-`Hlc` timestamp, and the winner is the one with the greater timestamp under the **total
+(HLC, after Kulkarni et al. 2014) rather than a raw wall clock. Each value carries a `Timestamp`
+(the HLC stamp), and the winner is the one with the greater timestamp under the **total
 order** `(wall_ms, counter, node_id)`.
 
 This matters for correctness. A naive physical-clock LWW is unsafe on two counts:

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -21,7 +21,7 @@ mod imp {
     };
 
     use reconcile::testing::HashRangeQueryable;
-    use reconcile::{reconcile_store::Config, HRTree, Hlc, ReconcileStore, ValueOnly};
+    use reconcile::{reconcile_store::Config, HRTree, ReconcileStore, Timestamp, ValueOnly};
 
     fn hrtree_new(c: &mut Criterion) {
         let mut group = c.benchmark_group("HRTree::new");
@@ -232,7 +232,7 @@ mod imp {
         }
     }
 
-    /// Compare the in-memory cost of a **naive dated mirror** (`HRTree<K, (Hlc, Option<V>)>`, which
+    /// Compare the in-memory cost of a **naive dated mirror** (`HRTree<K, (Timestamp, Option<V>)>`, which
     /// drags along a timestamp it never uses) against the **lightweight value-only mirror**
     /// (`HRTree<K, ValueOnly<V>>`) that issue #128 introduces.
     ///
@@ -240,10 +240,10 @@ mod imp {
     /// (less to move/hash per entry) and, as the one-off report below shows, stores fewer bytes per
     /// entry — the whole point of the optimization for fleets with many passive read replicas.
     fn mirror_memory(c: &mut Criterion) {
-        let dated = std::mem::size_of::<(Hlc, Option<u32>)>();
+        let dated = std::mem::size_of::<(Timestamp, Option<u32>)>();
         let light = std::mem::size_of::<ValueOnly<u32>>();
         println!(
-            "[mirror memory] per-entry value size: dated (Hlc, Option<u32>) = {dated} B, \
+            "[mirror memory] per-entry value size: dated (Timestamp, Option<u32>) = {dated} B, \
          value-only ValueOnly<u32> = {light} B, saved = {} B/entry",
             dated - light
         );
@@ -264,13 +264,13 @@ mod imp {
             group.sample_size(10.max(1_000_000 / size).min(100));
             group.sampling_mode(SamplingMode::Linear);
             group.bench_with_input(
-                BenchmarkId::new("dated (Hlc, Option<u32>)", size),
+                BenchmarkId::new("dated (Timestamp, Option<u32>)", size),
                 &size,
                 |b, &size| {
                     b.iter(|| {
-                        let mut tree = HRTree::<u32, (Hlc, Option<u32>)>::new();
+                        let mut tree = HRTree::<u32, (Timestamp, Option<u32>)>::new();
                         for &k in keys[..size].iter() {
-                            tree.insert(k, (Hlc::new(k as u64, 0, 0), Some(k)));
+                            tree.insert(k, (Timestamp::new(k as u64, 0, 0), Some(k)));
                         }
                     })
                 },

--- a/src/hlc.rs
+++ b/src/hlc.rs
@@ -18,7 +18,7 @@
 //!   their fingerprints never match and the protocol re-exchanges the pair eternally
 //!   (permanent divergence + livelock).
 //!
-//! A [`Hlc`] fixes both. It is a 64-bit-ish hybrid timestamp (Kulkarni et al., 2014) that:
+//! A [`Timestamp`] fixes both. It is a 64-bit-ish hybrid timestamp (Kulkarni et al., 2014) that:
 //!
 //! * stays close to physical time, yet is **locally monotonic** and **respects causality**:
 //!   on receiving a remote timestamp a node advances its own clock past it (the engine's
@@ -44,7 +44,7 @@ use serde::{Deserialize, Serialize};
 #[derive(
     Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize, Default,
 )]
-pub struct Hlc {
+pub struct Timestamp {
     /// Physical component: milliseconds since the Unix epoch, as last observed by the clock.
     wall_ms: u64,
     /// Logical component: disambiguates events sharing the same `wall_ms`.
@@ -53,13 +53,13 @@ pub struct Hlc {
     node_id: u64,
 }
 
-impl Hlc {
-    /// Build an `Hlc` from its raw components.
+impl Timestamp {
+    /// Build a `Timestamp` from its raw components.
     ///
     /// Mostly useful in tests and when reconstructing a timestamp from external storage;
     /// normal code obtains timestamps from the store's internal clock.
-    pub fn new(wall_ms: u64, counter: u32, node_id: u64) -> Hlc {
-        Hlc {
+    pub fn new(wall_ms: u64, counter: u32, node_id: u64) -> Timestamp {
+        Timestamp {
             wall_ms,
             counter,
             node_id,
@@ -89,7 +89,7 @@ fn phys_now_ms() -> u64 {
 
 /// A per-node Hybrid Logical Clock.
 ///
-/// Generates locally-monotonic [`Hlc`] timestamps with [`now`](HlcClock::now) and advances
+/// Generates locally-monotonic [`Timestamp`]s with [`now`](HlcClock::now) and advances
 /// past timestamps received from peers with [`observe`](HlcClock::observe). The clock is
 /// internally synchronized, so a single instance is shared (cloned) across all tasks of a
 /// node.
@@ -98,7 +98,7 @@ pub(crate) struct HlcClock {
     node_id: u64,
     /// Last timestamp produced or observed; the wall/counter pair is updated atomically
     /// under the mutex so that [`now`](HlcClock::now) stays strictly monotonic.
-    last: Mutex<Hlc>,
+    last: Mutex<Timestamp>,
 }
 
 impl HlcClock {
@@ -106,7 +106,7 @@ impl HlcClock {
     pub fn new(node_id: u64) -> HlcClock {
         HlcClock {
             node_id,
-            last: Mutex::new(Hlc {
+            last: Mutex::new(Timestamp {
                 wall_ms: 0,
                 counter: 0,
                 node_id,
@@ -118,17 +118,17 @@ impl HlcClock {
     ///
     /// The returned timestamp is strictly greater than every timestamp previously produced
     /// or observed by this clock, ensuring local monotonicity.
-    pub fn now(&self) -> Hlc {
+    pub fn now(&self) -> Timestamp {
         let pt = phys_now_ms();
         let mut last = self.last.lock();
         let next = if pt > last.wall_ms {
-            Hlc {
+            Timestamp {
                 wall_ms: pt,
                 counter: 0,
                 node_id: self.node_id,
             }
         } else {
-            Hlc {
+            Timestamp {
                 wall_ms: last.wall_ms,
                 counter: last.counter + 1,
                 node_id: self.node_id,
@@ -143,7 +143,7 @@ impl HlcClock {
     /// After observing `remote`, a subsequent [`now`](HlcClock::now) is guaranteed to be
     /// greater than `remote`, so a local write following the receipt of a remote value is
     /// ordered after it. This is what prevents lost updates under clock skew.
-    pub fn observe(&self, remote: Hlc) {
+    pub fn observe(&self, remote: Timestamp) {
         let pt = phys_now_ms();
         let mut last = self.last.lock();
         let max_wall = pt.max(last.wall_ms).max(remote.wall_ms);
@@ -156,7 +156,7 @@ impl HlcClock {
         } else {
             0
         };
-        *last = Hlc {
+        *last = Timestamp {
             wall_ms: max_wall,
             counter,
             node_id: self.node_id,
@@ -164,17 +164,17 @@ impl HlcClock {
     }
 }
 
-/// A value that carries an [`Hlc`] timestamp.
+/// A value that carries a [`Timestamp`].
 ///
 /// Lets the reconciliation engine read the timestamp of a stored value (to advance its
 /// clock on receipt) without knowing the concrete value type.
 pub trait Timestamped {
     /// The Hybrid Logical Clock timestamp attached to this value.
-    fn timestamp(&self) -> Hlc;
+    fn timestamp(&self) -> Timestamp;
 }
 
-impl<V> Timestamped for (Hlc, V) {
-    fn timestamp(&self) -> Hlc {
+impl<V> Timestamped for (Timestamp, V) {
+    fn timestamp(&self) -> Timestamp {
         self.0
     }
 }
@@ -199,7 +199,7 @@ mod tests {
         let clock = HlcClock::new(1);
         // Force the clock far into the future so physical time cannot advance past it for
         // the duration of the test: every `now()` must then bump the counter.
-        clock.observe(Hlc::new(u64::MAX - 100, 0, 9));
+        clock.observe(Timestamp::new(u64::MAX - 100, 0, 9));
         let a = clock.now();
         let b = clock.now();
         assert_eq!(a.wall_ms(), b.wall_ms());
@@ -211,7 +211,7 @@ mod tests {
         // Reproduces defect (a): a peer with a clock running ahead. After observing its
         // timestamp, our next local write must be ordered *after* it, not lost.
         let clock = HlcClock::new(1);
-        let future = Hlc::new(phys_now_ms() + 10_000_000, 5, 2);
+        let future = Timestamp::new(phys_now_ms() + 10_000_000, 5, 2);
         clock.observe(future);
         let local = clock.now();
         assert!(
@@ -224,12 +224,12 @@ mod tests {
     fn total_order_breaks_ties_on_node_id() {
         // Equal wall and counter: the node_id decides, deterministically and identically on
         // every replica.
-        let a = Hlc::new(100, 0, 1);
-        let b = Hlc::new(100, 0, 2);
+        let a = Timestamp::new(100, 0, 1);
+        let b = Timestamp::new(100, 0, 2);
         assert!(a < b);
         assert!(b > a);
         // And it is consistent with the field priority: wall dominates counter dominates id.
-        assert!(Hlc::new(100, 1, 1) > Hlc::new(100, 0, 2));
-        assert!(Hlc::new(101, 0, 1) > Hlc::new(100, 9, 9));
+        assert!(Timestamp::new(100, 1, 1) > Timestamp::new(100, 0, 2));
+        assert!(Timestamp::new(101, 0, 1) > Timestamp::new(100, 9, 9));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@ pub(crate) mod timeout_wheel;
 
 pub use bounds::{Key, Value};
 pub use fingerprint::Fingerprint;
-pub use hlc::Hlc;
+pub use hlc::Timestamp;
 pub use hrtree::HRTree;
 // The `hrtree_iter` module is `pub(crate)`, but these iterator types appear in public `HRTree`
 // method return types, so they must stay publicly reachable. A `pub` type re-exported from a

--- a/src/mirror.rs
+++ b/src/mirror.rs
@@ -11,7 +11,7 @@
 //!
 //! # What it is for
 //!
-//! A dated store keeps a [`Hlc`] timestamp next to every value so it can resolve conflicts
+//! A dated store keeps a [`Timestamp`] next to every value so it can resolve conflicts
 //! (last-write-wins) and run the #109 tombstone causal-stability machinery. For a fleet with many
 //! *passive read replicas* that only ever consume values, that timestamp is pure overhead: ~12–16
 //! bytes per entry that the replica never needs. A `ReconcileMirror` stores only
@@ -67,7 +67,7 @@ use crate::bounds::Key;
 use crate::diff::{Diffable, HashRangeQueryable};
 use crate::fingerprint::Fingerprint;
 use crate::gen_ip::gen_ip;
-use crate::hlc::Hlc;
+use crate::hlc::Timestamp;
 use crate::reconcilable::ValueOnly;
 use crate::reconcile_engine::{send_messages_to, send_to_retry, Message};
 use crate::reconcile_store::Config;
@@ -83,7 +83,7 @@ type OnUpdateCallback<K, V> = Box<dyn Send + Sync + Fn(&K, &ValueOnly<V>)>;
 /// it only needs the type so the shared [`Message`] enum has a concrete `Update` payload (which it
 /// ignores) and so the value-only [`Projected`](crate::reconcilable::Projectable::Projected) type
 /// resolves to [`ValueOnly<V>`].
-type WireDated<V> = (Hlc, Option<V>);
+type WireDated<V> = (Timestamp, Option<V>);
 
 /// A lightweight, dateless, read-only mirror of a dated [`ReconcileStore`](crate::ReconcileStore).
 ///
@@ -430,10 +430,10 @@ mod tests {
     }
 
     /// A live value and its `ValueOnly` projection hash identically only via the value-only basis:
-    /// per-entry, the dateless mirror saves the whole `Hlc` (the point of #128).
+    /// per-entry, the dateless mirror saves the whole `Timestamp` (the point of #128).
     #[test]
     fn value_only_is_smaller_per_entry() {
-        let dated = std::mem::size_of::<(Hlc, Option<u64>)>();
+        let dated = std::mem::size_of::<(Timestamp, Option<u64>)>();
         let light = std::mem::size_of::<ValueOnly<u64>>();
         assert!(
             light < dated,

--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -44,17 +44,17 @@ use std::sync::Mutex;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
-use crate::hlc::Hlc;
+use crate::hlc::Timestamp;
 
 /// The store's keyed entries in their internal dated, tombstone-aware form: each key maps to a
 /// `(timestamp, Option<V>)`, where a `None` payload is a tombstone.
-pub type DatedEntries<K, V> = Vec<(K, (Hlc, Option<V>))>;
+pub type DatedEntries<K, V> = Vec<(K, (Timestamp, Option<V>))>;
 
 /// A snapshot of everything a [`ReconcileStore`](crate::ReconcileStore) needs to durably survive a
 /// restart without behaving like a fresh replica.
 ///
 /// `V` is the user value type; entries store the internal dated, tombstone-aware representation
-/// `(Hlc, Option<V>)`.
+/// `(Timestamp, Option<V>)`.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(bound(
     serialize = "K: Serialize, V: Serialize",
@@ -194,8 +194,8 @@ mod tests {
 
         PersistedState {
             entries: vec![
-                (1, (Hlc::new(1_000, 0, 7), Some("alive".to_string()))),
-                (2, (Hlc::new(2_000, 1, 7), None)), // tombstone
+                (1, (Timestamp::new(1_000, 0, 7), Some("alive".to_string()))),
+                (2, (Timestamp::new(2_000, 1, 7), None)), // tombstone
             ],
             members,
             tombstone_acks: acks,
@@ -231,11 +231,11 @@ mod tests {
         let backend = InMemoryPersistence::<i32, String>::new();
 
         let mut first = sample_state();
-        first.entries = vec![(1, (Hlc::new(1, 0, 0), Some("first".to_string())))];
+        first.entries = vec![(1, (Timestamp::new(1, 0, 0), Some("first".to_string())))];
         backend.save(&first).unwrap();
 
         let mut second = sample_state();
-        second.entries = vec![(1, (Hlc::new(2, 0, 0), Some("second".to_string())))];
+        second.entries = vec![(1, (Timestamp::new(2, 0, 0), Some("second".to_string())))];
         backend.save(&second).unwrap();
 
         let loaded = backend.load().unwrap().unwrap();
@@ -267,11 +267,11 @@ mod tests {
         let backend = FileSnapshot::new(dir.path().join("snapshot.bin"));
 
         let mut first = sample_state();
-        first.entries = vec![(1, (Hlc::new(1, 0, 0), Some("first".to_string())))];
+        first.entries = vec![(1, (Timestamp::new(1, 0, 0), Some("first".to_string())))];
         Persistence::<i32, String>::save(&backend, &first).unwrap();
 
         let mut second = sample_state();
-        second.entries = vec![(1, (Hlc::new(2, 0, 0), Some("second".to_string())))];
+        second.entries = vec![(1, (Timestamp::new(2, 0, 0), Some("second".to_string())))];
         Persistence::<i32, String>::save(&backend, &second).unwrap();
 
         // No leftover temporary file, and the latest snapshot wins.

--- a/src/reconcilable.rs
+++ b/src/reconcilable.rs
@@ -13,7 +13,7 @@ use std::hash::Hash;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
-use crate::hlc::Hlc;
+use crate::hlc::Timestamp;
 
 /// Values stored in a map to be synced by the [`ReconcileStore`](crate::reconcile_store::ReconcileStore)
 /// have to be [`Reconcilable`] to ensure safe conflict handling.
@@ -21,15 +21,15 @@ pub trait Reconcilable {
     fn reconcile(&self, other: &Self) -> Self;
 }
 
-/// Last-write-wins keyed on a [`Hlc`] timestamp.
+/// Last-write-wins keyed on a [`Timestamp`].
 ///
-/// Because [`Hlc`] is a **total order** `(wall_ms, counter, node_id)`, `reconcile` is `max`
+/// Because [`Timestamp`] is a **total order** `(wall_ms, counter, node_id)`, `reconcile` is `max`
 /// over that order: it is commutative, associative and idempotent, so every replica
 /// converges to the same value (Strong Eventual Consistency). Two *distinct* writes can
-/// never share an `Hlc` (the same node bumps the counter, different nodes differ on
+/// never share an `Timestamp` (the same node bumps the counter, different nodes differ on
 /// `node_id`), so the equal-timestamp branch only fires for identical values. See the
 /// [`hlc`](crate::hlc) module for why the previous physical-clock scheme was unsafe.
-impl<V: Clone> Reconcilable for (Hlc, V) {
+impl<V: Clone> Reconcilable for (Timestamp, V) {
     fn reconcile(&self, other: &Self) -> Self {
         if other.0 > self.0 {
             other.clone()
@@ -50,7 +50,7 @@ pub trait MaybeTombstone {
     fn is_tombstone(&self) -> bool;
 }
 
-impl<V> MaybeTombstone for (Hlc, Option<V>) {
+impl<V> MaybeTombstone for (Timestamp, Option<V>) {
     fn is_tombstone(&self) -> bool {
         self.1.is_none()
     }
@@ -61,11 +61,11 @@ impl<V> MaybeTombstone for (Hlc, Option<V>) {
 /// *projection* tree a dated store maintains to answer them.
 ///
 /// Its [`Hash`] is **value-only by construction**: it wraps just the [`Option<V>`] payload, with no
-/// [`Hlc`] timestamp, so two replicas that agree on the logical value compute the *same* per-element
+/// [`Timestamp`], so two replicas that agree on the logical value compute the *same* per-element
 /// fingerprint regardless of when (or on which node) each last wrote it. A live value is
 /// `ValueOnly(Some(v))`; a tombstone is `ValueOnly(None)`.
 ///
-/// This is deliberately a *separate* type from the dated `(Hlc, Option<V>)`: the dated value keeps
+/// This is deliberately a *separate* type from the dated `(Timestamp, Option<V>)`: the dated value keeps
 /// its timestamp-inclusive `Hash` (required by the engine's `version_hash` for the #109
 /// causal-stability acks), so a single value-only hash never replaces it. See issue #128.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -101,7 +101,7 @@ pub trait Projectable {
 }
 
 impl<V: Clone + Hash + Send + Sync + Serialize + DeserializeOwned + 'static> Projectable
-    for (Hlc, Option<V>)
+    for (Timestamp, Option<V>)
 {
     type Projected = ValueOnly<V>;
     fn project(&self) -> ValueOnly<V> {
@@ -118,8 +118,8 @@ mod tests {
         // Distinct node_ids with the same wall+counter: the old physical-clock tie-break
         // kept the local value, so the two replicas diverged forever (defect (b)). The
         // total order makes the survivor deterministic regardless of argument order.
-        let a = (Hlc::new(100, 0, 1), "a");
-        let b = (Hlc::new(100, 0, 2), "b");
+        let a = (Timestamp::new(100, 0, 1), "a");
+        let b = (Timestamp::new(100, 0, 2), "b");
         assert_eq!(a.reconcile(&b), b.reconcile(&a));
         // The higher node_id wins consistently.
         assert_eq!(a.reconcile(&b).1, "b");
@@ -127,14 +127,14 @@ mod tests {
 
     #[test]
     fn reconcile_is_idempotent() {
-        let a = (Hlc::new(7, 3, 42), "x");
+        let a = (Timestamp::new(7, 3, 42), "x");
         assert_eq!(a.reconcile(&a), a);
     }
 
     #[test]
     fn reconcile_picks_the_greater_timestamp() {
-        let older = (Hlc::new(10, 0, 5), "old");
-        let newer = (Hlc::new(11, 0, 1), "new");
+        let older = (Timestamp::new(10, 0, 5), "old");
+        let newer = (Timestamp::new(11, 0, 1), "new");
         assert_eq!(older.reconcile(&newer).1, "new");
         assert_eq!(newer.reconcile(&older).1, "new");
     }

--- a/src/reconcile_engine.rs
+++ b/src/reconcile_engine.rs
@@ -34,7 +34,7 @@ use crate::diff::HashRangeQueryable;
 use crate::diff::{Diffable, HashSegment};
 use crate::fingerprint::Fingerprint;
 use crate::gen_ip::gen_ip;
-use crate::hlc::{Hlc, HlcClock, Timestamped};
+use crate::hlc::{HlcClock, Timestamp, Timestamped};
 use crate::observability;
 use crate::reconcilable::{MaybeTombstone, Projectable, Reconcilable};
 use crate::reconcile_store::Config;
@@ -148,7 +148,7 @@ pub(crate) enum Message<K: Serialize, V: Serialize, P: Serialize> {
     /// diffing against its value-only *projection* tree, never its dated map.
     ValueComparisonItem(HashSegment<K>),
     /// An individual timestamp-less update sent to a dateless mirror once the value-only diff has
-    /// identified a difference. Carries the projected payload only (no [`Hlc`]).
+    /// identified a difference. Carries the projected payload only (no [`Timestamp`]).
     ValueUpdate((K, P)),
 }
 
@@ -222,7 +222,7 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
     }
 
     /// Mint a fresh Hybrid Logical Clock timestamp for a local write.
-    pub fn clock_now(&self) -> Hlc {
+    pub fn clock_now(&self) -> Timestamp {
         self.clock.now()
     }
 
@@ -779,17 +779,18 @@ mod auth_attack {
     use tokio::net::UdpSocket;
 
     use super::Message;
-    use crate::hlc::Hlc;
+    use crate::hlc::Timestamp;
     use crate::{auth, reconcile_store::Config, ReconcileStore};
 
     /// Serialize the F3 attack payload: an `Update` with a far-future timestamp that, if merged,
     /// would win against every legitimate write forever.
     fn forged_update() -> Vec<u8> {
-        let far_future = Hlc::new(u64::MAX, 0, 0);
-        let message =
-            Message::Update::<i32, (Hlc, Option<String>), crate::reconcilable::ValueOnly<String>>(
-                (0, (far_future, Some("evil".to_string()))),
-            );
+        let far_future = Timestamp::new(u64::MAX, 0, 0);
+        let message = Message::Update::<
+            i32,
+            (Timestamp, Option<String>),
+            crate::reconcilable::ValueOnly<String>,
+        >((0, (far_future, Some("evil".to_string()))));
         let mut buf = Vec::new();
         message
             .serialize(&mut Serializer::new(&mut buf, DefaultOptions::new()))
@@ -838,11 +839,11 @@ mod auth_attack {
 mod causal_stability {
     use std::net::IpAddr;
 
-    use crate::hlc::Hlc;
+    use crate::hlc::Timestamp;
     use crate::reconcile_engine::{version_hash, ReconcileEngine};
     use crate::reconcile_store::Config;
 
-    type Tombstoned = (Hlc, Option<i32>);
+    type Tombstoned = (Timestamp, Option<i32>);
 
     async fn engine(addr: &str) -> ReconcileEngine<i32, Tombstoned> {
         let config = Config::default()
@@ -857,7 +858,7 @@ mod causal_stability {
         let peer_a: IpAddr = "127.0.0.61".parse().unwrap();
         let peer_b: IpAddr = "127.0.0.62".parse().unwrap();
         let key = 7;
-        let tombstone: Tombstoned = (Hlc::new(1, 0, 0), None);
+        let tombstone: Tombstoned = (Timestamp::new(1, 0, 0), None);
         let version = version_hash(&tombstone);
 
         // No member known yet: nothing could resurrect the value, so GC is allowed.
@@ -899,7 +900,7 @@ mod causal_stability {
         let live: IpAddr = "127.0.0.64".parse().unwrap();
         let gone: IpAddr = "127.0.0.65".parse().unwrap();
         let key = 9;
-        let tombstone: Tombstoned = (Hlc::new(1, 0, 0), None);
+        let tombstone: Tombstoned = (Timestamp::new(1, 0, 0), None);
         let version = version_hash(&tombstone);
 
         eng.members.write().insert(live);

--- a/src/reconcile_store.rs
+++ b/src/reconcile_store.rs
@@ -24,7 +24,7 @@ use tracing::{info, instrument, warn};
 
 use crate::bounds::{Key, Value};
 use crate::fingerprint::Fingerprint;
-use crate::hlc::Hlc;
+use crate::hlc::Timestamp;
 use crate::persistence::{DatedEntries, InMemoryPersistence, PersistedState, Persistence};
 use crate::reconcilable::Projectable;
 use crate::reconcile_engine::{version_hash, ReconcileEngine};
@@ -49,10 +49,10 @@ const SNAPSHOT_INTERVAL: Duration = Duration::from_secs(5);
 pub struct ReconcileStore<K, V>
 where
     K: Clone + Hash + std::cmp::Eq + Send + Sync,
-    (Hlc, Option<V>): Projectable,
+    (Timestamp, Option<V>): Projectable,
 {
     /// Internal map and hooks container.
-    engine: ReconcileEngine<K, (Hlc, Option<V>)>,
+    engine: ReconcileEngine<K, (Timestamp, Option<V>)>,
     /// Tombstone timestamps for deleted entries.
     tombstones: TimeoutWheel<K>,
     /// Durable backend. Always present (the trait is mandatory); defaults to the non-durable
@@ -63,7 +63,7 @@ where
 impl<K, V> Clone for ReconcileStore<K, V>
 where
     K: Clone + Hash + std::cmp::Eq + Send + Sync,
-    (Hlc, Option<V>): Projectable,
+    (Timestamp, Option<V>): Projectable,
 {
     /// Allows cloning of the `ReconcileStore` handle for lightweight sharing in hooks or tests.
     fn clone(&self) -> Self {
@@ -79,7 +79,7 @@ impl<K: Key, V: Value> ReconcileStore<K, V> {
     /// Create a new `ReconcileStore`, set up network and tombstones.
     pub async fn new(config: Config) -> Self {
         let svc = ReconcileStore {
-            engine: ReconcileEngine::<K, (Hlc, Option<V>)>::new(config).await,
+            engine: ReconcileEngine::<K, (Timestamp, Option<V>)>::new(config).await,
             tombstones: TimeoutWheel::new(),
             persistence: Arc::new(InMemoryPersistence::default()),
         };
@@ -168,12 +168,12 @@ impl<K: Key, V: Value> ReconcileStore<K, V> {
     ///
     /// Hooks are executed outside of the map’s write lock, so calling back into any insert
     /// method from within a hook will not block or deadlock.
-    pub fn add_pre_insert<F: Send + Sync + Fn(&K, &(Hlc, Option<V>)) + 'static>(
+    pub fn add_pre_insert<F: Send + Sync + Fn(&K, &(Timestamp, Option<V>)) + 'static>(
         &self,
         pre_insert: F,
     ) {
         let tombstones = self.tombstones.clone();
-        let wrapped_pre_insert = move |k: &K, v: &(Hlc, Option<V>)| {
+        let wrapped_pre_insert = move |k: &K, v: &(Timestamp, Option<V>)| {
             pre_insert(k, v);
             if v.1.is_some() {
                 tombstones.remove(k);


### PR DESCRIPTION
Pure naming refactor. No behaviour, API shape, or wire/on-disk format change — only the public type's name (crate is pre-1.0, unpublished).

## Why

The value type was named after the algorithm that mints it, colliding with the clock itself:
- `Hlc` was the **timestamp** `(wall_ms, counter, node_id)`, but the name reads as "the clock".
- `HlcClock` is the actual clock — literally "Hybrid Logical **Clock** Clock".

Tolerable while `Hlc` was the only clock-ish name, but the incoming `Clock` port (#142 / #158) puts `Hlc` / `HlcClock` / `Clock` / `ManualClock` side by side — four "clock" names, one of which *is* the value. This came out of review discussion on #158.

## What

| Role | Before | After |
|------|--------|-------|
| timestamp value | `Hlc` | **`Timestamp`** |
| production clock | `HlcClock` | `HlcClock` *(unchanged)* |
| module | `hlc` | `hlc` *(unchanged)* |

- `Hlc` → `Timestamp` everywhere (112 refs across 8 source files, benches, and the docs).
- `HlcClock` keeps its name — paired with `Timestamp` it no longer collides.
- The module stays `hlc` and the "HLC" *algorithm* references in prose/doc-comments are unchanged (HLC is the algorithm; `Timestamp` is the stamp it mints).
- Design-rationale prose that read "pin `Timestamp` to `Hlc`" (ARCHITECTURE §3.4, PROGRESS) was reworded — a blind substitution would have produced "pin `Timestamp` to `Timestamp`".

## Sequencing

Dedicated rename PR, intended to land **first**; I'll then rebase #158 (`Clock` port) onto it so that PR introduces the port already speaking `Timestamp`.

⚠️ #156 (step 2, already green) also references the timestamp type heavily. To avoid re-reviewing it, the suggested **merge order is #156 → this rename → #158**; I'll rebase whichever of the two is outstanding when this lands.

Green locally: `cargo build`, `clippy --all-targets --features internal-testing -- -D warnings`, `cargo fmt --check`, `cargo test --features internal-testing`, `cargo doc -D warnings`.

https://claude.ai/code/session_01HBF2ECF1B8VuvE765XaZyG

---
_Generated by [Claude Code](https://claude.ai/code/session_01HBF2ECF1B8VuvE765XaZyG)_