### PR TITLE
ci: trigger workflows on main and on all pull requests

### DIFF
--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -2,9 +2,8 @@ name: Devcontainer CI
 
 on:
   push:
-    branches: ["master"]
+    branches: ["main"]
   pull_request:
-    branches: ["master"]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -2,9 +2,8 @@ name: master
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "main" ]
   pull_request:
-    branches: [ "master" ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
**Problem.** Both `master.yml` and `devcontainer.yml` trigger on `branches: ["master"]`, but the repository's default branch is `main` (`master` no longer exists on the remote). Consequence: **no CI has run on any push to main or on any pull request** since the rename — including recently merged PRs. The freshly opened Phase-0 stack (#207–#212) confirmed it: zero check runs.

**Fix.** Two-line-per-file trigger change: `push` → `main`; the `pull_request` branch filter is dropped entirely so PRs whose base is a feature branch (the stacked PRs #208–#212, and future stacks) also build. Job definitions untouched; the cosmetic `name: master` rename is left for the Phase-1 CI overhaul (#203).

**Stack 0/6 — this is now the bottom of the Phase-0 stack.** The six stack branches are rebased onto this one (per review decision), so every stack PR's merge tree contains the fixed triggers and CI runs on all of them immediately. Merge this first, then #207 → #212 in order.

Documented on #203 (CI gaps).

https://claude.ai/code/session_01BaajsC6gEk1v7Y55dA5cPG