### PR TITLE
refactor: rename module `hlc` → `clock`

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -42,7 +42,7 @@ converge. The design rests on five mechanisms:
 | `fingerprint.rs` | 256-bit additive fingerprint (`[u64; 4]`, per-element BLAKE3, add/sub mod 2²⁵⁶). |
 | `diff.rs` | Anti-entropy algorithm (`start_diff`, `diff_round`) and its wire types. |
 | `reconcilable.rs` | Value/tombstone semantics and the conflict-resolution policy. |
-| `hlc.rs` | Hybrid Logical Clock: timestamp type, ordering, and the clock that mints/observes stamps. |
+| `clock.rs` | Hybrid Logical Clock: timestamp type, ordering, and the clock that mints/observes stamps. |
 | `auth.rs` | Per-datagram message authentication (MAC). |
 | `persistence.rs` | Durability boundary: load/save a snapshot of the dated map. |
 | `reconcile_engine.rs` | Network orchestration: UDP socket, (de)serialisation, peer discovery, gossip. |
@@ -66,7 +66,7 @@ The infrastructure dependencies are concentrated in two places:
 
 | Module | Infrastructure imported directly | `file:line` |
 |---|---|---|
-| `hlc.rs` | `chrono::Utc` — physical time read inside the domain | `hlc.rs:35` |
+| `clock.rs` | `chrono::Utc` — physical time read inside the domain | `clock.rs:35` |
 | `reconcile_engine.rs` | `tokio::net::UdpSocket`, `tokio::time`, `bincode`, `rand::StdRng`, `ipnet` | `reconcile_engine.rs:21-28,67` |
 | `reconcile_store.rs` | `chrono`, `ipnet` | `reconcile_store.rs:19-20` |
 
@@ -89,7 +89,7 @@ Seven traits exist. They fall into three groups:
   real implementation (`HRTree`). They are exposed through `pub mod diff` (`lib.rs:30`), placing the
   protocol mechanism on the crate's public surface.
 - **Value-shape helpers (4).** `MaybeTombstone` (`reconcilable.rs:43`), `Reconcilable`
-  (`reconcilable.rs:27`) and `Timestamped` (`hlc.rs:171`) each carry a single implementation over a
+  (`reconcilable.rs:27`) and `Timestamped` (`clock.rs:171`) each carry a single implementation over a
   tuple — the stored cell is represented as `(Timestamp, Option<V>)`. `Mac` (`auth.rs:92`) selects a MAC
   backend chosen at compile time.
 
@@ -158,7 +158,7 @@ Four outbound ports, each removing one concrete infrastructure dependency from t
 // The HLC algorithm stays in the domain; only physical time crosses the boundary.
 // The port returns the concrete `Timestamp` rather than a generic associated type: it is the
 // only stamp in use, alternate causality schemes (vector clocks / CRDT) are out of scope
-// (see hlc.rs), and the tombstone wheel, version_hash and the serde format are already
+// (see clock.rs), and the tombstone wheel, version_hash and the serde format are already
 // coupled to its shape — a generic timestamp would leak that shape while adding a type
 // parameter to the engine, store and Config. Only the physical-time read crosses the boundary.
 pub trait Clock: Send + Sync + 'static {
@@ -214,7 +214,7 @@ pub trait Discovery: Send + Sync + 'static {
 
 | Port | Default adapter | Backed by |
 |---|---|---|
-| `Clock` | `HlcClock` (its `now`/`observe`, `hlc.rs:121,146`, already match the port) | system time |
+| `Clock` | `HlcClock` (its `now`/`observe`, `clock.rs:121,146`, already match the port) | system time |
 | `Transport` | `UdpTransport(Arc<UdpSocket>)` | tokio / UDP |
 | `Codec` | `BincodeCodec(DefaultOptions)` | bincode |
 | `Persistence` | `FileSnapshot`, `InMemory` | file / memory |
@@ -324,7 +324,7 @@ without a compile error — the guarantee a single crate cannot provide.
 | `Projectable` / `ValueOnly<V>` (dateless mirror) | `Entry::project` → `State<V>` (the projection cell *is* `State`) |
 | `HashRangeQueryable`, `Diffable` (public) | inherent `HRTree` methods + `pub(crate)` diff functions |
 | `pub mod diff` exposing wire types | `pub(crate)` `HashSegment` / `DiffRange` |
-| `chrono::Utc` read in `hlc.rs` | `Clock` port; `HlcClock` adapter holds the time read |
+| `chrono::Utc` read in `clock.rs` | `Clock` port; `HlcClock` adapter holds the time read |
 | `UdpSocket` in `reconcile_engine.rs` | `Transport` port; `UdpTransport` adapter |
 | `bincode` in `reconcile_engine.rs` | `Codec` port; `BincodeCodec` adapter |
 | `Persistence` | unchanged (the model port) |
@@ -341,7 +341,7 @@ correctness and security guarantees tracked in [`PROGRESS.md`](./PROGRESS.md).
 
 1. **Fingerprint format & arithmetic** — `[u64; 4]`, per-element BLAKE3, add/sub mod 2²⁵⁶; the
    golden vectors in `fingerprint.rs` hold.
-2. **HLC total order** `(wall_ms, counter, node_id)` (`hlc.rs:44-54`) — the derived ordering *is* the
+2. **HLC total order** `(wall_ms, counter, node_id)` (`clock.rs:44-54`) — the derived ordering *is* the
    conflict order; the `Clock` port mints `Timestamp` directly, preserving it, and merge uses strict `>`.
 3. **Size-not-hash emptiness/equality** in `diff_round` (`diff.rs:135-141`).
 4. **Malformed-bound / inverted-range hardening** in `diff_round` (`diff.rs:100-134`).

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -40,7 +40,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// The fields are compared in declaration order, so the derived [`Ord`] is exactly the
 /// total order `(wall_ms, counter, node_id)` used to resolve conflicts. See the
-/// [module documentation](crate::hlc) for the rationale.
+/// [module documentation](crate::clock) for the rationale.
 #[derive(
     Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize, Default,
 )]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,9 +28,9 @@
 //! threat model and scope.
 
 pub mod bounds;
+pub mod clock;
 pub mod discovery;
 pub mod fingerprint;
-pub mod hlc;
 pub mod hrtree;
 pub mod mirror;
 pub mod persistence;
@@ -53,9 +53,9 @@ pub(crate) mod reconcile_engine;
 pub(crate) mod timeout_wheel;
 
 pub use bounds::{Key, Value};
+pub use clock::{Clock, Timestamp};
 pub use discovery::{DiscoverFuture, Discovery, DnsDiscovery, RandomProbe};
 pub use fingerprint::Fingerprint;
-pub use hlc::Timestamp;
 pub use hrtree::HRTree;
 // The `hrtree_iter` module is `pub(crate)`, but these iterator types appear in public `HRTree`
 // method return types, so they must stay publicly reachable. A `pub` type re-exported from a

--- a/src/mirror.rs
+++ b/src/mirror.rs
@@ -64,10 +64,10 @@ use tracing::{debug, trace, warn};
 
 use crate::auth;
 use crate::bounds::Key;
+use crate::clock::Timestamp;
 use crate::diff::{Diffable, HashRangeQueryable};
 use crate::fingerprint::Fingerprint;
 use crate::gen_ip::{gen_ip, net_of};
-use crate::hlc::Timestamp;
 use crate::reconcilable::ValueOnly;
 use crate::reconcile_engine::{send_messages_to, send_to_retry, Message};
 use crate::reconcile_store::Config;

--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -44,7 +44,7 @@ use std::sync::Mutex;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
-use crate::hlc::Timestamp;
+use crate::clock::Timestamp;
 
 /// The store's keyed entries in their internal dated, tombstone-aware form: each key maps to a
 /// `(timestamp, Option<V>)`, where a `None` payload is a tombstone.

--- a/src/reconcilable.rs
+++ b/src/reconcilable.rs
@@ -13,7 +13,7 @@ use std::hash::Hash;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
-use crate::hlc::Timestamp;
+use crate::clock::Timestamp;
 
 /// Values stored in a map to be synced by the [`ReconcileStore`](crate::reconcile_store::ReconcileStore)
 /// have to be [`Reconcilable`] to ensure safe conflict handling.
@@ -28,7 +28,7 @@ pub trait Reconcilable {
 /// converges to the same value (Strong Eventual Consistency). Two *distinct* writes can
 /// never share an `Timestamp` (the same node bumps the counter, different nodes differ on
 /// `node_id`), so the equal-timestamp branch only fires for identical values. See the
-/// [`hlc`](crate::hlc) module for why the previous physical-clock scheme was unsafe.
+/// [`clock`](crate::clock) module for why the previous physical-clock scheme was unsafe.
 impl<V: Clone> Reconcilable for (Timestamp, V) {
     fn reconcile(&self, other: &Self) -> Self {
         if other.0 > self.0 {

--- a/src/reconcile_engine.rs
+++ b/src/reconcile_engine.rs
@@ -32,12 +32,12 @@ use tracing::{debug, error, info, instrument, trace, warn};
 
 use crate::auth;
 use crate::bounds::{Key, Value};
+use crate::clock::{Clock, HlcClock, Timestamp, Timestamped};
 use crate::diff::HashRangeQueryable;
 use crate::diff::{Diffable, HashSegment};
 use crate::discovery::{Discovery, RandomProbe};
 use crate::fingerprint::Fingerprint;
 use crate::gen_ip::{host_net, net_of};
-use crate::hlc::{Clock, HlcClock, Timestamp, Timestamped};
 use crate::observability;
 use crate::reconcilable::{MaybeTombstone, Projectable, Reconcilable};
 use crate::reconcile_store::{Config, MAX_NETS};
@@ -1009,7 +1009,7 @@ mod auth_attack {
     use tokio::net::UdpSocket;
 
     use super::Message;
-    use crate::hlc::Timestamp;
+    use crate::clock::Timestamp;
     use crate::{auth, reconcile_store::Config, ReconcileStore};
 
     /// Serialize the F3 attack payload: an `Update` with a far-future timestamp that, if merged,
@@ -1069,7 +1069,7 @@ mod auth_attack {
 mod causal_stability {
     use std::net::IpAddr;
 
-    use crate::hlc::Timestamp;
+    use crate::clock::Timestamp;
     use crate::reconcile_engine::{version_hash, ReconcileEngine};
     use crate::reconcile_store::Config;
 
@@ -1157,11 +1157,11 @@ mod causal_stability {
 mod clock_port {
     use std::sync::Arc;
 
-    use crate::hlc::{ManualClock, Timestamp};
+    use crate::clock::{ManualClock, Timestamp};
     use crate::reconcile_engine::ReconcileEngine;
     use crate::reconcile_store::Config;
 
-    /// The engine mints timestamps only through the injected [`Clock`](crate::hlc::Clock) port, so
+    /// The engine mints timestamps only through the injected [`Clock`](crate::clock::Clock) port, so
     /// a deterministic adapter makes `clock_now()` fully reproducible — no wall-clock time involved.
     /// This is the engine-level testability the port exists to provide.
     #[tokio::test]

--- a/src/reconcile_store.rs
+++ b/src/reconcile_store.rs
@@ -24,9 +24,9 @@ use serde::{de::DeserializeOwned, Serialize};
 use tracing::{debug, info, instrument, warn};
 
 use crate::bounds::{Key, Value};
+use crate::clock::Timestamp;
 use crate::discovery::{Discovery, DnsDiscovery};
 use crate::fingerprint::Fingerprint;
-use crate::hlc::Timestamp;
 use crate::persistence::{DatedEntries, InMemoryPersistence, PersistedState, Persistence};
 use crate::reconcilable::Projectable;
 use crate::reconcile_engine::{version_hash, ReconcileEngine};


### PR DESCRIPTION
Pure module rename. No behaviour, API-shape, or wire/on-disk change — only the module path.

## Why

After the `Clock` port (#158), the module is no longer "just the HLC": it hosts the **port** `Clock`, its production adapter `HlcClock`, the `ManualClock` test stub, and the `Timestamp` value. `clock` names that role; `hlc` named only the default adapter's algorithm — the same kind of mismatch that motivated `Hlc`→`Timestamp` (#159).

## What

- `src/hlc.rs` → `src/clock.rs` (`git mv`, history preserved).
- Every `crate::hlc::` → `crate::clock::`, `pub mod hlc` → `pub mod clock`, doc links `crate::hlc` → `crate::clock`, and `hlc.rs` doc references in `ARCHITECTURE.md`.
- The `Clock` port is now re-exported at the crate root: **`reconcile::Clock`** (it's a public port). `reconcile::Timestamp` unchanged.
- `HlcClock` **keeps its name** (the adapter's algorithm is still a Hybrid Logical Clock) and the module-level doc still describes the HLC. `clock::Clock` in `use` paths is unremarkable (like `fmt::Formatter`).

## Stacking ⚠️

Based on **`claude/issue-142-clock-port` (#158)**, not `master` — the `clock` name presupposes the port that #158 introduces. **Merge #158 first**, then this; I'll retarget the base to `master` once #158 lands. (#158's own base still predates #161/#162, so a pre-existing `clippy::io_other_error` in `reconcile_store.rs` — from #157, not this change — will show until #158 is rebased; CI on the current master is green.)

Green locally: `cargo build`, `cargo fmt --check`, `cargo test --features internal-testing` (71 unit + integration), `cargo doc` with `-D warnings`.

https://claude.ai/code/session_01HBF2ECF1B8VuvE765XaZyG

---
_Generated by [Claude Code](https://claude.ai/code/session_01HBF2ECF1B8VuvE765XaZyG)_