### PR TITLE
feat(engine): size gossip socket SO_RCVBUF/SO_SNDBUF (#169)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1300,6 +1300,7 @@ dependencies = [
  "range-cmp",
  "serde",
  "sha2",
+ "socket2",
  "tempfile",
  "tokio",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,6 +83,9 @@ rand = "0.8.5"
 range-cmp = "0.1.1"
 serde = { version = "1.0.192", features = ["derive"] }
 sha2 = { version = "0.10", optional = true }
+# Sizes the gossip UDP socket's SO_RCVBUF / SO_SNDBUF (issue #169). Already in the tree as a
+# transitive dependency of tokio, so this is essentially free.
+socket2 = "0.5"
 tokio = { version = "1.33.0", features = ["net", "time", "rt", "macros"] }
 tracing = "0.1.40"
 zeroize = { version = "1.7", optional = true, features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -198,6 +198,32 @@ let body: String = handle.render();
 Enable with `cargo build --features metrics-prometheus` (or list `metrics`/`metrics-prometheus`
 in your dependency's `features`).
 
+## Operational tuning
+
+### Gossip socket buffers
+
+The gossip UDP socket requests a multi-MiB send/receive buffer by default (8 MiB; see
+`Config::recv_buffer_size` / `send_buffer_size`). The stock OS default holds only a handful of
+full-size datagrams, so a bulk or cold-sync burst can overrun the kernel **receive** buffer and the
+excess is dropped *inside the kernel*, before the application sees it.
+
+The kernel clamps the request to its maximum, so the default helps only as far as the OS allows. On
+Linux, raise the ceiling (and persist it in `/etc/sysctl.d/`) to let the buffer grow:
+
+```sh
+sysctl -w net.core.rmem_max=8388608   # 8 MiB; match Config::recv_buffer_size
+sysctl -w net.core.wmem_max=8388608
+```
+
+To check whether the kernel is dropping datagrams at the socket buffer, watch the `RcvbufErrors`
+counter (it should stay flat):
+
+```sh
+grep -A1 '^Udp:' /proc/net/snmp        # the RcvbufErrors column
+```
+
+Set either field to `None` to leave the inherited OS default untouched.
+
 ## Read-only mirror (`ReconcileMirror`)
 
 For fleets with many *passive read replicas*, the per-value `Timestamp` a dated `ReconcileStore`

--- a/src/reconcile_engine.rs
+++ b/src/reconcile_engine.rs
@@ -26,6 +26,7 @@ use rand::rngs::StdRng;
 use rand::seq::SliceRandom;
 use rand::SeedableRng;
 use serde::{Deserialize, Serialize};
+use socket2::SockRef;
 use tokio::net::{ToSocketAddrs, UdpSocket};
 use tokio::time::{sleep, timeout};
 use tracing::{debug, error, info, instrument, trace, warn};
@@ -80,6 +81,46 @@ fn derive_local_net(nets: &[IpNet], listen_addr: IpAddr) -> IpNet {
         );
         host_net(listen_addr)
     })
+}
+
+/// Apply the configured `SO_RCVBUF` / `SO_SNDBUF` to the gossip socket.
+///
+/// `setsockopt` never errors for asking too much: the kernel clamps each request to the OS maximum
+/// (`net.core.rmem_max` / `wmem_max` on Linux), so a generous default only ever helps. Clamping is
+/// therefore expected on an untuned host — **not** a warning condition — so the achieved size is
+/// reported at `debug`; an operator who needs the full buffer raises the sysctl (see the README)
+/// and can confirm via `/proc/net/snmp` `RcvbufErrors`. Only an actual `setsockopt` failure (which
+/// does not happen for a buffer request on a valid socket) is surfaced as a `warn`. A `None` size
+/// leaves the inherited OS default untouched.
+///
+/// Note: on Linux `getsockopt` reports the *doubled* value (bookkeeping overhead), so a fully
+/// honoured request reads back larger than asked.
+fn set_socket_buffers(socket: &UdpSocket, config: &Config) {
+    let sock = SockRef::from(socket);
+    if let Some(size) = config.recv_buffer_size {
+        match sock.set_recv_buffer_size(size) {
+            Ok(()) => match sock.recv_buffer_size() {
+                Ok(actual) => debug!(
+                    "gossip socket SO_RCVBUF: requested {size} B, OS granted {actual} B \
+                     (raise net.core.rmem_max if a larger buffer is needed)"
+                ),
+                Err(e) => debug!("could not read back SO_RCVBUF: {e}"),
+            },
+            Err(e) => warn!("failed to set gossip socket SO_RCVBUF to {size} B: {e}"),
+        }
+    }
+    if let Some(size) = config.send_buffer_size {
+        match sock.set_send_buffer_size(size) {
+            Ok(()) => match sock.send_buffer_size() {
+                Ok(actual) => debug!(
+                    "gossip socket SO_SNDBUF: requested {size} B, OS granted {actual} B \
+                     (raise net.core.wmem_max if a larger buffer is needed)"
+                ),
+                Err(e) => debug!("could not read back SO_SNDBUF: {e}"),
+            },
+            Err(e) => warn!("failed to set gossip socket SO_SNDBUF to {size} B: {e}"),
+        }
+    }
 }
 
 /// The internal reconciliation engine at the network level.
@@ -246,6 +287,8 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
             .await
             .unwrap();
         info!("Listening on: {}", socket.local_addr().unwrap());
+        // Size the kernel send/receive buffers before any traffic flows.
+        set_socket_buffers(&socket, &config);
         let authenticator = auth::Authenticator::new(config.cluster_key, config.encrypt);
         if authenticator.is_encrypted() {
             debug!("per-datagram authenticated encryption (XChaCha20-Poly1305) ENABLED");
@@ -1501,5 +1544,62 @@ mod pacing {
         let messages = bulk_updates(256, 1024);
         assert!(time_send(&messages, None).await < Duration::from_millis(200));
         assert!(time_send(&messages, Some(0)).await < Duration::from_millis(200));
+    }
+}
+
+#[cfg(test)]
+mod socket_buffers {
+    use socket2::SockRef;
+
+    use crate::clock::Timestamp;
+    use crate::reconcile_engine::ReconcileEngine;
+    use crate::reconcile_store::Config;
+
+    type Tombstoned = (Timestamp, Option<i32>);
+
+    async fn engine(addr: &str, config: Config) -> ReconcileEngine<i32, Tombstoned> {
+        ReconcileEngine::new(config.with_listen_addr(addr.parse().unwrap())).await
+    }
+
+    /// The receive-buffer knob must actually size the gossip socket. Asserting an
+    /// absolute byte count would be flaky — the kernel clamps `SO_RCVBUF` to `net.core.rmem_max`,
+    /// which varies per host (and CI sandbox) — so we assert *monotonicity* instead: the multi-MiB
+    /// default must yield a strictly larger buffer than an explicitly tiny request. That holds for
+    /// any `rmem_max` above a few KiB, which is true on every realistic host.
+    #[tokio::test]
+    async fn recv_buffer_size_is_configurable() {
+        // Default config requests the multi-MiB DEFAULT_SOCKET_BUFFER_SIZE.
+        let big = engine("127.0.0.90", Config::default()).await;
+        // An explicit, tiny request — well below any plausible rmem_max, so it is honoured as-is.
+        let small = engine(
+            "127.0.0.91",
+            Config::default().with_recv_buffer_size(8 * 1024),
+        )
+        .await;
+
+        let big_buf = SockRef::from(&*big.socket).recv_buffer_size().unwrap();
+        let small_buf = SockRef::from(&*small.socket).recv_buffer_size().unwrap();
+
+        assert!(
+            big_buf > small_buf,
+            "the multi-MiB default ({big_buf} B) should exceed an explicitly tiny buffer \
+             ({small_buf} B)"
+        );
+    }
+
+    /// `None` opts out of the tuning entirely, leaving the inherited OS default. Combined with the
+    /// test above (the default is large), this pins down both ends of the knob: a tiny explicit
+    /// request shrinks the buffer below the large default.
+    #[tokio::test]
+    async fn recv_buffer_size_none_leaves_os_default() {
+        let config = Config {
+            recv_buffer_size: None,
+            ..Config::default()
+        };
+        let eng = engine("127.0.0.92", config).await;
+        // Just assert it builds and the socket is usable; the OS default is host-dependent, so we
+        // only check the call path does not panic and yields a positive buffer.
+        let buf = SockRef::from(&*eng.socket).recv_buffer_size().unwrap();
+        assert!(buf > 0, "a socket always has a positive receive buffer");
     }
 }

--- a/src/reconcile_store.rs
+++ b/src/reconcile_store.rs
@@ -51,6 +51,14 @@ const DEFAULT_DISCOVERY_MISS_THRESHOLD: u32 = 3;
 /// over ranges still in flight (the byte amplification this caps).
 const DEFAULT_BULK_SEND_RATE: usize = 32 * 1024 * 1024;
 
+/// Default size requested for the gossip socket's send/receive buffers (`SO_SNDBUF` / `SO_RCVBUF`),
+/// in bytes (see [`Config::recv_buffer_size`]). A generous 8 MiB: the kernel silently clamps the
+/// request to the OS maximum (`net.core.rmem_max` / `wmem_max` on Linux), so this is an improvement
+/// on a tuned host and a harmless no-op on an untuned one. The stock OS default holds only a handful
+/// of full-size datagrams, which a bulk/cold sync burst overruns — dropping datagrams in the kernel
+/// before the application ever sees them.
+const DEFAULT_SOCKET_BUFFER_SIZE: usize = 8 * 1024 * 1024;
+
 /// Core service wrapping a key-value map to enable reconciliation between different instances over a network.
 ///
 /// The store also keeps track of the addresses of other instances.
@@ -685,6 +693,24 @@ pub struct Config {
     /// ≈ the dataset size, fast, regardless of `reconcile_interval`. Only the bulk value dump is
     /// paced; small refinement comparisons, acks, and local-write broadcasts are sent immediately.
     pub bulk_send_rate: Option<usize>,
+    /// Size to request for the gossip socket's receive buffer (`SO_RCVBUF`), in bytes.
+    ///
+    /// Defaults to 8 MiB. The kernel clamps the request to the OS
+    /// maximum (`net.core.rmem_max` on Linux) and never errors for asking too much, so a large
+    /// default is safe — it only ever helps. The stock OS default holds only a few full-size
+    /// datagrams, so a bulk/cold-sync burst overruns it and the kernel silently drops the excess
+    /// (counted as `Udp.RcvbufErrors` in `/proc/net/snmp`, invisible to the application); a
+    /// multi-MiB buffer absorbs the burst instead. Set to `None` to leave the inherited OS default
+    /// untouched. See [`with_recv_buffer_size`](Config::with_recv_buffer_size).
+    pub recv_buffer_size: Option<usize>,
+    /// Size to request for the gossip socket's send buffer (`SO_SNDBUF`), in bytes.
+    ///
+    /// Defaults to 8 MiB, clamped by the kernel to the OS maximum
+    /// (`net.core.wmem_max` on Linux). A larger send buffer lets a bulk send burst queue in the
+    /// kernel instead of failing with `EWOULDBLOCK`/`ENOBUFS` (which the engine must then retry).
+    /// Set to `None` to leave the inherited OS default untouched. See
+    /// [`with_send_buffer_size`](Config::with_send_buffer_size).
+    pub send_buffer_size: Option<usize>,
     // may include other options in the future: tombstone_ttl, metrics, etc.
 }
 impl Default for Config {
@@ -700,6 +726,8 @@ impl Default for Config {
             encrypt: false,
             reconcile_interval: Duration::from_secs(1),
             bulk_send_rate: Some(DEFAULT_BULK_SEND_RATE),
+            recv_buffer_size: Some(DEFAULT_SOCKET_BUFFER_SIZE),
+            send_buffer_size: Some(DEFAULT_SOCKET_BUFFER_SIZE),
         }
     }
 }
@@ -775,6 +803,28 @@ impl Config {
         self
     }
 
+    /// Request `size` bytes for the gossip socket's receive buffer (`SO_RCVBUF`).
+    ///
+    /// The kernel clamps the request to the OS maximum (`net.core.rmem_max` on Linux), so passing
+    /// more than the host allows is harmless — it is simply capped. Raising this (together with the
+    /// matching sysctl) is the cheap fix for datagrams dropped during bulk/cold syncs.
+    /// See [`recv_buffer_size`](Config::recv_buffer_size); to leave the OS default untouched, set
+    /// that field to `None` directly.
+    pub fn with_recv_buffer_size(mut self, size: usize) -> Self {
+        self.recv_buffer_size = Some(size);
+        self
+    }
+
+    /// Request `size` bytes for the gossip socket's send buffer (`SO_SNDBUF`).
+    ///
+    /// Clamped by the kernel to the OS maximum (`net.core.wmem_max` on Linux). See
+    /// [`send_buffer_size`](Config::send_buffer_size); to leave the OS default untouched, set that
+    /// field to `None` directly.
+    pub fn with_send_buffer_size(mut self, size: usize) -> Self {
+        self.send_buffer_size = Some(size);
+        self
+    }
+
     /// Enable per-datagram MAC authentication using a shared 32-byte cluster secret.
     ///
     /// Every outgoing datagram is then framed with a keyed MAC over its payload, and every
@@ -847,6 +897,8 @@ mod reconcile_store_tests {
             encrypt: false,
             reconcile_interval: Duration::from_secs(1),
             bulk_send_rate: Some(super::DEFAULT_BULK_SEND_RATE),
+            recv_buffer_size: Some(super::DEFAULT_SOCKET_BUFFER_SIZE),
+            send_buffer_size: Some(super::DEFAULT_SOCKET_BUFFER_SIZE),
         }
     }
 


### PR DESCRIPTION
Closes #169.

## Problem

The gossip UDP socket is bound with a plain `UdpSocket::bind` and inherits the (small) OS-default send/receive buffers. The stock Linux `net.core.rmem_default` (~208 KiB) holds only ~3 full-size (64 KiB) datagrams, so a **bulk or cold-sync burst overruns the kernel receive buffer** and the excess is dropped *inside the kernel* — counted as `Udp.RcvbufErrors` in `/proc/net/snmp`, invisible to the application, and only recovered on the next reconcile round. This is the main amplifier behind the cold-sync byte blow-up in #168.

## Change

Size the gossip socket's `SO_RCVBUF` / `SO_SNDBUF` right after bind, via `socket2`:

- **New `Config` knobs** `recv_buffer_size` / `send_buffer_size` (`Option<usize>`), with `with_recv_buffer_size` / `with_send_buffer_size` builders. Default: **8 MiB** each.
- `setsockopt` clamps the request to the OS maximum (`net.core.rmem_max` / `wmem_max`) and never errors for asking too much, so the new default is **strictly an improvement on a tuned host and a harmless no-op on an untuned one** — no regression. When the granted buffer comes back short, we log a hint to raise the sysctl.
- Setting a field to `None` leaves the inherited OS default untouched (escape hatch).
- `socket2` was already in the dependency tree (transitive via tokio), so the new direct dependency is essentially free.

## Operability

README gains an **Operational tuning** section documenting the buffer knob, the matching `sysctl` (`net.core.rmem_max` / `wmem_max`), and how to watch `Udp.RcvbufErrors` to confirm the kernel is no longer dropping at the socket buffer — covering the issue's operability ask.

## Tests

- `recv_buffer_size_is_configurable` — host-independent **monotonicity** assertion (the multi-MiB default yields a strictly larger buffer than an explicit tiny request); absolute byte assertions would be flaky because the kernel clamps to a per-host `rmem_max`.
- `recv_buffer_size_none_leaves_os_default` — the `None` opt-out path builds and yields a usable socket.

`cargo fmt --check`, `cargo clippy --all-targets --all-features -D warnings`, `cargo doc --no-deps --all-features` (`RUSTDOCFLAGS=-Dwarnings`), and the full test suite (lib + integration + doctests) all pass.

> Note: this is the cheap, high-impact half of the cold-sync story. The companion flow-control / loss-recovery work (#168) builds on top and follows in a separate PR.

https://claude.ai/code/session_01F5RsYDnd7b3X7G9MyuCFtn

---
_Generated by [Claude Code](https://claude.ai/code/session_01F5RsYDnd7b3X7G9MyuCFtn)_