### PR TITLE
fix(store): advance the clock past persisted stamps on restore

### DIFF
--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: ["main"]
   pull_request:
+  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [ "main" ]
   pull_request:
+  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -154,6 +154,22 @@ pub trait Clock: Send + Sync + 'static {
     /// that a single poisoned stamp cannot pin the local clock into the far future. The
     /// total order on [`Timestamp`] and the strict-`>` merge are unaffected.
     fn observe(&self, remote: Timestamp);
+    /// Advance the clock past a stamp that **this node itself authored** (e.g. restored from its
+    /// own persisted state), so that the first post-restart [`now`](Clock::now) is strictly
+    /// ordered after every pre-restart write.
+    ///
+    /// Unlike [`observe`](Clock::observe), implementations must **not** apply the far-future
+    /// suspicion clamp to a self-authored stamp. The clamp guards against a remote peer injecting
+    /// an arbitrarily large wall value; it must not fire on a stamp we wrote ourselves, because
+    /// refusing to chase our own past output re-introduces own-write shadowing after a backward
+    /// clock step (NTP correction, VM resume) that moved physical time behind the persisted max.
+    ///
+    /// The default implementation delegates to [`observe`](Clock::observe), which is safe for
+    /// adapters that already have no clamp (e.g. the test `ManualClock`). `HlcClock` overrides
+    /// this with a clamp-free advance to preserve the guarantee above.
+    fn observe_trusted(&self, remote: Timestamp) {
+        self.observe(remote);
+    }
 }
 
 /// A per-node Hybrid Logical Clock — the default [`Clock`] adapter.
@@ -181,6 +197,54 @@ impl HlcClock {
                 node_id,
             }),
         }
+    }
+}
+
+impl HlcClock {
+    /// Shared advance logic for [`Clock::observe`] and [`Clock::observe_trusted`].
+    ///
+    /// `effective_remote_wall` is the wall value to use for the remote stamp — callers that
+    /// apply the far-future clamp pass the clamped value; the trusted path passes the raw value.
+    /// `remote_counter` is the counter from the original `remote` stamp (unchanged by any clamp).
+    ///
+    /// Preserves strict monotonicity and counter semantics exactly as the original `observe`
+    /// implementation did in its unclamped branches.
+    fn advance_inner(
+        &self,
+        last: &mut Timestamp,
+        pt: u64,
+        effective_remote_wall: u64,
+        remote_counter: u32,
+    ) {
+        let max_wall = pt.max(last.wall_ms).max(effective_remote_wall);
+
+        // Pick the base counter from the dominant wall bucket, then advance one logical tick.
+        // advance() handles u32::MAX → (wall+1, 0) so the result can never wrap.
+        let base_counter = if max_wall == last.wall_ms && max_wall == effective_remote_wall {
+            // Both last and the (clamped) remote share max_wall: take the larger counter.
+            last.counter.max(remote_counter)
+        } else if max_wall == last.wall_ms {
+            last.counter
+        } else if max_wall == effective_remote_wall {
+            remote_counter
+        } else {
+            // Physical time leapt past both: fresh wall, counter starts at 0.
+            // We return early here rather than running through advance() to preserve the
+            // original semantics (counter = 0, not 1) for the physical-time-dominates case.
+            *last = Timestamp {
+                wall_ms: max_wall,
+                counter: 0,
+                node_id: self.node_id,
+            };
+            return;
+        };
+
+        let (new_wall, new_counter) = advance(max_wall, base_counter);
+        *last = Timestamp {
+            wall_ms: new_wall,
+            counter: new_counter,
+            node_id: self.node_id,
+        };
     }
 }
 
@@ -244,35 +308,22 @@ impl Clock for HlcClock {
             remote.wall_ms
         };
 
-        let max_wall = pt.max(last.wall_ms).max(effective_remote_wall);
+        self.advance_inner(&mut last, pt, effective_remote_wall, remote.counter);
+    }
 
-        // Pick the base counter from the dominant wall bucket, then advance one logical tick.
-        // advance() handles u32::MAX → (wall+1, 0) so the result can never wrap.
-        let base_counter = if max_wall == last.wall_ms && max_wall == effective_remote_wall {
-            // Both last and the (clamped) remote share max_wall: take the larger counter.
-            last.counter.max(remote.counter)
-        } else if max_wall == last.wall_ms {
-            last.counter
-        } else if max_wall == effective_remote_wall {
-            remote.counter
-        } else {
-            // Physical time leapt past both: fresh wall, counter starts at 0.
-            // We return early here rather than running through advance() to preserve the
-            // original semantics (counter = 0, not 1) for the physical-time-dominates case.
-            *last = Timestamp {
-                wall_ms: max_wall,
-                counter: 0,
-                node_id: self.node_id,
-            };
-            return;
-        };
-
-        let (new_wall, new_counter) = advance(max_wall, base_counter);
-        *last = Timestamp {
-            wall_ms: new_wall,
-            counter: new_counter,
-            node_id: self.node_id,
-        };
+    /// Advance the clock past a stamp this node itself authored (e.g. restored from persisted
+    /// state), without applying the far-future clamp used for remote peer stamps.
+    ///
+    /// The clamp guards against a hostile or buggy peer injecting an arbitrarily large wall
+    /// value; it must not fire on self-authored stamps. If the wall clock stepped backward by
+    /// more than [`MAX_CLOCK_DRIFT_MS`] across a restart (NTP step, VM resume), an honest
+    /// persisted stamp would exceed `phys_now + MAX_CLOCK_DRIFT_MS` and the clamped path would
+    /// fail to advance the clock past it, re-introducing the own-write-shadowing bug.
+    fn observe_trusted(&self, remote: Timestamp) {
+        let pt = phys_now_ms();
+        let mut last = self.last.lock();
+        // No clamp: pass the raw wall value directly.
+        self.advance_inner(&mut last, pt, remote.wall_ms, remote.counter);
     }
 }
 
@@ -487,6 +538,54 @@ mod tests {
         assert!(
             rolled.wall_ms() > pinned_wall,
             "wall_ms did not roll forward: {rolled:?}"
+        );
+    }
+
+    /// `observe_trusted` of a stamp far beyond `phys_now + MAX_CLOCK_DRIFT_MS` must advance the
+    /// clock all the way past that stamp (so the next `now()` is strictly greater than it), while
+    /// plain `observe` of the same stamp stays clamped and the next `now()` stays well below it.
+    ///
+    /// This pins the trusted/untrusted distinction: the trusted path is needed for persisted
+    /// stamps when the wall clock stepped backward by more than MAX_CLOCK_DRIFT_MS (NTP step,
+    /// VM resume). Without it, the clamped path would leave the clock below the persisted max,
+    /// and a fresh write would shadow an older persisted value — the own-write-shadowing bug.
+    #[test]
+    fn observe_trusted_bypasses_far_future_clamp() {
+        let pt = phys_now_ms();
+        // A stamp far beyond the cap — the exact scenario of a wall-clock backward step that
+        // makes an honest persisted stamp land outside phys_now + MAX_CLOCK_DRIFT_MS.
+        let far_future = Timestamp::new(pt + MAX_CLOCK_DRIFT_MS + 5_000_000, 3, 7);
+
+        // ---- trusted path: clock must chase the stamp ----
+        let trusted_clock = HlcClock::new(1);
+        trusted_clock.observe_trusted(far_future);
+        let after_trusted = trusted_clock.now();
+        assert!(
+            after_trusted > far_future,
+            "observe_trusted did not advance the clock past the far-future stamp: \
+             next now() {after_trusted:?} is not > {far_future:?}"
+        );
+
+        // ---- clamped path: clock must NOT chase the stamp ----
+        let clamped_clock = HlcClock::new(2);
+        clamped_clock.observe(far_future);
+        let after_clamped = clamped_clock.now();
+        // Re-read physical time for the cap bound: `observe`/`now` recompute the cap against a
+        // fresh phys_now, so basing the bound on the stale `pt` from the top of the test would
+        // flake if the wall clock advanced more than a few ms during execution. `cap_upper`
+        // re-reads now and adds slack for the +1 that `advance()` may contribute.
+        let cap_upper = phys_now_ms() + MAX_CLOCK_DRIFT_MS + 10;
+        assert!(
+            after_clamped.wall_ms() <= cap_upper,
+            "observe (clamped) let wall_ms escape the cap: {} > {}",
+            after_clamped.wall_ms(),
+            cap_upper
+        );
+        // Confirm the clamped result is below the far-future stamp (pins the distinction).
+        assert!(
+            after_clamped < far_future,
+            "clamped observe produced a stamp >= the far-future value: \
+             {after_clamped:?} should be < {far_future:?}"
         );
     }
 

--- a/src/reconcile_engine.rs
+++ b/src/reconcile_engine.rs
@@ -215,6 +215,10 @@ pub(crate) struct Inner<K, V: Projectable> {
     /// stub via [`new_with_clock`](ReconcileEngine::new_with_clock)). Shared across all clones so
     /// that every write and every received timestamp advances the same clock.
     clock: Arc<dyn Clock>,
+    /// `true` when the node id was generated at random (i.e. `Config::node_id` was `None`).
+    /// Exposed via [`node_id_is_random`](ReconcileEngine::node_id_is_random) so that the store
+    /// layer can warn operators when persistence is configured but the identity is ephemeral.
+    pub(crate) node_id_is_random: bool,
 }
 
 impl<K, V: Projectable> Clone for ReconcileEngine<K, V> {
@@ -270,19 +274,22 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
     pub async fn new(config: Config) -> Self {
         // Default adapter for the `Clock` port: the chrono-backed Hybrid Logical Clock. This is the
         // only place the engine names a concrete clock; everything else goes through `dyn Clock`.
+        let node_id_is_random = config.node_id.is_none();
         let node_id = config.node_id.unwrap_or_else(rand::random);
         let clock: Arc<dyn Clock> = Arc::new(HlcClock::new(node_id));
-        Self::build(config, clock).await
+        Self::build(config, clock, node_id_is_random).await
     }
 
     /// Construct an engine over an explicit [`Clock`] adapter. Test-only seam: a deterministic
     /// clock (`ManualClock`) makes HLC behaviour reproducible without real wall-clock time.
     #[cfg(test)]
     pub(crate) async fn new_with_clock(config: Config, clock: Arc<dyn Clock>) -> Self {
-        Self::build(config, clock).await
+        // A test-supplied clock implies a test-supplied (stable) identity; mark it as non-random
+        // so persistence tests do not trigger the operator warning.
+        Self::build(config, clock, false).await
     }
 
-    async fn build(config: Config, clock: Arc<dyn Clock>) -> Self {
+    async fn build(config: Config, clock: Arc<dyn Clock>, node_id_is_random: bool) -> Self {
         let socket = UdpSocket::bind(SocketAddr::new(config.listen_addr, config.port))
             .await
             .unwrap();
@@ -342,6 +349,7 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
                 members: Arc::new(RwLock::new(HashSet::new())),
                 tombstone_acks: Arc::new(RwLock::new(HashMap::new())),
                 clock,
+                node_id_is_random,
             }),
         }
     }
@@ -376,6 +384,19 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
     /// Mint a fresh Hybrid Logical Clock timestamp for a local write.
     pub fn clock_now(&self) -> Timestamp {
         self.clock.now()
+    }
+
+    /// Advance the clock past `stamp` using the trusted path — for stamps this node itself
+    /// authored (e.g. restored from its own persisted state). Unlike the remote-peer path,
+    /// this does not apply the far-future clamp, so the clock reliably chases its own output
+    /// even after a backward wall-clock step (NTP correction, VM resume).
+    pub(crate) fn clock_observe_trusted(&self, stamp: Timestamp) {
+        self.clock.observe_trusted(stamp);
+    }
+
+    /// Returns `true` when the node id was generated at random (`Config::node_id` was `None`).
+    pub(crate) fn node_id_is_random(&self) -> bool {
+        self.node_id_is_random
     }
 
     /// (runtime) Replace the declared networks wholesale and re-derive the local network.

--- a/src/reconcile_store.rs
+++ b/src/reconcile_store.rs
@@ -123,6 +123,28 @@ impl<K: Key, V: Value> ReconcileStore<K, V> {
         svc
     }
 
+    /// Test-only constructor that accepts an explicit [`Clock`] adapter.
+    ///
+    /// Injects a deterministic clock (e.g. `ManualClock`) so that persistence and HLC-ordering
+    /// tests are fully reproducible without relying on real wall-clock time.
+    #[cfg(test)]
+    pub(crate) async fn new_with_clock(
+        config: Config,
+        clock: Arc<dyn crate::clock::Clock>,
+    ) -> Self {
+        let svc = ReconcileStore {
+            engine: ReconcileEngine::<K, (Timestamp, Option<V>)>::new_with_clock(config, clock)
+                .await,
+            tombstones: TimeoutWheel::new(),
+            persistence: Arc::new(InMemoryPersistence::default()),
+            discovery: None,
+            discovery_interval: DEFAULT_DISCOVERY_INTERVAL,
+            discovery_miss_threshold: DEFAULT_DISCOVERY_MISS_THRESHOLD,
+        };
+        svc.add_pre_insert(|_, _| {});
+        svc
+    }
+
     /// Plug in a durable persistence backend, **loading any previously saved state first**.
     ///
     /// Every store always owns a backend; by default that is the non-durable
@@ -140,9 +162,47 @@ impl<K: Key, V: Value> ReconcileStore<K, V> {
     /// Panics if the backend fails to load (e.g. a corrupt snapshot file): recovering from a
     /// damaged durable state is a deliberate, explicit decision rather than a silent fresh start.
     pub fn with_persistence(mut self, backend: Arc<dyn Persistence<K, V>>) -> Self {
+        // Warn operators when a durable backend is used with a randomly-generated node id.
+        // A random id changes on every restart, which silently alters this node's LWW
+        // conflict-resolution identity: a write made before the restart by "node X" will now
+        // race against a write made after the restart by "node Y" (a different random id), so
+        // the deterministic total order that guarantees SEC is only maintained within a single
+        // process lifetime. Stability across restarts requires an explicit id set via
+        // Config::with_node_id. Note: persisting node_id would require a format change and is
+        // deferred to a later migration.
+        if self.engine.node_id_is_random() {
+            warn!(
+                "persistence is enabled but no stable node_id was configured \
+                 (Config::with_node_id was not called). The node id is randomly generated on \
+                 every start, so this node's LWW conflict-resolution identity changes across \
+                 restarts. Conflicts between a pre-restart write and a post-restart write from \
+                 the same node are resolved non-deterministically. Set a stable, unique \
+                 Config::with_node_id to preserve consistent LWW ordering across restarts."
+            );
+        }
         if let Some(state) = backend.load().expect("failed to load persisted state") {
             *self.engine.members.write() = state.members;
             *self.engine.tombstone_acks.write() = state.tombstone_acks;
+            // Advance the clock past every persisted timestamp so that the first post-restart
+            // write is strictly ordered after all pre-restart writes. Without this, the HLC
+            // starts cold at (wall_ms:0, counter:0); if the wall clock regressed across the
+            // restart (NTP step, VM resume — exactly the hazard HLC defends against), the first
+            // post-restart now() could be ≤ the max persisted stamp, causing a fresh write to
+            // silently lose last-write-wins to its own older persisted value.
+            //
+            // We use the trusted path (observe_trusted / clock_observe_trusted), which skips the
+            // far-future clamp that guards against hostile remote peers. Persisted stamps are
+            // self-authored: this node wrote them, so there is no remote adversary to protect
+            // against here. More importantly, after a wall-clock step BACKWARD by more than
+            // MAX_CLOCK_DRIFT_MS (NTP correction, VM resume — exactly the scenario we are
+            // defending against), an honest persisted stamp will exceed phys_now + MAX_CLOCK_DRIFT_MS
+            // and the clamped path would refuse to chase it, re-introducing the bug. The
+            // far-future clamp protects the clock during live gossip; this restore path is not
+            // live gossip. A poisoned stamp that made it into the snapshot is accepted here and
+            // consumed where stored stamps are used (e.g. tombstone expiry arithmetic).
+            for (_, (stamp, _)) in &state.entries {
+                self.engine.clock_observe_trusted(*stamp);
+            }
             // Replay through the wrapped pre-insert hook so the tombstone wheel is rebuilt with the
             // original deletion timestamps (do NOT route through the public insert helpers, which
             // would overwrite timestamps with `Utc::now()`).
@@ -894,6 +954,7 @@ mod reconcile_store_tests {
     use std::sync::Arc;
     use std::time::Duration;
 
+    use crate::persistence::Persistence;
     use crate::reconcile_engine::version_hash;
     use crate::{
         reconcile_store::{Config, MAX_NETS},
@@ -1200,5 +1261,122 @@ mod reconcile_store_tests {
         );
 
         handle.abort();
+    }
+
+    // ----- Observe-on-load (HLC monotonicity across restarts) tests -----
+
+    /// After loading persisted state, the clock must be advanced past the maximum persisted
+    /// timestamp so that the first post-restart write is strictly ordered after all pre-restart
+    /// writes.
+    ///
+    /// This test FAILS without the observe-on-load fix and PASSES with it.
+    ///
+    /// Technique: use a `ManualClock` whose counter starts at zero and then load a
+    /// `PersistedState` whose max stamp is in the future relative to that clock (but within
+    /// MAX_CLOCK_DRIFT_MS, so the observe clamp does not interfere). After loading, the first
+    /// `insert` must mint a timestamp strictly greater than the persisted max.
+    #[tokio::test]
+    async fn restart_clock_advanced_past_persisted_max_stamp() {
+        use crate::clock::ManualClock;
+        use crate::persistence::{InMemoryPersistence, PersistedState};
+
+        // Build a ManualClock starting at (wall_ms=0, counter=0).
+        let clock = Arc::new(ManualClock::new(1));
+
+        // Craft a PersistedState whose only entry carries a stamp well ahead of the clock.
+        // wall_ms=100 is in the "future" relative to the ManualClock's (0, 0) starting state.
+        let persisted_stamp = crate::clock::Timestamp::new(100, 0, 1);
+        let backend = Arc::new(InMemoryPersistence::<i32, i32>::new());
+        backend
+            .save(&PersistedState {
+                entries: vec![(42, (persisted_stamp, Some(999)))],
+                members: Default::default(),
+                tombstone_acks: Default::default(),
+            })
+            .unwrap();
+
+        // Create a store with the ManualClock and load the persisted state.
+        let store =
+            ReconcileStore::<i32, i32>::new_with_clock(ephemeral_config().with_node_id(1), clock)
+                .await
+                .with_persistence(backend);
+
+        // Insert a new value; the minted timestamp must be strictly greater than persisted_stamp.
+        store.insert(99, 1);
+
+        // Read the stored timestamp for key 99 via the internal map.
+        let minted_stamp = store
+            .engine
+            .map
+            .read()
+            .get(&99)
+            .map(|(ts, _)| *ts)
+            .expect("key 99 must be present after insert");
+
+        assert!(
+            minted_stamp > persisted_stamp,
+            "post-restart write timestamp {minted_stamp:?} is not strictly greater than the \
+             persisted max {persisted_stamp:?}; the clock was not advanced on load"
+        );
+    }
+
+    /// Variant of the monotonicity test where the maximum persisted stamp is on a **tombstone**.
+    ///
+    /// The critical property: a post-restart `insert` on the same key must mint a timestamp
+    /// strictly greater than the tombstone's stamp. If it does not, an anti-entropy round with a
+    /// peer that still holds the tombstone would re-apply the tombstone via LWW (tombstone stamp
+    /// > fresh insert's stamp), silently undoing the insert — the classic tombstone-resurrection
+    /// hazard.
+    ///
+    /// This test FAILS without the observe-on-load fix and PASSES with it.
+    #[tokio::test]
+    async fn restart_insert_beats_persisted_tombstone() {
+        use crate::clock::ManualClock;
+        use crate::persistence::{InMemoryPersistence, PersistedState};
+
+        // ManualClock starting at (wall_ms=0, counter=0).
+        let clock = Arc::new(ManualClock::new(2));
+
+        // A tombstone with a stamp in the "future" relative to the cold clock.
+        let tombstone_stamp = crate::clock::Timestamp::new(200, 0, 2);
+        let backend = Arc::new(InMemoryPersistence::<i32, i32>::new());
+        backend
+            .save(&PersistedState {
+                entries: vec![(7, (tombstone_stamp, None))], // None = tombstone
+                members: Default::default(),
+                tombstone_acks: Default::default(),
+            })
+            .unwrap();
+
+        let store =
+            ReconcileStore::<i32, i32>::new_with_clock(ephemeral_config().with_node_id(2), clock)
+                .await
+                .with_persistence(backend);
+
+        // The tombstone was recovered (key 7 is absent from the live view).
+        assert!(
+            store.get(&7).is_none(),
+            "tombstone was not recovered: expected key 7 to be absent after loading"
+        );
+
+        // Insert a fresh value for key 7 and inspect the minted timestamp.
+        store.insert(7, 42);
+        let minted_stamp = store
+            .engine
+            .map
+            .read()
+            .get(&7)
+            .map(|(ts, _)| *ts)
+            .expect("key 7 must be present after insert");
+
+        // The minted stamp must be strictly greater than the tombstone's stamp. Without this,
+        // a peer that still holds the tombstone would win the LWW merge during anti-entropy
+        // and silently re-apply the tombstone, undoing the fresh insert.
+        assert!(
+            minted_stamp > tombstone_stamp,
+            "post-restart insert timestamp {minted_stamp:?} is not strictly greater than the \
+             persisted tombstone stamp {tombstone_stamp:?}; the clock was not advanced on load, \
+             so a peer reconciling with this node could resurrect the tombstone via LWW"
+        );
     }
 }


### PR DESCRIPTION
**Problem.** A restarted durable node started its HLC cold: `with_persistence` replayed entries without observing their timestamps. After a backward wall-clock step across the restart, the first post-restart write could carry a stamp at or below the node's own persisted maximum — under strict-`>` LWW the fresh write then **lost to its own older value** (silently dropped update), and the symmetric case could resurrect the node's own tombstones.

**Fix.** `with_persistence` advances the clock past every persisted stamp (live entries *and* tombstones — the only persisted stamp carriers, verified exhaustively) before replaying state. Restoration goes through a new `Clock::observe_trusted` provided method — defaulting to `observe`, overridden clamp-free in `HlcClock` — because persisted stamps are the node's own past output, not hostile gossip; the inbound network path keeps the clamped `observe` (verified: the trusted path's only caller is the restore loop). Construction also warns when a durable store runs with a randomly generated `node_id` (LWW identity changes each restart until pinned via `Config::with_node_id`).

**Review provenance.** Two adversarial rounds. The **first version was REJECTED**: it routed restored stamps through the clamped `observe`, and the reviewer proved with a standalone repro that a >1 h backward clock step re-created the exact shadowing bug. The revision implements the reviewer's prescription; re-review approved (with a flake-proofing fix to the new clock test). Tests pin both halves: `observe_trusted` bypasses the clamp; `observe` keeps it; restore-monotonicity tests for entry and tombstone variants fail without the fix.

**Deferred (recorded on #195):** persisting `node_id` itself requires the snapshot-format migration (#143/#204 lineage); a poisoned stamp already *inside* the local snapshot is restored clamp-free (bounded by local snapshot-write access) — same class as the wheel-instant residual, scheduled for the Phase-1 hygiene PR.

Closes #195.

**Stack 4/6** — base: `claude/p0-3-timeout-wheel`. Merge after stack 3 (builds on the clock changes in stack 2).

https://claude.ai/code/session_01BaajsC6gEk1v7Y55dA5cPG

---
_Generated by [Claude Code](https://claude.ai/code/session_01BaajsC6gEk1v7Y55dA5cPG)_