### PR TITLE
Remove issue references from comments and documentation

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -234,7 +234,7 @@ mod imp {
 
     /// Compare the in-memory cost of a **naive dated mirror** (`HRTree<K, (Timestamp, Option<V>)>`, which
     /// drags along a timestamp it never uses) against the **lightweight value-only mirror**
-    /// (`HRTree<K, ValueOnly<V>>`) that issue #128 introduces.
+    /// (`HRTree<K, ValueOnly<V>>`) that the lightweight-mirror design introduces.
     ///
     /// Criterion times the *fill* of each tree at growing sizes; the value-only tree both builds faster
     /// (less to move/hash per entry) and, as the one-off report below shows, stores fewer bytes per

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -20,7 +20,7 @@
 //! [`Config::with_encryption`](crate::reconcile_store::Config::with_encryption), this keyed mode is
 //! upgraded from authentication-only to **authenticated encryption**: each datagram is framed as
 //! `nonce || ciphertext || tag` using XChaCha20-Poly1305 over the same cluster key, adding
-//! confidentiality (issue #96) on top of the integrity and authenticity the MAC already provides.
+//! confidentiality on top of the integrity and authenticity the MAC already provides.
 //!
 //! # Design
 //!

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -30,7 +30,7 @@
 //!   Strong Eventual Consistency.
 //!
 //! LWW still discards one of two *genuinely concurrent* writes by design; recovering both
-//! would require version vectors or a CRDT and is out of scope (see issue #110).
+//! would require version vectors or a CRDT and is out of scope.
 
 use chrono::Utc;
 use parking_lot::Mutex;

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -74,7 +74,7 @@ pub trait Discovery: Send + Sync + 'static {
 
 /// The default, **speculative** discovery: one random address per declared network each round.
 ///
-/// This is the historical auto-discovery for flat or geographically partitioned CIDRs (issue #53).
+/// This is the historical auto-discovery for flat or geographically partitioned CIDRs.
 /// The probed addresses might not be live peers, so they are used only as one-shot reconciliation
 /// targets and never seeded as known peers — if a peer exists there, it replies and is registered
 /// then. It shares the engine's live `nets` and `rng`, so retuning the topology at runtime

--- a/src/fingerprint.rs
+++ b/src/fingerprint.rs
@@ -38,7 +38,7 @@
 //!    bottom of this module freeze the wire format so any change that would
 //!    break interoperability fails CI.
 //!
-//! See issue #111 and: A. Meyer, *Range-Based Set Reconciliation*
+//! See: A. Meyer, *Range-Based Set Reconciliation*
 //! (arXiv:2212.13567); Clarke et al., *Incremental Multiset Hash Functions*
 //! (ASIACRYPT 2003).
 
@@ -58,7 +58,7 @@ use serde::{Deserialize, Serialize};
 /// NOTE: a *non-empty* range can legitimately fingerprint to [`ZERO`](Fingerprint::ZERO) (elements
 /// whose hashes sum to a multiple of 2²⁵⁶). The reconciliation protocol must
 /// therefore never treat `fingerprint == ZERO` as "empty"; emptiness is decided
-/// on the element count. See issue #106.
+/// on the element count.
 #[derive(Clone, Copy, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct Fingerprint(pub [u64; 4]);
 

--- a/src/gen_ip.rs
+++ b/src/gen_ip.rs
@@ -66,7 +66,7 @@ pub fn gen_ipv6<R: Rng>(rng: &mut R, network: Ipv6Net) -> Ipv6Addr {
 
 /// One random probe address per network CIDR.
 ///
-/// Used for multi-network peer auto-discovery (issue #53): a node probes one random address inside
+/// Used for multi-network peer auto-discovery: a node probes one random address inside
 /// each configured geographical network every reconciliation round, so discovery spans every
 /// network rather than a single flat CIDR.
 pub fn probe_targets<R: Rng>(rng: &mut R, nets: &[IpNet]) -> Vec<IpAddr> {
@@ -76,7 +76,7 @@ pub fn probe_targets<R: Rng>(rng: &mut R, nets: &[IpNet]) -> Vec<IpAddr> {
 /// Return the first network in `nets` whose CIDR contains `addr`, if any.
 ///
 /// A peer's geographical network is derived purely from its IP address, so the wire format carries
-/// no network tag (issue #53).
+/// no network tag.
 pub fn net_of(nets: &[IpNet], addr: IpAddr) -> Option<IpNet> {
     nets.iter().copied().find(|net| net.contains(&addr))
 }
@@ -84,7 +84,7 @@ pub fn net_of(nets: &[IpNet], addr: IpAddr) -> Option<IpNet> {
 /// The host route (`/32` for IPv4, `/128` for IPv6) of a single address.
 ///
 /// Used as the local network of last resort: when no configured network contains a node's listen
-/// address (a misconfiguration), the node treats only itself as local (issue #53).
+/// address (a misconfiguration), the node treats only itself as local.
 pub fn host_net(addr: IpAddr) -> IpNet {
     let prefix_len = match addr {
         IpAddr::V4(_) => 32,

--- a/src/hrtree.rs
+++ b/src/hrtree.rs
@@ -15,7 +15,7 @@
 //! the cumulated [`Fingerprint`] of all key-value pairs between two keys.
 //!
 //! The per-element hash and the way fingerprints are combined (256-bit addition,
-//! *not* XOR) live in [`crate::fingerprint`]; see that module and issue #111 for
+//! *not* XOR) live in [`crate::fingerprint`]; see that module for
 //! why the combiner and hash function are chosen the way they are.
 
 //! Although we did come we the idea independently, it exactly matches a paper

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,7 @@
 //! threat model and scope.
 
 // The entire crate is implemented in safe Rust; this turns any `unsafe` block into a hard
-// compile error (see issue #165).
+// compile error.
 #![forbid(unsafe_code)]
 
 pub mod bounds;

--- a/src/mirror.rs
+++ b/src/mirror.rs
@@ -12,19 +12,19 @@
 //! # What it is for
 //!
 //! A dated store keeps a [`Timestamp`] next to every value so it can resolve conflicts
-//! (last-write-wins) and run the #109 tombstone causal-stability machinery. For a fleet with many
+//! (last-write-wins) and run the tombstone causal-stability machinery. For a fleet with many
 //! *passive read replicas* that only ever consume values, that timestamp is pure overhead: ~12–16
 //! bytes per entry that the replica never needs. A `ReconcileMirror` stores only
 //! [`ValueOnly<V>`] — the `Option<V>` payload, no timestamp — and still converges with a dated peer
 //! over the **existing range-based diff protocol**, on the same UDP port.
 //!
-//! # How it stays #109-safe
+//! # How it stays causal-stability-safe
 //!
 //! The mirror speaks only the **value-only channel** of the protocol (the `ValueComparisonItem` /
-//! `ValueUpdate` messages, see issue #128). A
+//! `ValueUpdate` messages). A
 //! dated peer answers those by diffing against its value-only *projection* tree, so the mirror never
 //! sees a timestamp and the dated↔dated path is untouched. Crucially, the mirror **never
-//! acknowledges tombstones and is never added to a dated peer's #109 membership set**, so it cannot
+//! acknowledges tombstones and is never added to a dated peer's causal-stability membership set**, so it cannot
 //! block tombstone garbage collection — the regression the naive "single value-only hash" design
 //! would have caused.
 //!
@@ -87,14 +87,14 @@ type WireDated<V> = (Timestamp, Option<V>);
 
 /// A lightweight, dateless, read-only mirror of a dated [`ReconcileStore`](crate::ReconcileStore).
 ///
-/// See the [module documentation](crate::mirror) for the design and the #109-safety guarantees.
+/// See the [module documentation](crate::mirror) for the design and the causal-stability-safety guarantees.
 pub struct ReconcileMirror<K, V> {
     /// The value-only mirror. Its range fingerprints are timestamp-less by construction (see
     /// [`ValueOnly`]), matching a dated peer's value-only projection.
     tree: Arc<RwLock<HRTree<K, ValueOnly<V>>>>,
     port: u16,
     socket: Arc<UdpSocket>,
-    /// The single network this read-only mirror probes for discovery (issue #53). A mirror is a
+    /// The single network this read-only mirror probes for discovery. A mirror is a
     /// dateless sink, usually seeded onto a dated cluster, so it tracks just one network: the one
     /// containing its listen address, else the first declared network, else the loopback default.
     /// Shared so it can be retuned at runtime (see [`set_net`](Self::set_net)).
@@ -299,7 +299,7 @@ impl<K: Key, V: Clone + Debug + DeserializeOwned + Hash + Send + Serialize + Syn
                 Ok(Message::ValueComparisonItem(segment)) => value_in_comparison.push(segment),
                 Ok(Message::ValueUpdate(update)) => value_updates.push(update),
                 // The dated channel is meaningless to a mirror (it cannot store dated values nor
-                // participate in #109). Ignore it.
+                // participate in causal stability). Ignore it.
                 Ok(Message::ComparisonItem(_)) | Ok(Message::Update(_)) | Ok(Message::Ack(_)) => {}
             }
         }
@@ -450,7 +450,7 @@ mod tests {
     }
 
     /// A live value and its `ValueOnly` projection hash identically only via the value-only basis:
-    /// per-entry, the dateless mirror saves the whole `Timestamp` (the point of #128).
+    /// per-entry, the dateless mirror saves the whole `Timestamp` (the point of the dateless mirror).
     #[test]
     fn value_only_is_smaller_per_entry() {
         let dated = std::mem::size_of::<(Timestamp, Option<u64>)>();

--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -18,15 +18,15 @@
 //!
 //! Why this matters: a node that restarts with an empty map loses its **tombstones** too. Losing
 //! tombstones is not just a durability problem — it is a correctness multiplier for tombstone
-//! resurrection (see issue #109): the restarted node behaves like a fresh replica, re-learns
+//! resurrection: the restarted node behaves like a fresh replica, re-learns
 //! already-deleted values from peers, and can re-propagate them. A durable backend recovers the
-//! tombstones (and the #109 causal-stability state) before the node rejoins the gossip protocol.
+//! tombstones (and the causal-stability state) before the node rejoins the gossip protocol.
 //!
 //! # What is persisted
 //!
 //! - **All map entries**, live values *and* tombstones (the map stores `(timestamp, Option<V>)`,
 //!   and tombstones are `(timestamp, None)` retained until causal-stability-gated GC).
-//! - The **causal-stability state** from issue #109: the membership set and the per-tombstone
+//! - The **causal-stability state**: the membership set and the per-tombstone
 //!   acknowledgments, so a restarted node still holds back GC until every replica has seen a
 //!   deletion.
 //!
@@ -63,7 +63,7 @@ pub type DatedEntries<K, V> = Vec<(K, (Timestamp, Option<V>))>;
 pub struct PersistedState<K, V> {
     /// Every key with its dated value. A `None` payload is a tombstone.
     pub entries: DatedEntries<K, V>,
-    /// Every peer this node has ever communicated with (causal-stability membership, #109).
+    /// Every peer this node has ever communicated with (causal-stability membership).
     pub members: HashSet<IpAddr>,
     /// Per-tombstone acknowledgments: `key -> (peer -> version token of the tombstone it holds)`.
     pub tombstone_acks: HashMap<K, HashMap<IpAddr, u64>>,

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -74,7 +74,7 @@ pub fn diff_round<K, V>(
         // produces `Included`/`Unbounded` start bounds and `Excluded`/`Unbounded` end
         // bounds (see `start_diff` and the segments pushed below). Rather than reaching
         // `unimplemented!()` — a remote-triggerable panic that would kill the
-        // reconciliation task (issue #112) — we drop any other bound shape and move on.
+        // reconciliation task — we drop any other bound shape and move on.
         let start_index = match start_bound.as_ref() {
             Bound::Unbounded => 0,
             Bound::Included(key) => tree.insertion_position(key),
@@ -109,7 +109,7 @@ pub fn diff_round<K, V>(
         // `crate::fingerprint`), so a *non-empty* range can legitimately fingerprint
         // to `ZERO`; using `hash == ZERO` as an "empty" sentinel (or `hash ==
         // local_hash` alone as "equal") would alias such ranges and cause silent,
-        // permanent divergence. See issues #106 and #111.
+        // permanent divergence.
         if hash == local_hash && size == local_size {
             continue;
         } else if size == 0 {
@@ -192,7 +192,7 @@ mod tests {
         (out_comparison, differences)
     }
 
-    // ----- Issue #112: malformed segments from the wire must be dropped, never panic. -----
+    // ----- Malformed segments from the wire must be dropped, never panic. -----
 
     /// An `Excluded` start bound used to reach `unimplemented!()`. The segment must be
     /// dropped, not panic.
@@ -255,13 +255,13 @@ mod tests {
         assert_eq!(differences, vec![(Bound::Unbounded, Bound::Unbounded)]);
     }
 
-    // ----- Issue #106 / #111: emptiness and equality are decided on `size`, never on the -----
+    // ----- Emptiness and equality are decided on `size`, never on the -----
     // range fingerprint. A range fingerprint combines per-element hashes additively, so a
     // non-empty range can legitimately fingerprint to `ZERO` and two different ranges can
     // fingerprint equally. The segment fields below are exactly what such a colliding (or
     // hostile) peer puts on the wire; we drive them straight through `diff_round`.
 
-    /// Headline #106 counterexample. A *non-empty* peer range that fingerprints to `ZERO`
+    /// Headline counterexample. A *non-empty* peer range that fingerprints to `ZERO`
     /// (e.g. two elements whose per-element hashes cancel) is advertised against our empty
     /// tree, which also fingerprints to `ZERO`. The hashes match (`ZERO == ZERO`) but the
     /// sizes differ (`2 != 0`). The buggy code short-circuited on the first `hash ==
@@ -291,7 +291,7 @@ mod tests {
         );
     }
 
-    /// #106 dual: equal fingerprints with equal sizes over a *non-empty* range are correctly
+    /// Dual: equal fingerprints with equal sizes over a *non-empty* range are correctly
     /// concluded in sync (the size check does not produce false differences). We advertise
     /// the tree's own real fingerprint and size back to it.
     #[test]
@@ -307,7 +307,7 @@ mod tests {
         assert!(differences.is_empty());
     }
 
-    /// #106 branch: equal fingerprints but *different* sizes over a non-empty range must not
+    /// Branch: equal fingerprints but *different* sizes over a non-empty range must not
     /// be mistaken for "in sync"; the range is refined instead. We feed the tree's own
     /// fingerprint with a deliberately wrong (larger) size, forcing the fan-out branch.
     #[test]

--- a/src/reconcilable.rs
+++ b/src/reconcilable.rs
@@ -66,8 +66,8 @@ impl<V> MaybeTombstone for (Timestamp, Option<V>) {
 /// `ValueOnly(Some(v))`; a tombstone is `ValueOnly(None)`.
 ///
 /// This is deliberately a *separate* type from the dated `(Timestamp, Option<V>)`: the dated value keeps
-/// its timestamp-inclusive `Hash` (required by the engine's `version_hash` for the #109
-/// causal-stability acks), so a single value-only hash never replaces it. See issue #128.
+/// its timestamp-inclusive `Hash` (required by the engine's `version_hash` for the
+/// causal-stability acks), so a single value-only hash never replaces it.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct ValueOnly<V>(pub Option<V>);
 

--- a/src/reconcile_engine.rs
+++ b/src/reconcile_engine.rs
@@ -102,11 +102,11 @@ pub(crate) struct Inner<K, V: Projectable> {
     /// Its range fingerprints are timestamp-less by construction (see
     /// [`ValueOnly`](crate::reconcilable::ValueOnly)), which is what lets a dateless mirror
     /// converge with this dated store over the existing range-diff protocol. It is read-only state
-    /// for the dated↔dated path and never touches the #109 causal-stability bookkeeping.
+    /// for the dated↔dated path and never touches the causal-stability bookkeeping.
     pub(crate) projection: Arc<RwLock<HRTree<K, V::Projected>>>,
     port: u16,
     socket: Arc<UdpSocket>,
-    /// The geographical networks the cluster spans, each a CIDR (issue #53). One random address is
+    /// The geographical networks the cluster spans, each a CIDR. One random address is
     /// probed per network each round for auto-discovery, and a peer's network is derived from its IP
     /// via `IpNet::contains`. Shared and mutable at runtime (see [`set_nets`](Self::set_nets)) so the
     /// topology can be retuned live without recreating the node — the [`run`](Self::run) loop snapshots
@@ -132,9 +132,9 @@ pub(crate) struct Inner<K, V: Projectable> {
     reconcile_interval: Arc<RwLock<Duration>>,
     /// Rate (bytes/sec) at which a single bulk anti-entropy value transfer to one peer is paced, or
     /// `None` to send back-to-back. Mirrors [`Config::bulk_send_rate`](crate::reconcile_store::Config::bulk_send_rate)
-    /// and is read by [`spawn_paced_send`](Self::spawn_paced_send) (issue #168).
+    /// and is read by [`spawn_paced_send`](Self::spawn_paced_send).
     bulk_send_rate: Option<usize>,
-    /// Peers with a bulk value transfer currently in flight (issue #168). At most one paced dump
+    /// Peers with a bulk value transfer currently in flight. At most one paced dump
     /// runs per peer at a time: while one is in flight, the reconcile timer re-firing (the receiver
     /// applies updates silently, so the holder sees a lull and re-initiates) must NOT spawn a second
     /// dump over ranges still in transit — that is precisely the byte amplification this prevents.
@@ -161,7 +161,7 @@ pub(crate) struct Inner<K, V: Projectable> {
     /// prevents a peer that is partitioned for longer than the peer-expiration window from
     /// resurrecting a deleted value on its return.
     ///
-    /// Multi-network note (issue #53): remote-network members are gossiped to on a slower cadence, so
+    /// Multi-network note: remote-network members are gossiped to on a slower cadence, so
     /// their tombstone acknowledgments arrive later and cross-network GC is correspondingly slower —
     /// but still strictly correct, since GC never proceeds before *every* member has acked. Lowering
     /// [`Config::remote_interval`] or raising [`Config::remote_fanout`] speeds it up at the
@@ -196,7 +196,7 @@ impl<K, V: Projectable> std::ops::Deref for ReconcileEngine<K, V> {
 /// The three original variants form the **dated** channel (`ComparisonItem` / `Update` / `Ack`),
 /// exchanged between full dated stores exactly as before — their bincode tags (0, 1, 2) and wire
 /// bytes are unchanged. The two trailing variants form the additive **value-only** channel used by
-/// lightweight dateless mirrors (issue #128): they are tagged 3 and 4, so a node that does not
+/// lightweight dateless mirrors: they are tagged 3 and 4, so a node that does not
 /// understand them simply fails to deserialize and drops the datagram (the receive loop is hardened
 /// against that), keeping the protocol backward compatible on a single port.
 ///
@@ -256,7 +256,7 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
                 "SECURITY: no cluster key set — UDP reconciliation is UNAUTHENTICATED. Any host \
                  that can send UDP to this port can forge updates and poison the cluster via \
                  last-write-wins. Set Config::with_cluster_key on every node, or restrict the \
-                 network to a trusted underlay. See issue #108 / REVIEW.md F3."
+                 network to a trusted underlay. See REVIEW.md F3."
             );
         }
         let map = HRTree::<K, V>::new();
@@ -445,8 +445,7 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
         });
     }
 
-    /// Send a bulk batch of differing values to one peer on a detached, **rate-paced** task (issue
-    /// #168).
+    /// Send a bulk batch of differing values to one peer on a detached, **rate-paced** task.
     ///
     /// This is the cold/bulk anti-entropy path: when a peer differs over a whole range it must
     /// receive every value in that range (most starkly, a cold/empty peer pulling the whole
@@ -454,7 +453,7 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
     /// receiver's socket buffer — datagrams dropped in the kernel — and (b) hold the receive loop for
     /// the whole transfer, so no other peer is served meanwhile.
     ///
-    /// Two cooperating mechanisms fix the cold-sync amplification (issue #168):
+    /// Two cooperating mechanisms fix the cold-sync amplification:
     ///
     /// 1. **Pacing** to [`bulk_send_rate`](Inner::bulk_send_rate) bytes/sec, on a spawned task, keeps
     ///    the burst below the receiver's overrun threshold and off the receive loop.
@@ -583,8 +582,8 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
                                 //
                                 // Crucially, a sender that spoke *only* the value-only channel is a
                                 // dateless read-only mirror: it never acknowledges tombstones, so it
-                                // must NOT join the #109 membership set or it would block GC
-                                // forever (the very regression #128 must avoid). Such a mirror is
+                                // must NOT join the causal-stability membership set or it would block GC
+                                // forever (the very regression we must avoid). Such a mirror is
                                 // served reactively off `peer` and is not tracked as a peer/member.
                                 if spoke_dated {
                                     let addr = peer.ip();
@@ -617,7 +616,7 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
                 .serialize(&mut Serializer::new(&mut *send_buf, DefaultOptions::new()))
                 .expect("serializing a ComparisonItem into an in-memory buffer cannot fail");
         }
-        // Geography-aware target selection (issue #53). With a single network this reduces to the
+        // Geography-aware target selection. With a single network this reduces to the
         // historical behaviour: every known peer is local, so all of them are contacted each round,
         // plus a single random discovery probe.
         //
@@ -695,7 +694,7 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
     ///
     /// Returns `true` if the datagram contained at least one **dated** protocol message
     /// (`ComparisonItem` / `Update` / `Ack`). The caller uses this to decide whether to register
-    /// the sender in the #109 membership set: a sender that spoke only the value-only channel is a
+    /// the sender in the causal-stability membership set: a sender that spoke only the value-only channel is a
     /// read-only mirror and must not gate tombstone GC.
     #[instrument(name = "reconcile.handle", skip_all, fields(peer = %peer))]
     async fn handle_messages(
@@ -804,7 +803,7 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
             }
             // The differing values are the bulk payload — a cold/empty peer pulls the whole dataset
             // here. Hand them to a rate-paced background task so the burst cannot overrun the
-            // receiver and the receive loop stays free for other peers (issue #168).
+            // receiver and the receive loop stays free for other peers.
             if !differences.is_empty() {
                 debug!("returning {} diff_ranges", differences.len());
                 trace!("diff_ranges: {differences:?}");
@@ -832,14 +831,14 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
             // 1) Under a read lock, decide which merged values would actually change state. We must
             //    NOT run the pre-insert hook here: hooks are contractually executed *outside* the
             //    map's write lock (matching `just_insert`), so a hook that re-inserts cannot
-            //    re-enter the lock and deadlock (issue #149).
+            //    re-enter the lock and deadlock.
             let mut to_apply: Vec<(K, V)> = Vec::new();
             {
                 let guard = self.map.read();
                 for (k, remote_v) in updates {
                     // Advance our clock past the timestamp carried by the remote value, so a
                     // later local write is ordered after everything we have seen. This is
-                    // what prevents lost updates under clock skew (issue #110).
+                    // what prevents lost updates under clock skew.
                     self.clock.observe(remote_v.timestamp());
                     match guard.get(&k) {
                         Some(local_v) => {
@@ -897,7 +896,7 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
         // Value-only channel: answer a dateless mirror by diffing against the value-only
         // *projection* tree (never the dated map) and replying with `ValueUpdate`s carrying only
         // the projected payload. This path is entirely independent of the dated channel and of the
-        // #109 causal-stability state — no acks, no membership, no GC interaction.
+        // causal-stability state — no acks, no membership, no GC interaction.
         if !value_in_comparison.is_empty() {
             debug!("received {} value-only segments", value_in_comparison.len());
             let mut differences = Vec::new();
@@ -927,7 +926,7 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
                 .await;
             }
             // Bulk value-only payload — a dateless mirror pulling the dataset. Rate-pace it on a
-            // background task, exactly like the dated bulk path (issue #168).
+            // background task, exactly like the dated bulk path.
             if !differences.is_empty() {
                 let updates: Vec<Message<K, V, V::Projected>> = {
                     let guard = self.projection.read();
@@ -1038,8 +1037,8 @@ pub(crate) async fn send_to_retry<A: ToSocketAddrs>(
 /// Send `messages` to `peer` back-to-back (unpaced).
 ///
 /// Used for the small, latency-sensitive batches — refinement comparison items, tombstone acks, and
-/// local-write broadcasts. The bulk anti-entropy value dump uses the paced variant instead (issue
-/// #168); see [`send_messages_paced`] and [`ReconcileEngine::spawn_paced_send`].
+/// local-write broadcasts. The bulk anti-entropy value dump uses the paced variant instead;
+/// see [`send_messages_paced`] and [`ReconcileEngine::spawn_paced_send`].
 pub(crate) async fn send_messages_to<K: Serialize, V: Serialize, P: Serialize>(
     messages: &[Message<K, V, P>],
     socket: Arc<UdpSocket>,
@@ -1055,7 +1054,7 @@ pub(crate) async fn send_messages_to<K: Serialize, V: Serialize, P: Serialize>(
 /// With `rate = None` the datagrams go out back-to-back (the historical behaviour). With
 /// `rate = Some(bytes_per_sec)` the function sleeps between datagrams so the average send rate stays
 /// at or below that bound — used for bulk anti-entropy value transfers so the burst cannot overrun
-/// the receiver's socket buffer (issue #168). Because it sleeps, it must run **off** the receive
+/// the receiver's socket buffer. Because it sleeps, it must run **off** the receive
 /// loop (see [`ReconcileEngine::spawn_paced_send`]); pacing inline in `handle_messages` would stall
 /// reception of every other peer for the duration of the transfer.
 #[instrument(name = "reconcile.send", skip_all, fields(peer = %peer, count = messages.len()))]
@@ -1110,7 +1109,7 @@ async fn pace(rate: Option<usize>, start: Instant, sent_bytes: usize) {
     }
 }
 
-/// RAII marker that a bulk dump to `peer` is in flight (issue #168). Removing the peer on `Drop` —
+/// RAII marker that a bulk dump to `peer` is in flight. Removing the peer on `Drop` —
 /// rather than at the end of the send task's body — guarantees the in-flight mark is cleared even if
 /// the send task panics, so a transient failure can never wedge a peer into "permanently
 /// transferring" (which would silently stop it from ever syncing again). See
@@ -1190,8 +1189,8 @@ mod deadlock_regressions {
         buf
     }
 
-    /// Network-path counterpart of [`pre_insert_hook_can_call_insert_again_without_deadlock`]
-    /// (issue #149): a value arriving over the wire is integrated by [`handle_messages`], which must
+    /// Network-path counterpart of [`pre_insert_hook_can_call_insert_again_without_deadlock`]:
+    /// a value arriving over the wire is integrated by [`handle_messages`], which must
     /// run the pre-insert hook *outside* the map's write lock, just like the direct `just_insert`
     /// path. Otherwise a hook that re-inserts re-enters the (non-reentrant) write lock and deadlocks
     /// the receive loop.
@@ -1478,7 +1477,7 @@ mod pacing {
         start.elapsed()
     }
 
-    /// `bulk_send_rate` actually meters the transfer (issue #168): a multi-datagram payload sent at a
+    /// `bulk_send_rate` actually meters the transfer: a multi-datagram payload sent at a
     /// low rate takes substantially longer than the same payload sent unpaced. Anchored to
     /// wall-clock, so we only assert a generous lower bound on the paced run (sleeping can only
     /// lengthen it) and an upper bound on the unpaced run — robust to CI scheduler jitter.

--- a/src/reconcile_store.rs
+++ b/src/reconcile_store.rs
@@ -43,7 +43,7 @@ const DEFAULT_DISCOVERY_INTERVAL: Duration = Duration::from_secs(5);
 const DEFAULT_DISCOVERY_MISS_THRESHOLD: u32 = 3;
 
 /// Default rate, in bytes per second, at which a single bulk anti-entropy value transfer to one
-/// peer is metered (see [`Config::bulk_send_rate`] and issue #168). 32 MiB/s keeps a cold-sync fast
+/// peer is metered (see [`Config::bulk_send_rate`]). 32 MiB/s keeps a cold-sync fast
 /// while spacing datagrams (~2 ms apart at the 64 KiB datagram size) so the burst cannot overrun the
 /// receiver's socket buffer, and so the receiver keeps being fed and does not re-issue a full diff
 /// over ranges still in flight (the byte amplification this caps).
@@ -376,7 +376,7 @@ impl<K: Key, V: Value> ReconcileStore<K, V> {
     ///
     /// Unlike the previous physical-clock API, callers no longer supply timestamps: a
     /// caller-chosen `DateTime` could collide with another replica's and trigger the
-    /// non-commutative tie-break that caused permanent divergence (issue #110).
+    /// non-commutative tie-break that caused permanent divergence.
     pub fn remove_bulk(&self, keys: &[K]) {
         self.engine.insert_bulk(
             &keys
@@ -627,7 +627,7 @@ pub const MAX_NETS: usize = 8;
 pub struct Config {
     pub port: u16,
     pub listen_addr: IpAddr,
-    /// The geographical networks the cluster spans, each a CIDR (issue #53). Empty slots are `None`.
+    /// The geographical networks the cluster spans, each a CIDR. Empty slots are `None`.
     ///
     /// Declare every network with [`with_net`](Config::with_net); a *network* is just an address
     /// range, sized to your topology (a whole cloud region, an availability zone, or a single
@@ -682,12 +682,12 @@ pub struct Config {
     /// peer RTT (and below the bulk pacing gap — see [`bulk_send_rate`](Self::bulk_send_rate)): the
     /// diff is multi-round-trip, so re-initiating before the previous round's reply lands — or
     /// between a bulk transfer's paced datagrams — only floods the single receive loop with redundant
-    /// comparisons, slowing convergence rather than speeding it (issue #178). Keep it ≥ a few × RTT;
+    /// comparisons, slowing convergence rather than speeding it. Keep it ≥ a few × RTT;
     /// the 1 s default is a safe, low-overhead choice. Retunable at runtime via
     /// [`set_reconcile_interval`](crate::ReconcileStore::set_reconcile_interval).
     pub reconcile_interval: Duration,
     /// Rate, in bytes per second, at which a single **bulk** anti-entropy value transfer to one peer
-    /// is metered (issue #168). Defaults to 32 MiB/s; `None` disables pacing (the historical
+    /// is metered. Defaults to 32 MiB/s; `None` disables pacing (the historical
     /// back-to-back burst).
     ///
     /// When a peer differs over a whole range — most starkly a cold/empty peer pulling the entire
@@ -729,7 +729,7 @@ impl Config {
         self.listen_addr = listen_addr;
         self
     }
-    /// Declare a geographical network the cluster spans, by its CIDR (issue #53).
+    /// Declare a geographical network the cluster spans, by its CIDR.
     ///
     /// Call once per network — **including this node's own**. The node's local network is whichever
     /// declared net contains [`listen_addr`](Config::listen_addr); the rest are remote and gossiped
@@ -817,7 +817,7 @@ impl Config {
     }
 
     /// Encrypt datagram payloads with XChaCha20-Poly1305, upgrading the keyed protocol from
-    /// authentication-only to authenticated **encryption** (issue #96).
+    /// authentication-only to authenticated **encryption**.
     ///
     /// This reuses the shared [`cluster_key`](Self::cluster_key) as the AEAD key, so
     /// [`with_cluster_key`](Self::with_cluster_key) must also be set on every node; a node
@@ -924,7 +924,7 @@ mod reconcile_store_tests {
         assert!(restarted.tombstones.remove(&2).is_some());
     }
 
-    /// The causal-stability state from issue #109 (membership + per-tombstone acks) must survive a
+    /// The causal-stability state (membership + per-tombstone acks) must survive a
     /// restart, otherwise GC gating is lost.
     #[tokio::test]
     async fn restart_preserves_membership_and_acks() {
@@ -966,7 +966,7 @@ mod reconcile_store_tests {
         );
     }
 
-    /// Regression for issue #122 ↔ #109: a restart must not turn a held-back tombstone into a
+    /// Regression: a restart must not turn a held-back tombstone into a
     /// collectable (and thus resurrectable) one. A fresh, empty store would treat the tombstone as
     /// causally stable (no members ⇒ GC allowed); a store that recovered its membership must still
     /// gate GC because the unacknowledged peer is restored too.
@@ -998,7 +998,7 @@ mod reconcile_store_tests {
         let fresh_version = fresh.engine.map.read().get(&1).map(version_hash).unwrap();
         assert!(
             fresh.engine.is_tombstone_stable(&1, fresh_version),
-            "a fresh restart with no membership would (wrongly) GC the tombstone — the hazard #122 describes"
+            "a fresh restart with no membership would (wrongly) GC the tombstone — the hazard this guards against"
         );
 
         // The recovered store keeps the tombstone gated, preventing resurrection.

--- a/tests/diff.rs
+++ b/tests/diff.rs
@@ -109,7 +109,7 @@ fn test_compare() {
     )
 }
 
-// The size-not-hash regression tests for issue #106/#111 — a *non-empty* range that
+// The size-not-hash regression tests — a *non-empty* range that
 // fingerprints to `ZERO`, and equal fingerprints over different-sized ranges — require feeding
 // crafted `HashSegment`s (whose `hash`/`size` fields are deliberately set to collide) straight
 // into `diff_round`. Because `HashSegment`'s fields are `pub(crate)`, those tests live as unit

--- a/tests/fuzz_packets.rs
+++ b/tests/fuzz_packets.rs
@@ -6,7 +6,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-//! Malformed-packet fuzzing of the receive loop (issue #113).
+//! Malformed-packet fuzzing of the receive loop.
 //!
 //! A single malformed datagram from any host must never panic or kill the
 //! receive task — otherwise an unauthenticated remote could DoS the whole

--- a/tests/mirror.rs
+++ b/tests/mirror.rs
@@ -6,13 +6,13 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-//! Interop between a dated [`ReconcileStore`] and a dateless [`ReconcileMirror`] (issue #128).
+//! Interop between a dated [`ReconcileStore`] and a dateless [`ReconcileMirror`].
 //!
 //! These cover the two properties the lightweight-mirror design must guarantee:
 //! 1. **Convergence**: the mirror receives the dated store's current values (timestamps dropped),
 //!    mirrors deletions as tombstones, and its value-only fingerprint matches the dated store's
 //!    value-only projection.
-//! 2. **#109-safety**: a read-only mirror is never counted as a causal-stability member, so it
+//! 2. **Causal-stability safety**: a read-only mirror is never counted as a causal-stability member, so it
 //!    cannot block the dated store's tombstone garbage collection.
 
 use std::time::Duration;
@@ -99,7 +99,7 @@ async fn mirror_converges_with_dated_store() {
     mirror_task.abort();
 }
 
-/// A read-only mirror must never join the dated store's #109 membership set, otherwise it would
+/// A read-only mirror must never join the dated store's causal-stability membership set, otherwise it would
 /// hold back tombstone garbage collection forever (it never acknowledges tombstones). With only a
 /// mirror talking to it, the dated store must still collect an expired tombstone.
 #[tokio::test(flavor = "multi_thread")]

--- a/tests/observability.rs
+++ b/tests/observability.rs
@@ -6,7 +6,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-//! Smoke tests for the observability instrumentation (issue #94).
+//! Smoke tests for the observability instrumentation.
 //!
 //! These tests deliberately exercise only the **synchronous, same-thread** paths:
 //! `tracing::subscriber::set_default` and `metrics::with_local_recorder` are both

--- a/tests/proptest_hrtree.rs
+++ b/tests/proptest_hrtree.rs
@@ -6,7 +6,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-//! Property-based / generative tests (issue #113).
+//! Property-based / generative tests.
 //!
 //! These exercise the two invariants that matter most for a reconciliation
 //! library and that fixed-seed example tests cannot cover exhaustively:

--- a/tests/service.rs
+++ b/tests/service.rs
@@ -86,7 +86,7 @@ async fn test() {
     // deterministic, causality-respecting LWW contract. (We deliberately do *not* rely on
     // wall-clock real-time order across the two independent node clocks: two writes in the same
     // millisecond on different nodes are genuinely concurrent and resolved by node id, which is
-    // exactly the ambiguity issue #110 is about.)
+    // exactly the ambiguity this is about.)
     let key = "42".to_string();
     for i in 0..20 {
         // Unique values per iteration so each `assert_until` observes *this* write, not a value
@@ -242,7 +242,7 @@ async fn authenticated_nodes_converge() {
     task1.abort();
 }
 
-/// Regression test for issue #110: two replicas that concurrently write *different* values to
+/// Regression test: two replicas that concurrently write *different* values to
 /// the same key must converge to a single agreed value, with matching fingerprints.
 ///
 /// Before the Hybrid Logical Clock fix, conflict resolution keyed on the physical wall clock
@@ -301,7 +301,7 @@ async fn concurrent_writes_converge() {
     task2.abort();
 }
 
-/// Regression test for issue #109: a tombstone must not be garbage-collected while a replica
+/// Regression test: a tombstone must not be garbage-collected while a replica
 /// that has not acknowledged it is still a member (causal stability), and decommissioning that
 /// replica must release the tombstone for GC.
 #[tokio::test(flavor = "multi_thread")]
@@ -371,7 +371,7 @@ async fn tombstone_is_retained_until_peer_acknowledges() {
     task1.abort();
 }
 
-/// Regression test for issue #109: a value deleted while a replica is partitioned must not be
+/// Regression test: a value deleted while a replica is partitioned must not be
 /// resurrected when that replica returns with the stale value.
 #[tokio::test(flavor = "multi_thread")]
 async fn deleted_value_is_not_resurrected_by_returning_peer() {
@@ -438,7 +438,7 @@ async fn deleted_value_is_not_resurrected_by_returning_peer() {
 }
 
 /// Regression test for the remote DoS where a single malformed UDP datagram panicked the
-/// receive loop, silently killing reconciliation (issue #107).
+/// receive loop, silently killing reconciliation.
 ///
 /// We send a malformed datagram to each node, then check that reconciliation still works.
 /// Before the fix, the receive loop task would panic and die, and the propagation assertion
@@ -480,7 +480,7 @@ async fn test_malformed_datagram_does_not_crash() {
 }
 
 /// Two nodes sharing the same cluster key with encryption enabled must converge, proving that
-/// payloads round-trip end-to-end through the XChaCha20-Poly1305 layer (issue #96).
+/// payloads round-trip end-to-end through the XChaCha20-Poly1305 layer.
 #[cfg(feature = "encryption")]
 #[tokio::test(flavor = "multi_thread")]
 async fn encrypted_nodes_converge() {
@@ -572,7 +572,7 @@ async fn encrypted_node_with_wrong_key_is_rejected() {
     task1.abort();
 }
 
-/// Issue #53: two nodes in distinct geographical networks converge over cross-network anti-entropy.
+/// Two nodes in distinct geographical networks converge over cross-network anti-entropy.
 ///
 /// Networks are simulated by two disjoint /30 subnets inside the loopback range, each node living in
 /// one of them and declaring both. A dedicated port isolates the test.
@@ -619,7 +619,7 @@ async fn cross_net_reconciliation() {
     task2.abort();
 }
 
-/// Issue #53: a node auto-discovers a peer in another network purely from the network's CIDR, with
+/// A node auto-discovers a peer in another network purely from the network's CIDR, with
 /// no seed. Discovery probes one random address per network each round. To keep the test
 /// deterministic (rather than relying on a random probe landing on the peer within a subnet), each
 /// node declares the *other node's exact address* as a network (a /32), so the per-network discovery


### PR DESCRIPTION
This PR removes references to specific GitHub issue numbers from comments, documentation, and test descriptions throughout the codebase. Instead of citing issues like `#109`, `#128`, `#168`, etc., comments now describe the concepts and features directly (e.g., "causal-stability" instead of "issue #109").

## Summary

This is a documentation and comment cleanup that improves code readability by:
- Replacing issue number references with descriptive terms for the concepts they represent
- Maintaining all technical accuracy and context while making comments more self-contained
- Ensuring future readers understand the "why" without needing to cross-reference external issue trackers

## Key Changes

- **Causal-stability references**: Replaced `#109` with "causal-stability" or "causal-stability membership set" throughout the codebase
- **Dateless mirror design**: Replaced `#128` with "dateless mirror" or "lightweight-mirror design"
- **Rate pacing**: Replaced `#168` with descriptive context about bulk send rate pacing
- **Multi-network topology**: Replaced `#53` with "geographical networks" or "multi-network"
- **Clock skew handling**: Replaced `#110` with "clock skew" or "concurrent writes"
- **Fingerprint collision safety**: Replaced `#106`/`#111` with descriptive explanations of the size-based equality checks
- **Other issues**: Removed references to `#96` (encryption), `#107` (malformed datagrams), `#112` (panic safety), `#113` (fuzzing), `#149` (deadlock), `#165` (unsafe code), and `#178` (reconciliation interval)

## Files Modified

- `src/reconcile_engine.rs`: Updated 15+ comment references
- `src/reconcile_store.rs`: Updated 8+ comment references
- `src/mirror.rs`: Updated 6+ comment references
- `src/proto.rs`: Updated 5+ comment references
- `src/persistence.rs`: Updated 4+ comment references
- `src/gen_ip.rs`: Updated 4+ comment references
- `src/fingerprint.rs`: Updated 3+ comment references
- `src/reconcilable.rs`: Updated 2+ comment references
- `src/auth.rs`, `src/clock.rs`, `src/discovery.rs`, `src/hrtree.rs`, `src/lib.rs`: Updated 1-2 references each
- `tests/service.rs`, `tests/mirror.rs`, `tests/diff.rs`, `tests/fuzz_packets.rs`, `tests/observability.rs`, `tests/proptest_hrtree.rs`, `benches/bench.rs`: Updated test and benchmark comments

No functional code changes; this is purely a documentation improvement.

https://claude.ai/code/session_01F5RsYDnd7b3X7G9MyuCFtn