### PR TITLE
Propagate get_mut edits to peers (re-stamp + broadcast)

### DIFF
--- a/src/reconcile_engine.rs
+++ b/src/reconcile_engine.rs
@@ -499,6 +499,13 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
         ret
     }
 
+    /// Broadcast a single locally-mutated entry to peers, mirroring [`insert`](Self::insert)'s
+    /// propagation. Used by in-place mutation paths (`ReconcileStore::get_mut`) that write the map
+    /// directly and must still notify peers so the edit reconciles, without re-applying it locally.
+    pub(crate) fn broadcast_update(&self, key: K, value: V) {
+        self.broadcast(vec![Message::Update::<K, V, V::Projected>((key, value))]);
+    }
+
     pub fn just_insert_bulk(&self, key_values: &[(K, V)]) {
         // 1) First run all pre-insert hooks outside the map lock
         for (key, value) in key_values {

--- a/src/reconcile_store.rs
+++ b/src/reconcile_store.rs
@@ -10,7 +10,6 @@
 //! to enable reconciliation between different instances over a network.
 
 use std::collections::{HashMap, HashSet};
-use std::fmt::Debug;
 use std::hash::Hash;
 use std::net::IpAddr;
 use std::ops::RangeBounds;
@@ -20,7 +19,6 @@ use std::time::{Duration, Instant};
 use chrono::{DateTime, Utc};
 use ipnet::IpNet;
 use parking_lot::{MappedRwLockReadGuard, RwLockReadGuard};
-use serde::{de::DeserializeOwned, Serialize};
 use tracing::{debug, info, instrument, warn};
 
 use crate::bounds::{Key, Value};
@@ -576,19 +574,32 @@ impl<K: Key, V: Value> ReconcileStore<K, V> {
     }
 }
 
-// NOTE: this block intentionally does NOT use the `Value` bundle for `V`: `get_mut` does not
-// require `V: PartialEq` (unlike the main impl above), and `Value` includes `PartialEq`. Spelling
-// the data bounds out here keeps the required bound set identical (no tightening). `K` matches the
-// `Key` bundle exactly, so it is bundled.
-impl<K: Key, V: Clone + Debug + DeserializeOwned + Hash + Send + Serialize + Sync + 'static>
-    ReconcileStore<K, V>
-{
+// `get_mut` shares the same `V: Value` bound as the rest of the store: an in-place edit is
+// re-stamped and broadcast (see below), and that broadcast serializes `V` through the engine's
+// `Value`-bounded path, so the bound set matches `insert`/`remove` exactly.
+impl<K: Key, V: Value> ReconcileStore<K, V> {
+    /// Mutate the value for `k` in place, then propagate the edit like [`insert`](ReconcileStore::insert).
+    ///
+    /// The callback receives `Some(&mut V)` when the key is live, or `None` when it is absent or
+    /// tombstoned. When it mutated a live value, the entry is then **re-stamped with a fresh Hybrid
+    /// Logical Clock timestamp and broadcast** to peers, exactly as a regular `insert` would be — so
+    /// an in-place edit converges across the cluster instead of remaining local. The whole
+    /// read-modify-write holds the map write lock for the duration of the callback, so it is atomic
+    /// against the reconciliation loop.
     pub fn get_mut<F: FnOnce(Option<&mut V>)>(&self, k: &K, callback: F) {
         use crate::reconcilable::Projectable;
+        // Mint the timestamp before taking the map lock, matching the lock order of `insert`
+        // (clock, then map → projection).
+        let now = self.engine.clock_now();
+        let mut updated: Option<(Timestamp, Option<V>)> = None;
         let mut guard = self.engine.map.write();
         guard.with_mut(k, |maybe_tv| {
-            if let Some((_, v)) = maybe_tv {
-                callback(v.as_mut());
+            if let Some(tv) = maybe_tv {
+                callback(tv.1.as_mut());
+                // Re-stamp so the edit wins last-write-wins on peers and reconciles; `with_mut`
+                // recomputes the dated fingerprint from the whole (timestamp, value) afterwards.
+                tv.0 = now;
+                updated = Some(tv.clone());
             } else {
                 callback(None);
             }
@@ -598,6 +609,12 @@ impl<K: Key, V: Clone + Debug + DeserializeOwned + Hash + Send + Serialize + Syn
         if let Some(tv) = guard.get(k) {
             let projected = tv.project();
             self.engine.projection.write().insert(k.clone(), projected);
+        }
+        drop(guard);
+        // Notify peers of the re-stamped entry, just like `insert`, so the edit propagates eagerly
+        // rather than being left to the next anti-entropy round (or failing to converge at all).
+        if let Some(value) = updated {
+            self.engine.broadcast_update(k.clone(), value);
         }
     }
 }

--- a/tests/service.rs
+++ b/tests/service.rs
@@ -147,6 +147,54 @@ async fn test() {
     task1.abort();
 }
 
+/// Regression test for the `get_mut` propagation bug: an in-place mutation must be re-stamped and
+/// broadcast so that peers converge to the edited value, exactly like a regular `insert`. Before
+/// the fix, `get_mut` neither bumped the timestamp nor broadcast, so the edit stayed local and the
+/// peer never saw it.
+#[tokio::test(flavor = "multi_thread")]
+async fn get_mut_edit_propagates_to_peers() {
+    let port = 8089;
+    let net = "127.0.0.1/8".parse().unwrap();
+    let addr1 = "127.0.0.100".parse().unwrap();
+    let addr2 = "127.0.0.101".parse().unwrap();
+    let cfg1 = Config::default()
+        .with_port(port)
+        .with_listen_addr(addr1)
+        .with_net(net);
+    let cfg2 = Config::default()
+        .with_port(port)
+        .with_listen_addr(addr2)
+        .with_net(net);
+
+    let store1 = ReconcileStore::new(cfg1).await.with_seed(addr2);
+    let store2 = ReconcileStore::new(cfg2).await.with_seed(addr1);
+    let task1 = tokio::spawn(store1.clone().run());
+    let task2 = tokio::spawn(store2.clone().run());
+
+    let key = "k".to_string();
+    let before = "before".to_string();
+    let after = "after".to_string();
+
+    // Seed a key on store1 and wait for store2 to observe the original value.
+    store1.insert(key.clone(), before.clone());
+    assert_until!(store2.get(&key).as_deref() == Some(&before));
+
+    // Mutate the value in place on store1.
+    store1.get_mut(&key, |v| {
+        if let Some(v) = v {
+            *v = after.clone();
+        }
+    });
+    assert_eq!(store1.get(&key).as_deref(), Some(&after));
+
+    // The crux: the in-place edit must reach store2. This fails before the fix, because `get_mut`
+    // did not re-stamp the timestamp or broadcast the change.
+    assert_until!(store2.get(&key).as_deref() == Some(&after));
+
+    task1.abort();
+    task2.abort();
+}
+
 /// Two nodes sharing the same cluster key must still converge, proving that authenticated
 /// datagrams round-trip end-to-end through the MAC layer.
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
Fixes #181.

## Problem

`ReconcileStore::get_mut` mutated a value in place but **neither minted a fresh Hybrid Logical Clock timestamp nor broadcast** the change — it only refreshed the local value-only projection. So an in-place edit stayed local:

- peers were never notified (no broadcast), and
- because the entry kept its old timestamp, the edit was not guaranteed to converge through anti-entropy either: a peer holding the same key at the *same* timestamp but the old value lands in the LWW tie-break rather than taking the newer value.

## Fix

`get_mut` now behaves like `insert` once the callback has mutated a live value:

1. Mints a fresh timestamp **before** taking the map lock (matching `insert`'s lock order: clock, then map → projection).
2. Re-stamps the entry inside the `with_mut` callback, so `with_mut` recomputes the dated fingerprint from the whole `(timestamp, value)`.
3. After dropping the map lock, broadcasts the re-stamped entry via a new `pub(crate)` engine helper `broadcast_update`, which centralises the single `Update` broadcast next to `insert`/`insert_bulk`.

The callback shape is intentionally kept (it scopes the write lock and prevents a guard from escaping and stalling the reconciliation loop).

## Note on bounds

The propagating path serializes `V` through the engine's `Value`-bounded broadcast, so `get_mut` now shares the same `V: Value` bound as the rest of the store. It previously spelled out the bounds to avoid `PartialEq`; that is no longer possible once `get_mut` propagates, and is harmless in practice since every stored `V` is already `Value` for `new`/`insert`/`remove`. (This also drops the now-unused `Debug`/`Serialize`/`DeserializeOwned` imports.)

## Testing

- New two-node regression test `get_mut_edit_propagates_to_peers`: seed a key on store1, edit it in place via `get_mut`, assert the edit reaches store2 (fails before the fix).
- Full suite green: 77 lib + integration tests, `clippy --all-targets -D warnings`, `cargo doc -D warnings`, `cargo fmt --check` all clean.

https://claude.ai/code/session_01F5RsYDnd7b3X7G9MyuCFtn

---
_Generated by [Claude Code](https://claude.ai/code/session_01F5RsYDnd7b3X7G9MyuCFtn)_