### PR TITLE
fix(api): fallible constructors; network sends never panic the run loops

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ the cluster as an empty replica.
 In code, this would look like this:
 
 ```rust
-let mut store = ReconcileStore::new(Config::default()).await;
+let mut store = ReconcileStore::new(Config::default()).await.unwrap();
 tokio::spawn(store.clone().run());
 // use the reconciliation store as a key-value store in the API
 ```
@@ -94,7 +94,7 @@ To close this vector, provide a shared 32-byte cluster secret on **every** node:
 ```rust
 let key: [u8; 32] = /* same secret on all nodes, e.g. loaded from your secret manager */;
 let config = Config::default().with_cluster_key(key);
-let store = ReconcileStore::new(config).await;
+let store = ReconcileStore::new(config).await.unwrap();
 ```
 
 With a key set, every outgoing datagram is framed with a per-datagram keyed MAC over its payload,
@@ -157,6 +157,7 @@ use reconcile::{reconcile_store::Config, FileSnapshot, ReconcileStore};
 
 let store = ReconcileStore::new(Config::default())
     .await
+    .unwrap()
     .with_persistence(Arc::new(FileSnapshot::new("/var/lib/myapp/reconcile.snapshot")));
 tokio::spawn(store.clone().run()); // periodically snapshots in the background
 ```
@@ -244,6 +245,7 @@ use reconcile::{reconcile_store::Config, ReconcileMirror};
 // Mirrors a dated cluster reachable at `dated_addr` on the same port.
 let mirror = ReconcileMirror::<String, String>::new(Config::default())
     .await
+    .unwrap()
     .with_seed(dated_addr);
 tokio::spawn(mirror.clone().run());
 // `mirror.get(&key)` reflects the cluster's current values; deletions appear as `None`.
@@ -268,7 +270,7 @@ let config = Config::default()
     .with_net("10.1.0.0/16".parse().unwrap())  // this node's network (contains listen_addr)
     .with_net("10.2.0.0/16".parse().unwrap())  // another location
     .with_net("10.3.0.0/16".parse().unwrap()); // and another
-let store = ReconcileStore::<String, String>::new(config).await;
+let store = ReconcileStore::<String, String>::new(config).await.unwrap();
 ```
 
 This node's **local** network is whichever declared net contains its `listen_addr`; all others are
@@ -337,6 +339,7 @@ let config = Config::default()
 // Note: no `with_net` — discovery is purely DNS-driven in Kubernetes.
 let store = ReconcileStore::<String, String>::new(config)
     .await
+    .unwrap()
     .with_dns_discovery("reconcile-headless.default.svc.cluster.local", 8080);
 store.run().await;
 ```

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -323,9 +323,15 @@ mod imp {
             group.bench_with_input(BenchmarkId::from_parameter(size), &size, |b, &size| {
                 rt.block_on(async {
                     // start reconciliation stores
-                    let store1 = ReconcileStore::new(cfg1).await.with_seed(addr2);
+                    let store1 = ReconcileStore::new(cfg1)
+                        .await
+                        .expect("bind failed")
+                        .with_seed(addr2);
                     store1.insert_bulk(&key_values[..size]);
-                    let store2 = ReconcileStore::new(cfg2).await.with_seed(addr1);
+                    let store2 = ReconcileStore::new(cfg2)
+                        .await
+                        .expect("bind failed")
+                        .with_seed(addr1);
                     store2.insert_bulk(&key_values[..size]);
                     let task1 = tokio::spawn(store1.clone().run());
                     let task2 = tokio::spawn(store2.clone().run());
@@ -384,9 +390,15 @@ mod imp {
             group.bench_with_input(BenchmarkId::from_parameter(size), &size, |b, &size| {
                 rt.block_on(async {
                     // start reconciliation services
-                    let store1 = ReconcileStore::new(cfg1).await.with_seed(addr2);
+                    let store1 = ReconcileStore::new(cfg1)
+                        .await
+                        .expect("bind failed")
+                        .with_seed(addr2);
                     store1.insert_bulk(&key_values[..size]);
-                    let store2 = ReconcileStore::new(cfg2).await.with_seed(addr1);
+                    let store2 = ReconcileStore::new(cfg2)
+                        .await
+                        .expect("bind failed")
+                        .with_seed(addr1);
                     store2.insert_bulk(&key_values[..size]);
                     let task1 = tokio::spawn(store1.clone().run());
                     let task2 = tokio::spawn(store2.clone().run());

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -47,7 +47,9 @@ async fn main() {
         key_values.push((key, value));
     }
     let key_values = key_values.as_slice();
-    let mut service = ReconcileStore::new(config).await;
+    let mut service = ReconcileStore::new(config)
+        .await
+        .expect("failed to bind UDP socket");
     service.insert_bulk(key_values);
     info!("Global fingerprint is {}", service.fingerprint(..));
 

--- a/examples/k8s/main.rs
+++ b/examples/k8s/main.rs
@@ -132,6 +132,7 @@ async fn main() {
 
     let store = ReconcileStore::<String, String>::new(config)
         .await
+        .expect("failed to bind UDP socket")
         .with_dns_discovery(dns_name, port)
         .with_discovery_interval(discovery_interval)
         .with_discovery_miss_threshold(miss_threshold);

--- a/src/mirror.rs
+++ b/src/mirror.rs
@@ -47,6 +47,7 @@
 use std::collections::HashMap;
 use std::fmt::Debug;
 use std::hash::Hash;
+use std::io;
 use std::net::{IpAddr, SocketAddr};
 use std::ops::RangeBounds;
 use std::sync::Arc;
@@ -133,14 +134,15 @@ impl<K: Key, V: Clone + Debug + DeserializeOwned + Hash + Send + Serialize + Syn
     /// [`with_cluster_key`](Config::with_cluster_key): to mirror an authenticated cluster it must
     /// share the cluster key. The Hybrid-Logical-Clock `node_id` is ignored (a mirror mints no
     /// timestamps).
-    pub async fn new(config: Config) -> Self {
-        let socket = UdpSocket::bind(SocketAddr::new(config.listen_addr, config.port))
-            .await
-            .unwrap();
-        debug!(
-            "ReconcileMirror listening on: {}",
-            socket.local_addr().unwrap()
-        );
+    ///
+    /// # Errors
+    ///
+    /// Returns an `io::Error` if the UDP socket cannot be bound to
+    /// `(config.listen_addr, config.port)` — for example, because the port is already in use or
+    /// the address is not available on this host.
+    pub async fn new(config: Config) -> io::Result<Self> {
+        let socket = UdpSocket::bind(SocketAddr::new(config.listen_addr, config.port)).await?;
+        debug!("ReconcileMirror listening on: {}", socket.local_addr()?);
         let authenticator = auth::Authenticator::new(config.cluster_key, config.encrypt);
         if !authenticator.is_enabled() {
             warn!(
@@ -154,7 +156,7 @@ impl<K: Key, V: Clone + Debug + DeserializeOwned + Hash + Send + Serialize + Syn
         let net = net_of(&nets, config.listen_addr)
             .or_else(|| nets.first().copied())
             .unwrap_or_else(|| "127.0.0.1/8".parse().unwrap());
-        ReconcileMirror {
+        Ok(ReconcileMirror {
             tree: Arc::new(RwLock::new(HRTree::<K, ValueOnly<V>>::new())),
             port: config.port,
             socket: Arc::new(socket),
@@ -163,7 +165,7 @@ impl<K: Key, V: Clone + Debug + DeserializeOwned + Hash + Send + Serialize + Syn
             peers: Arc::new(RwLock::new(HashMap::new())),
             authenticator,
             on_update: Arc::new(RwLock::new(Box::new(|_, _| {}))),
-        }
+        })
     }
 
     /// Provide the address of a known dated peer, reducing the time to first sync.
@@ -260,14 +262,18 @@ impl<K: Key, V: Clone + Debug + DeserializeOwned + Hash + Send + Serialize + Syn
         peers.push(addr);
         for peer in peers {
             trace!("mirror start_diff {} bytes to {peer}", send_buf.len());
-            send_to_retry(
+            if let Err(err) = send_to_retry(
                 &self.socket,
                 &self.authenticator,
                 send_buf,
                 (peer, self.port),
             )
             .await
-            .unwrap();
+            {
+                warn!(
+                    "mirror failed to send reconciliation initiation to {peer}: {err}; continuing"
+                );
+            }
         }
     }
 
@@ -395,7 +401,9 @@ mod tests {
     /// `get` returns the live value, and absent keys are `None`.
     #[tokio::test]
     async fn get_returns_integrated_value() {
-        let mirror = ReconcileMirror::<i32, String>::new(ephemeral_config()).await;
+        let mirror = ReconcileMirror::<i32, String>::new(ephemeral_config())
+            .await
+            .expect("bind failed");
         assert!(mirror.get(&1).is_none());
         mirror.integrate(vec![(1, ValueOnly(Some("hello".to_string())))]);
         assert_eq!(mirror.get(&1).as_deref(), Some(&"hello".to_string()));
@@ -406,7 +414,9 @@ mod tests {
     /// A mirrored tombstone (`ValueOnly(None)`) hides the value but is still a stored entry.
     #[tokio::test]
     async fn mirrors_tombstones() {
-        let mirror = ReconcileMirror::<i32, String>::new(ephemeral_config()).await;
+        let mirror = ReconcileMirror::<i32, String>::new(ephemeral_config())
+            .await
+            .expect("bind failed");
         mirror.integrate(vec![(1, ValueOnly(Some("v".to_string())))]);
         assert_eq!(mirror.get(&1).as_deref(), Some(&"v".to_string()));
 
@@ -422,7 +432,9 @@ mod tests {
     #[tokio::test]
     async fn on_update_hook_fires() {
         use std::sync::atomic::{AtomicUsize, Ordering};
-        let mirror = ReconcileMirror::<i32, i32>::new(ephemeral_config()).await;
+        let mirror = ReconcileMirror::<i32, i32>::new(ephemeral_config())
+            .await
+            .expect("bind failed");
         let count = Arc::new(AtomicUsize::new(0));
         let count2 = count.clone();
         mirror.add_on_update(move |_, _| {
@@ -436,7 +448,9 @@ mod tests {
     /// content — i.e. timestamps genuinely play no part in the hash.
     #[tokio::test]
     async fn value_fingerprint_is_timestamp_independent() {
-        let mirror = ReconcileMirror::<i32, String>::new(ephemeral_config()).await;
+        let mirror = ReconcileMirror::<i32, String>::new(ephemeral_config())
+            .await
+            .expect("bind failed");
         mirror.integrate(vec![
             (1, ValueOnly(Some("a".to_string()))),
             (2, ValueOnly(None)),

--- a/src/reconcile_engine.rs
+++ b/src/reconcile_engine.rs
@@ -13,6 +13,7 @@ use std::collections::hash_map::DefaultHasher;
 use std::collections::{HashMap, HashSet};
 use std::fmt::Debug;
 use std::hash::{Hash, Hasher};
+use std::io;
 use std::net::{IpAddr, SocketAddr};
 use std::ops::RangeBounds;
 use std::sync::atomic::{AtomicU32, AtomicUsize, Ordering};
@@ -271,7 +272,14 @@ pub(crate) enum Message<K: Serialize, V: Serialize, P: Serialize> {
 impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestamped>
     ReconcileEngine<K, V>
 {
-    pub async fn new(config: Config) -> Self {
+    /// Create a new engine, binding the gossip UDP socket.
+    ///
+    /// # Errors
+    ///
+    /// Returns an `io::Error` if the UDP socket cannot be bound to
+    /// `(config.listen_addr, config.port)` — for example, because the port is already in use or
+    /// the address is not available on this host.
+    pub async fn new(config: Config) -> io::Result<Self> {
         // Default adapter for the `Clock` port: the chrono-backed Hybrid Logical Clock. This is the
         // only place the engine names a concrete clock; everything else goes through `dyn Clock`.
         let node_id_is_random = config.node_id.is_none();
@@ -283,17 +291,19 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
     /// Construct an engine over an explicit [`Clock`] adapter. Test-only seam: a deterministic
     /// clock (`ManualClock`) makes HLC behaviour reproducible without real wall-clock time.
     #[cfg(test)]
-    pub(crate) async fn new_with_clock(config: Config, clock: Arc<dyn Clock>) -> Self {
+    pub(crate) async fn new_with_clock(config: Config, clock: Arc<dyn Clock>) -> io::Result<Self> {
         // A test-supplied clock implies a test-supplied (stable) identity; mark it as non-random
         // so persistence tests do not trigger the operator warning.
         Self::build(config, clock, false).await
     }
 
-    async fn build(config: Config, clock: Arc<dyn Clock>, node_id_is_random: bool) -> Self {
-        let socket = UdpSocket::bind(SocketAddr::new(config.listen_addr, config.port))
-            .await
-            .unwrap();
-        info!("Listening on: {}", socket.local_addr().unwrap());
+    async fn build(
+        config: Config,
+        clock: Arc<dyn Clock>,
+        node_id_is_random: bool,
+    ) -> io::Result<Self> {
+        let socket = UdpSocket::bind(SocketAddr::new(config.listen_addr, config.port)).await?;
+        info!("Listening on: {}", socket.local_addr()?);
         // Size the kernel send/receive buffers before any traffic flows.
         set_socket_buffers(&socket, &config);
         let authenticator = auth::Authenticator::new(config.cluster_key, config.encrypt);
@@ -326,7 +336,7 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
         let rng = Arc::new(RwLock::new(StdRng::from_entropy()));
         let probe: Arc<dyn Discovery> =
             Arc::new(RandomProbe::new(Arc::clone(&nets), Arc::clone(&rng)));
-        ReconcileEngine {
+        Ok(ReconcileEngine {
             inner: Arc::new(Inner {
                 map: Arc::new(RwLock::new(map)),
                 projection: Arc::new(RwLock::new(projection)),
@@ -351,7 +361,7 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
                 clock,
                 node_id_is_random,
             }),
-        }
+        })
     }
 
     pub fn fingerprint<R: RangeBounds<K>>(&self, range: R) -> Fingerprint {
@@ -595,6 +605,10 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
         self.broadcast(messages);
     }
 
+    /// Drive the gossip and reconciliation loops forever.
+    ///
+    /// This method does not return and cannot fail: network send errors are logged and
+    /// counted, never fatal, so a vanished or unreachable peer cannot stop the loops.
     #[instrument(name = "reconcile.run", skip_all, fields(port = self.port))]
     pub async fn run(self) {
         // extra byte that easily detect when the buffer is too small
@@ -739,14 +753,16 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
         // initiate the reconciliation protocol with the selected peers and discovery probes
         for peer in targets {
             trace!("start_diff {} bytes to {peer}", send_buf.len());
-            send_to_retry(
+            if let Err(err) = send_to_retry(
                 &self.socket,
                 &self.authenticator,
                 send_buf,
                 (peer, self.port),
             )
             .await
-            .unwrap();
+            {
+                warn!("failed to send reconciliation initiation to {peer}: {err}; continuing");
+            }
         }
         observability::record_round_duration(timer);
     }
@@ -1144,20 +1160,24 @@ pub(crate) async fn send_messages_paced<K: Serialize, V: Serialize, P: Serialize
             .expect("serializing a protocol Message into an in-memory buffer cannot fail");
         if send_buf.len() > max_payload {
             trace!("sending {} bytes to {peer}", last_size);
-            send_to_retry(&socket, authenticator, &send_buf[..last_size], peer)
-                .await
-                .unwrap();
-            trace!("sent {} bytes to {peer}", last_size);
+            if let Err(err) =
+                send_to_retry(&socket, authenticator, &send_buf[..last_size], peer).await
+            {
+                warn!("failed to send datagram to {peer}: {err}; continuing");
+            } else {
+                trace!("sent {} bytes to {peer}", last_size);
+            }
             send_buf.drain(..last_size);
             sent_bytes += last_size;
             pace(rate, start, sent_bytes).await;
         }
     }
     trace!("sending last {} bytes to {peer}", send_buf.len());
-    send_to_retry(&socket, authenticator, send_buf, peer)
-        .await
-        .unwrap();
-    trace!("sent last {} bytes to {peer}", send_buf.len());
+    if let Err(err) = send_to_retry(&socket, authenticator, send_buf, peer).await {
+        warn!("failed to send final datagram to {peer}: {err}; continuing");
+    } else {
+        trace!("sent last {} bytes to {peer}", send_buf.len());
+    }
 }
 
 /// Sleep, if necessary, so that having sent `sent_bytes` since `start` does not exceed `rate`
@@ -1214,7 +1234,7 @@ mod deadlock_regressions {
             .with_port(8080)
             .with_listen_addr("127.0.0.44".parse().unwrap());
         // let tree = HRTree::from_iter(vec![(1, 10), (2, 20)]);
-        let svc = ReconcileStore::new(config).await;
+        let svc = ReconcileStore::new(config).await.expect("bind failed");
         svc.insert_bulk(&[(1, 10_u8)]);
 
         let flag = Arc::new(AtomicBool::new(false));
@@ -1276,7 +1296,9 @@ mod deadlock_regressions {
                 let config = Config::default()
                     .with_port(8083)
                     .with_listen_addr("127.0.0.50".parse().unwrap());
-                let engine = ReconcileEngine::<i32, (Timestamp, Option<u8>)>::new(config).await;
+                let engine = ReconcileEngine::<i32, (Timestamp, Option<u8>)>::new(config)
+                    .await
+                    .expect("bind failed");
 
                 // The same re-entrant hook as the direct-path test, registered on the engine whose
                 // map `handle_messages` writes to: it calls back into `just_insert` on that engine.
@@ -1369,7 +1391,9 @@ mod auth_attack {
             .with_port(port)
             .with_listen_addr(victim_addr.parse().unwrap())
             .with_cluster_key(key);
-        let store = ReconcileStore::<i32, String>::new(config).await;
+        let store = ReconcileStore::<i32, String>::new(config)
+            .await
+            .expect("bind failed");
         store.just_insert(0, "legit".to_string());
         let task = tokio::spawn(store.clone().run());
 
@@ -1409,7 +1433,7 @@ mod causal_stability {
         let config = Config::default()
             .with_port(8080)
             .with_listen_addr(addr.parse().unwrap());
-        ReconcileEngine::new(config).await
+        ReconcileEngine::new(config).await.expect("bind failed")
     }
 
     #[tokio::test]
@@ -1501,7 +1525,9 @@ mod clock_port {
             .with_listen_addr("127.0.0.70".parse().unwrap());
         let clock = Arc::new(ManualClock::new(42));
         let eng: ReconcileEngine<i32, (Timestamp, Option<i32>)> =
-            ReconcileEngine::new_with_clock(config, clock).await;
+            ReconcileEngine::new_with_clock(config, clock)
+                .await
+                .expect("bind failed");
 
         assert_eq!(eng.clock_now(), Timestamp::new(0, 1, 42));
         assert_eq!(eng.clock_now(), Timestamp::new(0, 2, 42));
@@ -1585,7 +1611,9 @@ mod socket_buffers {
     type Tombstoned = (Timestamp, Option<i32>);
 
     async fn engine(addr: &str, config: Config) -> ReconcileEngine<i32, Tombstoned> {
-        ReconcileEngine::new(config.with_listen_addr(addr.parse().unwrap())).await
+        ReconcileEngine::new(config.with_listen_addr(addr.parse().unwrap()))
+            .await
+            .expect("bind failed")
     }
 
     /// The receive-buffer knob must actually size the gossip socket. Asserting an

--- a/src/reconcile_store.rs
+++ b/src/reconcile_store.rs
@@ -11,6 +11,7 @@
 
 use std::collections::{HashMap, HashSet};
 use std::hash::Hash;
+use std::io;
 use std::net::IpAddr;
 use std::ops::RangeBounds;
 use std::sync::Arc;
@@ -109,10 +110,16 @@ where
 }
 
 impl<K: Key, V: Value> ReconcileStore<K, V> {
-    /// Create a new `ReconcileStore`, set up network and tombstones.
-    pub async fn new(config: Config) -> Self {
+    /// Create a new `ReconcileStore`, binding the gossip UDP socket and setting up tombstone tracking.
+    ///
+    /// # Errors
+    ///
+    /// Returns an `io::Error` if the UDP socket cannot be bound to
+    /// `(config.listen_addr, config.port)` — for example, because the port is already in use or
+    /// the address is not available on this host.
+    pub async fn new(config: Config) -> io::Result<Self> {
         let svc = ReconcileStore {
-            engine: ReconcileEngine::<K, (Timestamp, Option<V>)>::new(config).await,
+            engine: ReconcileEngine::<K, (Timestamp, Option<V>)>::new(config).await?,
             tombstones: TimeoutWheel::new(),
             persistence: Arc::new(InMemoryPersistence::default()),
             discovery: None,
@@ -120,7 +127,7 @@ impl<K: Key, V: Value> ReconcileStore<K, V> {
             discovery_miss_threshold: DEFAULT_DISCOVERY_MISS_THRESHOLD,
         };
         svc.add_pre_insert(|_, _| {});
-        svc
+        Ok(svc)
     }
 
     /// Test-only constructor that accepts an explicit [`Clock`] adapter.
@@ -131,10 +138,10 @@ impl<K: Key, V: Value> ReconcileStore<K, V> {
     pub(crate) async fn new_with_clock(
         config: Config,
         clock: Arc<dyn crate::clock::Clock>,
-    ) -> Self {
+    ) -> io::Result<Self> {
         let svc = ReconcileStore {
             engine: ReconcileEngine::<K, (Timestamp, Option<V>)>::new_with_clock(config, clock)
-                .await,
+                .await?,
             tombstones: TimeoutWheel::new(),
             persistence: Arc::new(InMemoryPersistence::default()),
             discovery: None,
@@ -142,7 +149,7 @@ impl<K: Key, V: Value> ReconcileStore<K, V> {
             discovery_miss_threshold: DEFAULT_DISCOVERY_MISS_THRESHOLD,
         };
         svc.add_pre_insert(|_, _| {});
-        svc
+        Ok(svc)
     }
 
     /// Plug in a durable persistence backend, **loading any previously saved state first**.
@@ -627,6 +634,10 @@ impl<K: Key, V: Value> ReconcileStore<K, V> {
         }
     }
 
+    /// Drive the gossip and reconciliation loops forever.
+    ///
+    /// This method does not return and cannot fail: network send errors are logged and
+    /// counted, never fatal, so a vanished or unreachable peer cannot stop the loops.
     #[instrument(name = "reconcile.store", skip_all)]
     pub async fn run(self) {
         info!("reconcile store starting");
@@ -991,6 +1002,7 @@ mod reconcile_store_tests {
             .with_net("127.0.0.45/32".parse().unwrap());
         let store = ReconcileStore::<i32, i32>::new(config)
             .await
+            .expect("bind failed")
             .with_tombstone_timeout(Duration::from_millis(1));
 
         // This test exercises the tombstone TimeoutWheel directly; it deliberately does *not*
@@ -1015,6 +1027,7 @@ mod reconcile_store_tests {
 
         let store = ReconcileStore::<i32, i32>::new(ephemeral_config())
             .await
+            .expect("bind failed")
             .with_persistence(Arc::new(FileSnapshot::new(&path)));
         store.insert(1, 11); // live value
         store.insert(2, 22);
@@ -1025,6 +1038,7 @@ mod reconcile_store_tests {
         // A brand-new store recovers the previous state from the same file.
         let restarted = ReconcileStore::<i32, i32>::new(ephemeral_config())
             .await
+            .expect("bind failed")
             .with_persistence(Arc::new(FileSnapshot::new(&path)));
         assert_eq!(restarted.get(&1).as_deref(), Some(&11));
         assert!(restarted.get(&2).is_none(), "tombstone was not recovered");
@@ -1047,6 +1061,7 @@ mod reconcile_store_tests {
 
         let store = ReconcileStore::<i32, i32>::new(ephemeral_config())
             .await
+            .expect("bind failed")
             .with_persistence(Arc::new(FileSnapshot::new(&path)));
         store.engine.members.write().insert(peer);
         store.insert(5, 55);
@@ -1062,6 +1077,7 @@ mod reconcile_store_tests {
 
         let restarted = ReconcileStore::<i32, i32>::new(ephemeral_config())
             .await
+            .expect("bind failed")
             .with_persistence(Arc::new(FileSnapshot::new(&path)));
         assert!(
             restarted.engine.members.read().contains(&peer),
@@ -1091,6 +1107,7 @@ mod reconcile_store_tests {
 
         let store = ReconcileStore::<i32, i32>::new(ephemeral_config())
             .await
+            .expect("bind failed")
             .with_persistence(Arc::new(FileSnapshot::new(&path)));
         store.engine.members.write().insert(peer);
         store.insert(1, 11);
@@ -1105,7 +1122,9 @@ mod reconcile_store_tests {
 
         // Sanity check the hazard: a *fresh* store (no recovered membership) would consider the
         // same tombstone stable and collect it.
-        let fresh = ReconcileStore::<i32, i32>::new(ephemeral_config()).await;
+        let fresh = ReconcileStore::<i32, i32>::new(ephemeral_config())
+            .await
+            .expect("bind failed");
         fresh.insert(1, 11);
         fresh.remove(&1);
         let fresh_version = fresh.engine.map.read().get(&1).map(version_hash).unwrap();
@@ -1117,6 +1136,7 @@ mod reconcile_store_tests {
         // The recovered store keeps the tombstone gated, preventing resurrection.
         let restarted = ReconcileStore::<i32, i32>::new(ephemeral_config())
             .await
+            .expect("bind failed")
             .with_persistence(Arc::new(FileSnapshot::new(&path)));
         assert!(restarted.get(&1).is_none(), "tombstone was not recovered");
         let version = restarted
@@ -1192,6 +1212,7 @@ mod reconcile_store_tests {
         let fake = FakeDiscovery::new(FakeResp::Present(vec![member]));
         let store = ReconcileStore::<i32, i32>::new(discovery_config())
             .await
+            .expect("bind failed")
             .with_discovery(Arc::new(fake.clone()))
             .with_discovery_interval(Duration::from_millis(20))
             .with_discovery_miss_threshold(3);
@@ -1235,6 +1256,7 @@ mod reconcile_store_tests {
         let fake = FakeDiscovery::new(FakeResp::Present(vec![member]));
         let store = ReconcileStore::<i32, i32>::new(discovery_config())
             .await
+            .expect("bind failed")
             .with_discovery(Arc::new(fake.clone()))
             .with_discovery_interval(Duration::from_millis(20))
             .with_discovery_miss_threshold(3);
@@ -1299,6 +1321,7 @@ mod reconcile_store_tests {
         let store =
             ReconcileStore::<i32, i32>::new_with_clock(ephemeral_config().with_node_id(1), clock)
                 .await
+                .expect("bind failed")
                 .with_persistence(backend);
 
         // Insert a new value; the minted timestamp must be strictly greater than persisted_stamp.
@@ -1351,6 +1374,7 @@ mod reconcile_store_tests {
         let store =
             ReconcileStore::<i32, i32>::new_with_clock(ephemeral_config().with_node_id(2), clock)
                 .await
+                .expect("bind failed")
                 .with_persistence(backend);
 
         // The tombstone was recovered (key 7 is absent from the live view).
@@ -1377,6 +1401,34 @@ mod reconcile_store_tests {
             "post-restart insert timestamp {minted_stamp:?} is not strictly greater than the \
              persisted tombstone stamp {tombstone_stamp:?}; the clock was not advanced on load, \
              so a peer reconciling with this node could resurrect the tombstone via LWW"
+        );
+    }
+
+    /// `new` must return `Err` rather than panic when the requested port is already in use.
+    ///
+    /// We hold a `std::net::UdpSocket` on the same address/port first; the OS will refuse the
+    /// second bind and the fallible constructor must surface that error to the caller.
+    #[tokio::test]
+    async fn new_returns_err_on_bind_failure() {
+        // Occupy a loopback port chosen by the OS (bind to :0, then read it back) so this test
+        // cannot collide with a fixed port already taken by the parallel suite or a stray process.
+        let holder =
+            std::net::UdpSocket::bind("127.0.0.50:0").expect("pre-condition: a port must be free");
+        let busy = holder
+            .local_addr()
+            .expect("holder must report its bound address");
+
+        let config = Config::default()
+            .with_port(busy.port())
+            .with_listen_addr(busy.ip());
+        let result = ReconcileStore::<i32, i32>::new(config).await;
+        let err = result
+            .err()
+            .expect("expected Err when the bind address is already in use");
+        assert_eq!(
+            err.kind(),
+            std::io::ErrorKind::AddrInUse,
+            "bind failure should surface as AddrInUse, got {err:?}"
         );
     }
 }

--- a/tests/discovery.rs
+++ b/tests/discovery.rs
@@ -78,6 +78,7 @@ async fn vanished_peer_is_decommissioned_and_tombstone_collected() {
     let discovery = ScriptedDiscovery::new(vec![addr2]);
     let store1 = ReconcileStore::<i32, i32>::new(cfg1)
         .await
+        .expect("bind failed")
         .with_seed(addr2)
         .with_tombstone_timeout(Duration::from_millis(50))
         .with_discovery(Arc::new(discovery.clone()))
@@ -85,6 +86,7 @@ async fn vanished_peer_is_decommissioned_and_tombstone_collected() {
         .with_discovery_miss_threshold(3);
     let store2 = ReconcileStore::<i32, i32>::new(cfg2)
         .await
+        .expect("bind failed")
         .with_seed(addr1)
         .with_tombstone_timeout(Duration::from_millis(50));
 

--- a/tests/fuzz_packets.rs
+++ b/tests/fuzz_packets.rs
@@ -67,7 +67,9 @@ async fn malformed_datagrams_do_not_panic_or_corrupt_state() {
         .with_listen_addr(victim_addr.parse().unwrap());
     // No cluster key: arbitrary bytes are *not* dropped at the auth gate and
     // reach the deserializer, which is exactly the path we want to fuzz.
-    let store = ReconcileStore::<i32, String>::new(config).await;
+    let store = ReconcileStore::<i32, String>::new(config)
+        .await
+        .expect("bind failed");
     store.just_insert(0, "legit".to_string());
 
     let task = tokio::spawn(store.clone().run());

--- a/tests/mirror.rs
+++ b/tests/mirror.rs
@@ -51,7 +51,8 @@ async fn mirror_converges_with_dated_store() {
             .with_listen_addr(dated_addr)
             .with_net(net),
     )
-    .await;
+    .await
+    .expect("bind failed");
     // Seed the mirror with the dated store's address: the mirror *drives* reconciliation over the
     // value-only channel, so it just needs to know where to send.
     let mirror = ReconcileMirror::<String, String>::new(
@@ -61,6 +62,7 @@ async fn mirror_converges_with_dated_store() {
             .with_net(net),
     )
     .await
+    .expect("bind failed")
     .with_seed(dated_addr);
 
     // Populate the dated store with live values and one key we will later delete.
@@ -117,6 +119,7 @@ async fn mirror_does_not_block_tombstone_gc() {
             .with_net(net),
     )
     .await
+    .expect("bind failed")
     .with_tombstone_timeout(Duration::from_millis(50));
     let mirror = ReconcileMirror::<i32, i32>::new(
         Config::default()
@@ -125,6 +128,7 @@ async fn mirror_does_not_block_tombstone_gc() {
             .with_net(net),
     )
     .await
+    .expect("bind failed")
     .with_seed(dated_addr);
 
     dated.insert(1, 11);

--- a/tests/observability.rs
+++ b/tests/observability.rs
@@ -82,7 +82,9 @@ async fn startup_emits_info_and_security_warning_without_cluster_key() {
     let subscriber = Registry::default().with(layer);
     let _guard = tracing::subscriber::set_default(subscriber);
 
-    let _store = ReconcileStore::<String, String>::new(local_config()).await;
+    let _store = ReconcileStore::<String, String>::new(local_config())
+        .await
+        .expect("bind failed");
 
     let events = events.lock().unwrap();
     let has_info_listening = events
@@ -109,7 +111,9 @@ async fn cluster_key_suppresses_the_security_warning() {
     let _guard = tracing::subscriber::set_default(subscriber);
 
     let config = local_config().with_cluster_key([7u8; 32]);
-    let _store = ReconcileStore::<String, String>::new(config).await;
+    let _store = ReconcileStore::<String, String>::new(config)
+        .await
+        .expect("bind failed");
 
     let events = events.lock().unwrap();
     let has_info_listening = events
@@ -139,7 +143,9 @@ async fn local_mutations_increment_metric_counters() {
     // `info!("Listening on")` emission from poisoning the shared callsite cache for the other
     // tests (see that helper).
     keep_callsites_hot();
-    let store = ReconcileStore::<i32, i32>::new(local_config()).await;
+    let store = ReconcileStore::<i32, i32>::new(local_config())
+        .await
+        .expect("bind failed");
 
     let recorder = DebuggingRecorder::new();
     let snapshotter = recorder.snapshotter();

--- a/tests/service.rs
+++ b/tests/service.rs
@@ -51,10 +51,16 @@ async fn test() {
     });
 
     // start reconciliation stores for tree1 and tree2
-    let store1 = ReconcileStore::new(cfg1).await.with_seed(addr2);
+    let store1 = ReconcileStore::new(cfg1)
+        .await
+        .expect("bind failed")
+        .with_seed(addr2);
     store1.insert_bulk(&key_values);
     let start_hash = store1.fingerprint(..);
-    let store2 = ReconcileStore::new(cfg2).await.with_seed(addr1);
+    let store2 = ReconcileStore::new(cfg2)
+        .await
+        .expect("bind failed")
+        .with_seed(addr1);
     // Check the initial state *before* spawning the run loops: store1's `insert_bulk` already
     // spawned a background broadcast to its seeded peer (store2), so once store2 starts
     // receiving these asserts would race with reconciliation.
@@ -166,8 +172,14 @@ async fn get_mut_edit_propagates_to_peers() {
         .with_listen_addr(addr2)
         .with_net(net);
 
-    let store1 = ReconcileStore::new(cfg1).await.with_seed(addr2);
-    let store2 = ReconcileStore::new(cfg2).await.with_seed(addr1);
+    let store1 = ReconcileStore::new(cfg1)
+        .await
+        .expect("bind failed")
+        .with_seed(addr2);
+    let store2 = ReconcileStore::new(cfg2)
+        .await
+        .expect("bind failed")
+        .with_seed(addr1);
     let task1 = tokio::spawn(store1.clone().run());
     let task2 = tokio::spawn(store2.clone().run());
 
@@ -222,10 +234,16 @@ async fn authenticated_nodes_converge() {
         (key, value)
     });
 
-    let store1 = ReconcileStore::new(cfg1).await.with_seed(addr2);
+    let store1 = ReconcileStore::new(cfg1)
+        .await
+        .expect("bind failed")
+        .with_seed(addr2);
     store1.insert_bulk(&key_values);
     let start_hash = store1.fingerprint(..);
-    let store2 = ReconcileStore::new(cfg2).await.with_seed(addr1);
+    let store2 = ReconcileStore::new(cfg2)
+        .await
+        .expect("bind failed")
+        .with_seed(addr1);
     let task2 = tokio::spawn(store2.clone().run());
     let task1 = tokio::spawn(store1.clone().run());
 
@@ -271,9 +289,11 @@ async fn concurrent_writes_converge() {
 
     let store1 = ReconcileStore::<String, String>::new(cfg1)
         .await
+        .expect("bind failed")
         .with_seed(addr2);
     let store2 = ReconcileStore::<String, String>::new(cfg2)
         .await
+        .expect("bind failed")
         .with_seed(addr1);
     let task1 = tokio::spawn(store1.clone().run());
     let task2 = tokio::spawn(store2.clone().run());
@@ -326,10 +346,12 @@ async fn tombstone_is_retained_until_peer_acknowledges() {
     // would be GC'd almost immediately.
     let store1 = ReconcileStore::<i32, i32>::new(cfg1)
         .await
+        .expect("bind failed")
         .with_seed(addr2)
         .with_tombstone_timeout(Duration::from_millis(50));
     let store2 = ReconcileStore::<i32, i32>::new(cfg2)
         .await
+        .expect("bind failed")
         .with_seed(addr1)
         .with_tombstone_timeout(Duration::from_millis(50));
 
@@ -391,10 +413,12 @@ async fn deleted_value_is_not_resurrected_by_returning_peer() {
 
     let store1 = ReconcileStore::<i32, i32>::new(cfg1)
         .await
+        .expect("bind failed")
         .with_seed(addr2)
         .with_tombstone_timeout(Duration::from_millis(50));
     let store2 = ReconcileStore::<i32, i32>::new(cfg2)
         .await
+        .expect("bind failed")
         .with_seed(addr1)
         .with_tombstone_timeout(Duration::from_millis(50));
 
@@ -458,8 +482,14 @@ async fn test_malformed_datagram_does_not_crash() {
         .with_listen_addr(addr2)
         .with_net(net);
 
-    let store1 = ReconcileStore::new(cfg1).await.with_seed(addr2);
-    let store2 = ReconcileStore::new(cfg2).await.with_seed(addr1);
+    let store1 = ReconcileStore::new(cfg1)
+        .await
+        .expect("bind failed")
+        .with_seed(addr2);
+    let store2 = ReconcileStore::new(cfg2)
+        .await
+        .expect("bind failed")
+        .with_seed(addr1);
     let task1 = tokio::spawn(store1.clone().run());
     let task2 = tokio::spawn(store2.clone().run());
 
@@ -509,10 +539,16 @@ async fn encrypted_nodes_converge() {
         (key, value)
     });
 
-    let store1 = ReconcileStore::new(cfg1).await.with_seed(addr2);
+    let store1 = ReconcileStore::new(cfg1)
+        .await
+        .expect("bind failed")
+        .with_seed(addr2);
     store1.insert_bulk(&key_values);
     let start_hash = store1.fingerprint(..);
-    let store2 = ReconcileStore::new(cfg2).await.with_seed(addr1);
+    let store2 = ReconcileStore::new(cfg2)
+        .await
+        .expect("bind failed")
+        .with_seed(addr1);
     let task2 = tokio::spawn(store2.clone().run());
     let task1 = tokio::spawn(store1.clone().run());
 
@@ -552,11 +588,15 @@ async fn encrypted_node_with_wrong_key_is_rejected() {
         .with_cluster_key([0x99u8; 32]) // different key
         .with_encryption();
 
-    let store1 = ReconcileStore::new(cfg1).await.with_seed(addr2);
+    let store1 = ReconcileStore::new(cfg1)
+        .await
+        .expect("bind failed")
+        .with_seed(addr2);
     store1.insert("secret".to_string(), "value".to_string());
     let start_hash = store1.fingerprint(..);
     let store2 = ReconcileStore::<String, String>::new(cfg2)
         .await
+        .expect("bind failed")
         .with_seed(addr1);
     let task2 = tokio::spawn(store2.clone().run());
     let task1 = tokio::spawn(store1.clone().run());
@@ -600,11 +640,15 @@ async fn cross_net_reconciliation() {
         .with_remote_interval(1)
         .with_remote_fanout(1);
 
-    let store1 = ReconcileStore::new(cfg1).await.with_seed(addr2);
+    let store1 = ReconcileStore::new(cfg1)
+        .await
+        .expect("bind failed")
+        .with_seed(addr2);
     store1.insert("key".to_string(), "value".to_string());
     let start_hash = store1.fingerprint(..);
     let store2 = ReconcileStore::<String, String>::new(cfg2)
         .await
+        .expect("bind failed")
         .with_seed(addr1);
     assert_eq!(store2.fingerprint(..), Fingerprint::ZERO);
 
@@ -651,10 +695,12 @@ async fn cross_net_discovery_without_seed() {
         .with_remote_fanout(1);
 
     // No `with_seed`: the two nodes must find each other purely through per-network discovery probes.
-    let store1 = ReconcileStore::new(cfg1).await;
+    let store1 = ReconcileStore::new(cfg1).await.expect("bind failed");
     store1.insert("k".to_string(), "v".to_string());
     let start_hash = store1.fingerprint(..);
-    let store2 = ReconcileStore::<String, String>::new(cfg2).await;
+    let store2 = ReconcileStore::<String, String>::new(cfg2)
+        .await
+        .expect("bind failed");
 
     let task2 = tokio::spawn(store2.clone().run());
     let task1 = tokio::spawn(store1.clone().run());
@@ -695,10 +741,12 @@ async fn runtime_add_net_enables_discovery_and_convergence() {
         .with_remote_fanout(1);
 
     // No seed: the nodes can only meet through per-network discovery probes.
-    let store1 = ReconcileStore::new(cfg1).await;
+    let store1 = ReconcileStore::new(cfg1).await.expect("bind failed");
     store1.insert("k".to_string(), "v".to_string());
     let start_hash = store1.fingerprint(..);
-    let store2 = ReconcileStore::<String, String>::new(cfg2).await;
+    let store2 = ReconcileStore::<String, String>::new(cfg2)
+        .await
+        .expect("bind failed");
 
     let task2 = tokio::spawn(store2.clone().run());
     let task1 = tokio::spawn(store1.clone().run());
@@ -746,11 +794,15 @@ async fn unclassified_peer_is_still_reconciled() {
         .with_remote_fanout(1);
 
     // Seeded so each knows the other, even though neither address is in any declared network.
-    let store1 = ReconcileStore::new(cfg1).await.with_seed(addr2);
+    let store1 = ReconcileStore::new(cfg1)
+        .await
+        .expect("bind failed")
+        .with_seed(addr2);
     store1.insert("k".to_string(), "v".to_string());
     let start_hash = store1.fingerprint(..);
     let store2 = ReconcileStore::<String, String>::new(cfg2)
         .await
+        .expect("bind failed")
         .with_seed(addr1);
 
     // Local net of last resort is each node's own host route (peer is not local).
@@ -782,7 +834,8 @@ async fn runtime_config_setters() {
             .with_listen_addr(addr)
             .with_net(net_c),
     )
-    .await;
+    .await
+    .expect("bind failed");
     assert_eq!(store.nets(), vec![net_c]);
     assert_eq!(store.local_net(), net_c);
 

--- a/tests/tombstone_wheel.rs
+++ b/tests/tombstone_wheel.rs
@@ -62,6 +62,7 @@ async fn isolated_store(
             .with_port(port),
     )
     .await
+    .expect("bind failed")
     .with_tombstone_timeout(tombstone_timeout)
 }
 


### PR DESCRIPTION
**Problem.** `ReconcileStore::new`, `ReconcileEngine::new`, and `ReconcileMirror::new` unwrapped the UDP bind — "address in use" aborted the embedding process. Worse for liveness: the engine's send paths unwrapped `send_to_retry` after retry exhaustion, so a persistently failing send (unreachable peer, `ENOBUFS` under flood, routing flap) **panicked the receive task and silently stopped all reconciliation** for the node — a cheap, remotely-influenced DoS.

**Fix.** The three socket-binding constructors return `io::Result<Self>` (`# Errors` documented). Every network send funnels through `send_messages_paced`, which now logs-and-continues after retry exhaustion (`send_to_retry` already counts give-ups via the metrics facade); both `run()` loops survive recv errors and document that sends are non-fatal. Call sites across tests, benches, and examples updated. New test: binding on an OS-assigned occupied port returns `ErrorKind::AddrInUse` instead of panicking.

**Review provenance.** Adversarially reviewed (approve-with-fixes, applied). The review exhaustively classified **every** `unwrap`/`expect` on runtime network paths and proved the inline receive-loop sends all funnel through the hardened choke point; it also rewrote the bind test from a fixed port to an OS-assigned one with a tightened `ErrorKind` assertion, and ran the full feature matrix (`--all-features`, `internal-testing`) as CI does.

**API note (deliberate 0.2.x break):** constructors now return `io::Result<Self>`. `with_persistence`'s load-time panic is intentionally untouched here (tracked in #202, Phase 1). Residual: per-failure `warn!` against a permanently dead peer is a mild log-flood vector (metric exists for dashboards).

Closes #148.

**Stack 5/6** — base: `claude/p0-4-clock-restore`. Merge after stack 4.

https://claude.ai/code/session_01BaajsC6gEk1v7Y55dA5cPG

---
_Generated by [Claude Code](https://claude.ai/code/session_01BaajsC6gEk1v7Y55dA5cPG)_