### PR TITLE
style: use `io::Error::other` in the discovery test helper

### DIFF
--- a/src/reconcile_store.rs
+++ b/src/reconcile_store.rs
@@ -997,7 +997,7 @@ mod reconcile_store_tests {
             Box::pin(async move {
                 match resp {
                     FakeResp::Present(addrs) => Ok(addrs),
-                    FakeResp::Blip => Err(std::io::Error::new(std::io::ErrorKind::Other, "blip")),
+                    FakeResp::Blip => Err(std::io::Error::other("blip")),
                 }
             })
         }


### PR DESCRIPTION
One-line lint fix. `clippy::io_other_error` (new in Rust 1.94) flags `io::Error::new(io::ErrorKind::Other, _)` and suggests `io::Error::other(_)`.

The only occurrence is the `FakeResp::Blip` stub in the discovery test helper (`reconcile_store.rs`, from #157). It surfaces under a clippy newer than the CI's pinned toolchain — harmless today, but it'll fail CI once the toolchain is bumped, so worth clearing now.

- Test-only code; behaviour-identical (`Error::other(x)` *is* `Error::new(ErrorKind::Other, x)`).
- `cargo clippy --all-targets --features internal-testing -- -D warnings` now clean; `cargo fmt --check`, `cargo test --features internal-testing` green.

https://claude.ai/code/session_01HBF2ECF1B8VuvE765XaZyG

---
_Generated by [Claude Code](https://claude.ai/code/session_01HBF2ECF1B8VuvE765XaZyG)_