### PR TITLE
docs: position reconcile-rs as an embedded in-memory data grid

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,30 @@ tokio::spawn(store.clone().run());
 // use the reconciliation store as a key-value store in the API
 ```
 
+## When to use this
+
+`reconcile-rs` is an **embedded, in-memory, eventually-consistent replicated map** — in data-grid
+terms, the masterless / AP / gossip corner of an in-memory data grid (the niche of Hazelcast's
+*Replicated Map* or Pekko *Distributed Data*, with no mature Rust equivalent). Every instance keeps
+the whole dataset in memory and serves reads locally (no network hop); writes propagate
+asynchronously and merge last-write-wins.
+
+**Good fit**
+- read-heavy access that must be fast and local — no per-read round-trip to Redis/etcd;
+- a working set that fits in RAM on every node (full replication = redundancy, not sharding);
+- eventual consistency / last-write-wins is acceptable, and same-key write conflicts are rare;
+- no separate datastore to operate, and the cluster must keep serving across network partitions.
+
+**Wrong tool for**
+- counters, quotas or rate-limits — LWW overwrites, it does not sum;
+- ledgers or anything needing strong consistency or transactions;
+- datasets larger than a single node's RAM — it is fully replicated, not partitioned;
+- collaborative text editing — use a sequence CRDT (Yjs/Automerge-style) instead.
+
+Because every replica holds everything, memory use and write fan-out grow with the dataset and the
+node count; see [`SOTA.md`](SOTA.md) for the detailed positioning and the issue tracker for current
+performance limitations.
+
 ## Documentation
 
 - [`PROGRESS.md`](PROGRESS.md) — the living status of the project: which review findings are fixed

--- a/SOTA.md
+++ b/SOTA.md
@@ -91,6 +91,34 @@ for with history-independence, **without paying for it** — and thereby escapes
   sufficient on its own (ScyllaDB makes this explicit with repair-based GC). The pre-fix **60 s**
   wall-clock purge could not honor that precondition; GC is now gated on causal stability (F4/#109).
 
+### 1.6 The embedded in-memory data grid (IMDG) use case
+
+Framed as a product rather than an algorithm, reconcile-rs is an **embedded in-memory data grid**:
+the state lives in-process, next to the application, fully replicated across a fleet of equal nodes.
+Its category is the **masterless / AP / gossip** corner of the IMDG space — adjacent to Hazelcast,
+Apache Ignite, Oracle Coherence and Infinispan (all JVM, all a separate cluster to operate), but as
+a single embeddable Rust library. The pitch is "replicated state without standing up Redis/etcd":
+
+- **Reads are local** — an in-process lookup, no network hop or (de)serialization. This is the one
+  place reconcile-rs is unambiguously faster than a networked store; it is a *read-latency* and
+  *operational-simplicity* play, not a write-path or consistency improvement.
+- **Redundancy, not sharding** — full replication means any surviving node holds the whole dataset,
+  so the grid tolerates losing nodes; the flip side is §1.2's memory / write-amplification ceiling.
+- **Partition tolerance with automatic convergence** — nodes keep serving while partitioned and
+  re-converge by anti-entropy on heal, with no manual conflict resolution (LWW).
+
+**When this is the right tool:** a read-heavy, RAM-resident working set on a fragile/commodity node
+grid where eliminating the store round-trip matters more than write throughput or strong
+consistency, and where losing a node or two must not lose data. **When it is not:** see §1.1–§1.2
+and the LWW caveats in §1.5 — counters, ledgers, strong consistency, datasets beyond one node's RAM,
+or high same-key write contention.
+
+**Path to best-of-breed.** Benchmarking against this use case surfaced concrete, tracked work: bulk
+cold-sync throughput and loss recovery (#168, #169), per-entry memory overhead (#170), point-read
+indexing (#171), snapshot cadence (#172), bulk-build throughput (#173), and a comparative benchmark
+suite (#174). Closing these is what moves reconcile-rs from the "real but narrow" niche of §1.2 to a
+credible Rust IMDG.
+
 ---
 
 ## 2. Competitor audit and differentiators

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,28 @@
 //! number of round-trips. It should also work well to populate an instance from
 //! scratch from other instances.
 
+//! # When to use this
+//!
+//! `reconcile-rs` is an **embedded, in-memory, eventually-consistent replicated map** — in
+//! data-grid terms, the masterless / AP / gossip corner of an in-memory data grid (the niche of
+//! Hazelcast's *Replicated Map* or Pekko *Distributed Data*, with no mature Rust equivalent). Every
+//! instance keeps the **whole dataset in memory** and serves reads locally with no network hop;
+//! writes propagate asynchronously and merge last-write-wins.
+//!
+//! Good fit:
+//! - reads dominate and must be fast and local (no per-read round-trip to Redis/etcd);
+//! - the working set fits in RAM on every node (full replication gives redundancy, not sharding);
+//! - eventual consistency and last-write-wins are acceptable, and same-key conflicts are rare;
+//! - you want no separate datastore to operate, and want to keep serving across partitions.
+//!
+//! Wrong tool for: counters/quotas (LWW overwrites, it does not sum), ledgers or anything needing
+//! strong consistency or transactions, datasets larger than one node's RAM (it is fully replicated,
+//! not partitioned), and collaborative text (use a sequence CRDT).
+//!
+//! Because every replica holds everything, memory use and write fan-out grow with the dataset and
+//! the node count; see the open performance issues (cold-sync throughput, per-entry memory
+//! overhead, point-read latency) for current limitations and their status.
+
 //! # Security model
 //!
 //! By default the UDP reconciliation protocol is **unauthenticated**: any host able to send a


### PR DESCRIPTION
## Summary

Documents *what reconcile-rs is for* — its use case and positioning — so a developer can decide at a glance whether it fits. It adds an honest "when to use this" framing in three places, by visibility:

- **`src/lib.rs`** (crate docs → shown on docs.rs, the first page a developer reads): a concise "When to use this" section.
- **`README.md`**: a "When to use this" section (good fit / wrong tool for), linking to `SOTA.md`.
- **`SOTA.md` §1.6**: a detailed "embedded in-memory data grid (IMDG)" subsection that builds on the existing §1.1–§1.2 niche analysis and §1.5 LWW caveats.

## Framing

reconcile-rs is an **embedded, in-memory, eventually-consistent replicated map** — the masterless / AP / gossip corner of an in-memory data grid (the niche of Hazelcast *Replicated Map* / Pekko *Distributed Data*, with no mature Rust equivalent), as a single embeddable library rather than a separate cluster.

The docs are deliberately even-handed:

- **Good fit:** read-heavy, RAM-resident working set; local reads with no store round-trip; redundancy via full replication; partition tolerance with automatic convergence; no separate datastore to operate.
- **Wrong tool for:** counters/quotas (LWW overwrites, does not sum), ledgers / strong consistency / transactions, datasets larger than one node's RAM (fully replicated, not partitioned), collaborative text (needs a sequence CRDT).

§1.6 also links the open performance issues (#168–#174) as the concrete path from "real but narrow niche" to a credible Rust IMDG.

## Notes

- Docs-only; no code changes. `cargo fmt --check` and `cargo doc --all-features` (with `-Dwarnings`) pass locally.
- `SOTA.md` is repository-only (excluded from the published crate); `src/lib.rs` and `README.md` ship.

https://claude.ai/code/session_01F5RsYDnd7b3X7G9MyuCFtn

---
_Generated by [Claude Code](https://claude.ai/code/session_01F5RsYDnd7b3X7G9MyuCFtn)_