### PR TITLE
docs: fix "an `Timestamp`" article typo in `reconcilable`

### DIFF
--- a/src/reconcilable.rs
+++ b/src/reconcilable.rs
@@ -26,7 +26,7 @@ pub trait Reconcilable {
 /// Because [`Timestamp`] is a **total order** `(wall_ms, counter, node_id)`, `reconcile` is `max`
 /// over that order: it is commutative, associative and idempotent, so every replica
 /// converges to the same value (Strong Eventual Consistency). Two *distinct* writes can
-/// never share an `Timestamp` (the same node bumps the counter, different nodes differ on
+/// never share a `Timestamp` (the same node bumps the counter, different nodes differ on
 /// `node_id`), so the equal-timestamp branch only fires for identical values. See the
 /// [`hlc`](crate::hlc) module for why the previous physical-clock scheme was unsafe.
 impl<V: Clone> Reconcilable for (Timestamp, V) {


### PR DESCRIPTION
One-word doc typo. Leftover from the `Hlc`→`Timestamp` rename (#159): the mechanical substitution turned "share an `Hlc`" into "share an `Timestamp`" in the `reconcile` (LWW) doc comment. Fixed the article ("an" → "a").

Doc-only, no code change. Found while auditing the rename's fallout (the same class of artifact is also being fixed in the still-open #156 and #158, where my rebases reintroduced a few — those are addressed on their own branches).

https://claude.ai/code/session_01HBF2ECF1B8VuvE765XaZyG

---
_Generated by [Claude Code](https://claude.ai/code/session_01HBF2ECF1B8VuvE765XaZyG)_