### PR TITLE
feat: bound per-peer state, tombstone-ack bookkeeping, and concurrent bulk dumps

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,4 +154,52 @@ pub mod testing {
     {
         store.members_snapshot()
     }
+
+    /// Number of entries in the peers gossip-routing map.
+    ///
+    /// Exposed for integration-test assertions so the peer-cap tests can verify that no new
+    /// gossip-peer record is created for a capped-out sender.
+    pub fn peers_map_len<K, V>(store: &crate::ReconcileStore<K, V>) -> usize
+    where
+        K: crate::bounds::Key,
+        V: crate::bounds::Value,
+    {
+        store.peers_map_len()
+    }
+
+    /// Number of entries in the per-peer replay filter.
+    ///
+    /// Exposed for integration-test assertions so the peer-cap tests can verify that no new
+    /// replay-filter entry is created for a capped-out sender.
+    pub fn replay_filter_len<K, V>(store: &crate::ReconcileStore<K, V>) -> usize
+    where
+        K: crate::bounds::Key,
+        V: crate::bounds::Value,
+    {
+        store.replay_filter_len()
+    }
+
+    /// Number of keys currently tracked in the tombstone-acknowledgment map.
+    ///
+    /// Exposed for integration-test assertions so tests can verify that acks for
+    /// non-tombstone keys are dropped without growing bookkeeping.
+    pub fn tombstone_acks_len<K, V>(store: &crate::ReconcileStore<K, V>) -> usize
+    where
+        K: crate::bounds::Key,
+        V: crate::bounds::Value,
+    {
+        store.tombstone_acks_len()
+    }
+
+    /// Number of bulk dump tasks currently in flight across all peers.
+    ///
+    /// Exposed for integration-test assertions so tests can verify that the global dump
+    /// budget is respected and slots are released after completion.
+    pub fn bulk_dumps_in_flight_count<K, V>(store: &crate::ReconcileStore<K, V>) -> usize
+    where
+        K: crate::bounds::Key,
+        V: crate::bounds::Value,
+    {
+        store.bulk_dumps_in_flight_count()
+    }
 }

--- a/src/mirror.rs
+++ b/src/mirror.rs
@@ -108,6 +108,10 @@ pub struct ReconcileMirror<K, V> {
     replay_filter: Arc<replay::ReplayFilter>,
     /// Invoked just before each inbound value is integrated, so callers can be notified of changes.
     on_update: Arc<RwLock<OnUpdateCallback<K, V>>>,
+    /// Hard cap on the number of dated-cluster peers the mirror tracks. Datagrams from unknown
+    /// senders are dropped before any per-sender state is allocated when the peers map reaches
+    /// this size. Sourced from [`Config::max_peers`].
+    max_peers: usize,
 }
 
 impl<K, V> Clone for ReconcileMirror<K, V> {
@@ -123,6 +127,7 @@ impl<K, V> Clone for ReconcileMirror<K, V> {
             sender_counter: self.sender_counter.clone(),
             replay_filter: self.replay_filter.clone(),
             on_update: self.on_update.clone(),
+            max_peers: self.max_peers,
         }
     }
 }
@@ -172,6 +177,7 @@ impl<K: Key, V: Clone + Debug + DeserializeOwned + Hash + Send + Serialize + Syn
             sender_counter: Arc::new(replay::SenderCounter::new()),
             replay_filter: Arc::new(replay::ReplayFilter::new(config.freshness_window)),
             on_update: Arc::new(RwLock::new(Box::new(|_, _| {}))),
+            max_peers: config.max_peers,
         })
     }
 
@@ -382,25 +388,41 @@ impl<K: Key, V: Clone + Debug + DeserializeOwned + Hash + Send + Serialize + Syn
                     } else {
                         match self.authenticator.open(&recv_buf[..size]) {
                             Some(payload) => {
-                                if self.authenticator.is_enabled() {
-                                    let sender = peer.ip();
-                                    if !self.replay_filter.check_and_record(
-                                        sender,
-                                        payload.seq,
-                                        payload.stamp,
-                                    ) {
+                                let sender = peer.ip();
+                                // Per-peer cap check: drop datagrams from unknown senders when the
+                                // peers map is at capacity, before any per-sender state is
+                                // allocated (peers slot or replay-filter entry).
+                                {
+                                    let guard = self.peers.read();
+                                    if !guard.contains_key(&sender) && guard.len() >= self.max_peers
+                                    {
                                         trace!(
-                                            "mirror dropped replayed datagram from {peer}: \
-                                             seq={} stamp={}",
-                                            payload.seq,
-                                            payload.stamp
+                                            "mirror dropped datagram from {peer}: peer cap \
+                                             reached ({}/{})",
+                                            guard.len(),
+                                            self.max_peers
                                         );
                                         continue;
                                     }
                                 }
+                                if self.authenticator.is_enabled()
+                                    && !self.replay_filter.check_and_record(
+                                        sender,
+                                        payload.seq,
+                                        payload.stamp,
+                                    )
+                                {
+                                    trace!(
+                                        "mirror dropped replayed datagram from {peer}: \
+                                         seq={} stamp={}",
+                                        payload.seq,
+                                        payload.stamp
+                                    );
+                                    continue;
+                                }
                                 self.handle_messages(payload, peer, &mut send_buf).await;
                                 // Record the sender so we keep gossiping value-only diffs to it.
-                                self.peers.write().insert(peer.ip(), Instant::now());
+                                self.peers.write().insert(sender, Instant::now());
                             }
                             None => trace!(
                                 "mirror dropped datagram from {peer}: missing or invalid MAC"

--- a/src/reconcile_engine.rs
+++ b/src/reconcile_engine.rs
@@ -184,6 +184,14 @@ pub(crate) struct Inner<K, V: Projectable> {
     /// Entries are inserted before a dump is spawned and removed (via an RAII guard, so it survives a
     /// panic in the send task) when it finishes.
     bulk_in_flight: Arc<RwLock<HashSet<SocketAddr>>>,
+    /// Count of bulk dump tasks currently in flight across all peers. When this reaches
+    /// [`max_concurrent_bulk_dumps`](Self::max_concurrent_bulk_dumps), new dumps are skipped before
+    /// allocating their snapshot Vec; the protocol is retry-driven, so the requesting peer's next
+    /// diff round re-triggers the dump once a slot is free. Decremented by an RAII guard on the
+    /// spawned task, so a panicking task never leaks a slot.
+    bulk_dumps_in_flight: Arc<AtomicUsize>,
+    /// Global cap on the number of concurrently active paced bulk dumps.
+    max_concurrent_bulk_dumps: usize,
     /// Monotonic reconciliation-round counter, shared across clones, gating the cross-network cadence.
     round: Arc<AtomicU32>,
     rng: Arc<RwLock<StdRng>>,
@@ -229,6 +237,9 @@ pub(crate) struct Inner<K, V: Projectable> {
     /// Exposed via [`node_id_is_random`](ReconcileEngine::node_id_is_random) so that the store
     /// layer can warn operators when persistence is configured but the identity is ephemeral.
     pub(crate) node_id_is_random: bool,
+    /// Hard cap on the number of tracked remote peers. Datagrams from unknown senders are dropped
+    /// before any per-sender state is allocated when the membership set reaches this size.
+    max_peers: usize,
 }
 
 impl<K, V: Projectable> Clone for ReconcileEngine<K, V> {
@@ -359,6 +370,8 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
                 reconcile_interval: Arc::new(RwLock::new(config.reconcile_interval)),
                 bulk_send_rate: config.bulk_send_rate,
                 bulk_in_flight: Arc::new(RwLock::new(HashSet::new())),
+                bulk_dumps_in_flight: Arc::new(AtomicUsize::new(0)),
+                max_concurrent_bulk_dumps: config.max_concurrent_bulk_dumps,
                 round: Arc::new(AtomicU32::new(0)),
                 rng,
                 probe,
@@ -371,6 +384,7 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
                 tombstone_acks: Arc::new(RwLock::new(HashMap::new())),
                 clock,
                 node_id_is_random,
+                max_peers: config.max_peers,
             }),
         })
     }
@@ -532,6 +546,50 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
         });
     }
 
+    /// Try to claim both a per-peer in-flight slot and a global concurrent-dump slot.
+    ///
+    /// Returns `Some((peer_guard, global_guard))` when both slots are available, or `None` when
+    /// either is already taken. The caller checks this **before** snapshotting the differing range
+    /// into a `Vec`, so a skipped dump allocates nothing. The guards release their slots on drop,
+    /// ensuring cleanup even if the spawned task panics.
+    fn try_claim_dump_slot(
+        &self,
+        peer: SocketAddr,
+    ) -> Option<(BulkInFlightGuard, BulkDumpCountGuard)> {
+        // Per-peer guard: at most one dump per peer at a time.
+        if !self.bulk_in_flight.write().insert(peer) {
+            return None;
+        }
+        // Global budget: at most `max_concurrent_bulk_dumps` across all peers. The
+        // compare-exchange loop increments only if currently below the cap. If at cap, release the
+        // per-peer mark before returning so that slot is not leaked.
+        let budget = self.max_concurrent_bulk_dumps;
+        let claimed = self
+            .bulk_dumps_in_flight
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |n| {
+                if n < budget {
+                    Some(n + 1)
+                } else {
+                    None
+                }
+            })
+            .is_ok();
+        if !claimed {
+            self.bulk_in_flight.write().remove(&peer);
+            trace!("skipped bulk dump to {peer}: global dump budget ({budget}) exhausted");
+            return None;
+        }
+        Some((
+            BulkInFlightGuard {
+                set: Arc::clone(&self.bulk_in_flight),
+                peer,
+            },
+            BulkDumpCountGuard {
+                counter: Arc::clone(&self.bulk_dumps_in_flight),
+            },
+        ))
+    }
+
     /// Send a bulk batch of differing values to one peer on a detached, **rate-paced** task.
     ///
     /// This is the cold/bulk anti-entropy path: when a peer differs over a whole range it must
@@ -550,23 +608,26 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
     ///    re-dump ranges still in transit, which is the byte amplification we are removing. Anything
     ///    genuinely still missing (e.g. a dropped datagram) is picked up by the next reconcile round
     ///    once the current dump finishes.
-    fn spawn_paced_send(&self, messages: Vec<Message<K, V, V::Projected>>, peer: SocketAddr) {
-        // Admit at most one in-flight dump per peer. `insert` returns false if already present.
-        if !self.bulk_in_flight.write().insert(peer) {
-            return;
-        }
-        // RAII: clears the in-flight mark when the dump finishes *or* if the send task panics, so a
-        // failed dump can never wedge a peer into "permanently transferring" and starve its sync.
-        let guard = BulkInFlightGuard {
-            set: Arc::clone(&self.bulk_in_flight),
-            peer,
-        };
+    /// 3. A **global concurrent-dump budget** (`max_concurrent_bulk_dumps`): even with the per-peer
+    ///    guard, M peers diffing simultaneously would each hold a full snapshot Vec. This cap limits
+    ///    total in-flight dump tasks. The caller checks the budget via [`try_claim_dump_slot`](Self::try_claim_dump_slot)
+    ///    **before** building the snapshot Vec, so a skipped dump allocates nothing.
+    fn spawn_paced_send(
+        &self,
+        messages: Vec<Message<K, V, V::Projected>>,
+        peer: SocketAddr,
+        peer_guard: BulkInFlightGuard,
+        global_guard: BulkDumpCountGuard,
+    ) {
         let socket = Arc::clone(&self.socket);
         let authenticator = self.authenticator.clone();
         let sender_counter = Arc::clone(&self.sender_counter);
         let rate = self.bulk_send_rate;
         tokio::spawn(async move {
-            let _guard = guard;
+            // Hold both RAII guards for the lifetime of the task: they release their respective
+            // slots on drop, even if this task is aborted or panics.
+            let _peer_guard = peer_guard;
+            let _global_guard = global_guard;
             let mut send_buf = Vec::new();
             send_messages_paced(
                 &messages,
@@ -664,27 +725,50 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
                         // dropped silently (trace-only, to avoid attacker-driven log flooding).
                         match self.authenticator.open(&recv_buf[..size]) {
                             Some(payload) => {
+                                let sender = peer.ip();
+                                // Per-peer cap check: if this sender is not yet tracked (not a
+                                // member) and the membership set is at capacity, drop the datagram
+                                // before allocating any per-sender state (replay filter entry,
+                                // peers map slot, or membership slot). Authenticated datagrams are
+                                // verified first (above), so this gate cannot be triggered by a
+                                // forged source address in authenticated mode.
+                                //
+                                // The check is intentionally placed *before* the replay filter so
+                                // that no replay-filter entry is created for a capped-out sender.
+                                // Known senders (already in `members`) bypass the cap.
+                                let is_known = self.members.read().contains(&sender);
+                                if !is_known {
+                                    let current_len = self.members.read().len();
+                                    if current_len >= self.max_peers {
+                                        trace!(
+                                            "dropped datagram from {peer}: peer cap reached \
+                                             ({current_len}/{})",
+                                            self.max_peers
+                                        );
+                                        observability::record_datagram_dropped("peer_cap");
+                                        continue;
+                                    }
+                                }
                                 // In authenticated modes, perform the replay check *after*
                                 // authentication (so forgeries cannot poison the per-peer state)
                                 // and *before* message processing. In unauthenticated mode
                                 // seq/stamp are both 0 and `is_enabled()` is false, so the check
                                 // is skipped entirely.
-                                if self.authenticator.is_enabled() {
-                                    let sender = peer.ip();
-                                    if !self.replay_filter.check_and_record(
+                                if self.authenticator.is_enabled()
+                                    && !self.replay_filter.check_and_record(
                                         sender,
                                         payload.seq,
                                         payload.stamp,
-                                    ) {
-                                        trace!(
-                                            "dropped replayed or stale datagram from {peer}: \
-                                             seq={} stamp={}",
-                                            payload.seq,
-                                            payload.stamp
-                                        );
-                                        observability::record_datagram_dropped("replay");
-                                        continue;
-                                    }
+                                    )
+                                {
+                                    trace!(
+                                        "dropped replayed or stale datagram from {peer}: \
+                                         seq={} stamp={}",
+                                        payload.seq,
+                                        payload.stamp
+                                    );
+                                    observability::record_datagram_dropped("replay");
+                                    continue;
                                 }
                                 let spoke_dated =
                                     self.handle_messages(payload, peer, &mut send_buf).await;
@@ -701,9 +785,8 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
                                 // forever (the very regression we must avoid). Such a mirror is
                                 // served reactively off `peer` and is not tracked as a peer/member.
                                 if spoke_dated {
-                                    let addr = peer.ip();
-                                    self.peers.write().insert(addr, Instant::now());
-                                    self.members.write().insert(addr);
+                                    self.peers.write().insert(sender, Instant::now());
+                                    self.members.write().insert(sender);
                                 }
                             }
                             None => {
@@ -868,13 +951,29 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
                 let map_guard = self.map.read();
                 let mut guard = self.tombstone_acks.write();
                 for (key, version) in acks {
+                    // Accept an ack only for a key we locally hold as a tombstone. Acks for
+                    // never-existent or non-tombstone keys are dropped here so they cannot
+                    // accumulate in `tombstone_acks` without bound.
+                    //
+                    // Ordering hazard: this gate cannot tell "a key we will never hold" from
+                    // "a key we don't hold YET". In a cluster of three or more nodes an ack
+                    // can arrive before the deletion it acknowledges (the acking peer may have
+                    // learned the deletion via a different gossip edge), and a dropped ack is
+                    // not re-delivered. Any future change to causal-stability GC must account
+                    // for this rather than rely on early acks being retained.
+                    let local_tombstone = map_guard.get(&key).filter(|v| v.is_tombstone());
+                    let Some(local_v) = local_tombstone else {
+                        trace!(
+                            "dropped ack from {peer_ip} for key with no local tombstone; \
+                             ignoring to prevent unbounded bookkeeping"
+                        );
+                        continue;
+                    };
                     let entry = guard.entry(key.clone()).or_default();
                     let already = entry.get(&peer_ip) == Some(&version);
                     entry.insert(peer_ip, version);
                     if !already {
-                        let holds_same_tombstone = map_guard
-                            .get(&key)
-                            .is_some_and(|v| v.is_tombstone() && version_hash(v) == version);
+                        let holds_same_tombstone = version_hash(local_v) == version;
                         if holds_same_tombstone {
                             reciprocal_acks
                                 .push(Message::Ack::<K, V, V::Projected>((key, version)));
@@ -927,18 +1026,24 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
             if !differences.is_empty() {
                 debug!("returning {} diff_ranges", differences.len());
                 trace!("diff_ranges: {differences:?}");
-                let updates: Vec<Message<K, V, V::Projected>> = {
-                    let guard = self.map.read();
-                    let mut updates = Vec::new();
-                    for range in differences {
-                        for (k, v) in guard.get_range(&range) {
-                            updates.push(Message::Update((k.clone(), v.clone())));
+                // Claim both slots (per-peer + global budget) *before* snapshotting the range
+                // into a Vec. A skipped dump allocates nothing; the peer re-initiates on its
+                // next diff round once a slot is free.
+                if let Some((peer_guard, global_guard)) = self.try_claim_dump_slot(peer) {
+                    let updates: Vec<Message<K, V, V::Projected>> = {
+                        let guard = self.map.read();
+                        let mut updates = Vec::new();
+                        for range in differences {
+                            for (k, v) in guard.get_range(&range) {
+                                updates.push(Message::Update((k.clone(), v.clone())));
+                            }
                         }
+                        updates
+                    };
+                    if !updates.is_empty() {
+                        self.spawn_paced_send(updates, peer, peer_guard, global_guard);
                     }
-                    updates
-                };
-                if !updates.is_empty() {
-                    self.spawn_paced_send(updates, peer);
+                    // If updates is empty the guards drop here, releasing both slots.
                 }
             }
         }
@@ -1050,18 +1155,20 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
             // Bulk value-only payload — a dateless mirror pulling the dataset. Rate-pace it on a
             // background task, exactly like the dated bulk path.
             if !differences.is_empty() {
-                let updates: Vec<Message<K, V, V::Projected>> = {
-                    let guard = self.projection.read();
-                    let mut updates = Vec::new();
-                    for range in differences {
-                        for (k, p) in guard.get_range(&range) {
-                            updates.push(Message::ValueUpdate((k.clone(), p.clone())));
+                if let Some((peer_guard, global_guard)) = self.try_claim_dump_slot(peer) {
+                    let updates: Vec<Message<K, V, V::Projected>> = {
+                        let guard = self.projection.read();
+                        let mut updates = Vec::new();
+                        for range in differences {
+                            for (k, p) in guard.get_range(&range) {
+                                updates.push(Message::ValueUpdate((k.clone(), p.clone())));
+                            }
                         }
+                        updates
+                    };
+                    if !updates.is_empty() {
+                        self.spawn_paced_send(updates, peer, peer_guard, global_guard);
                     }
-                    updates
-                };
-                if !updates.is_empty() {
-                    self.spawn_paced_send(updates, peer);
                 }
             }
         }
@@ -1104,6 +1211,7 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
     /// peer to membership. Keeping the replay state lets the bitmap reject the captured datagram.
     pub(crate) fn decommission_peer(&self, peer: IpAddr) {
         self.members.write().remove(&peer);
+        self.peers.write().remove(&peer);
         for key_acks in self.tombstone_acks.write().values_mut() {
             key_acks.remove(&peer);
         }
@@ -1125,6 +1233,38 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
     /// A snapshot of the monotonic membership set (peers that gate tombstone GC).
     pub(crate) fn members_snapshot(&self) -> HashSet<IpAddr> {
         self.members.read().clone()
+    }
+
+    /// Number of entries currently in the peers gossip-routing map.
+    ///
+    /// Exposed for test assertions under the `internal-testing` feature gate.
+    #[cfg(any(test, feature = "internal-testing"))]
+    pub(crate) fn peers_map_len(&self) -> usize {
+        self.peers.read().len()
+    }
+
+    /// Number of entries currently in the per-peer replay filter.
+    ///
+    /// Exposed for test assertions under the `internal-testing` feature gate.
+    #[cfg(any(test, feature = "internal-testing"))]
+    pub(crate) fn replay_filter_len(&self) -> usize {
+        self.replay_filter.len()
+    }
+
+    /// Number of keys currently tracked in the tombstone-acknowledgment map.
+    ///
+    /// Exposed for test assertions under the `internal-testing` feature gate.
+    #[cfg(any(test, feature = "internal-testing"))]
+    pub(crate) fn tombstone_acks_len(&self) -> usize {
+        self.tombstone_acks.read().len()
+    }
+
+    /// Number of bulk dump tasks currently in flight across all peers.
+    ///
+    /// Exposed for test assertions under the `internal-testing` feature gate.
+    #[cfg(any(test, feature = "internal-testing"))]
+    pub(crate) fn bulk_dumps_in_flight_count(&self) -> usize {
+        self.bulk_dumps_in_flight.load(Ordering::Acquire)
     }
 
     /// This node's configured listen address, used by discovery to never decommission itself.
@@ -1274,6 +1414,19 @@ struct BulkInFlightGuard {
 impl Drop for BulkInFlightGuard {
     fn drop(&mut self) {
         self.set.write().remove(&self.peer);
+    }
+}
+
+/// RAII counter-decrement for the global concurrent-dump budget. Decrements the shared atomic on
+/// `Drop`, guaranteeing the slot is freed even if the task holding it panics or is aborted. See
+/// [`ReconcileEngine::try_claim_dump_slot`].
+struct BulkDumpCountGuard {
+    counter: Arc<AtomicUsize>,
+}
+
+impl Drop for BulkDumpCountGuard {
+    fn drop(&mut self) {
+        self.counter.fetch_sub(1, Ordering::Release);
     }
 }
 
@@ -1735,5 +1888,184 @@ mod socket_buffers {
         // only check the call path does not panic and yields a positive buffer.
         let buf = SockRef::from(&*eng.socket).recv_buffer_size().unwrap();
         assert!(buf > 0, "a socket always has a positive receive buffer");
+    }
+}
+
+#[cfg(test)]
+mod tombstone_ack_bounds {
+    use std::net::SocketAddr;
+
+    use bincode::{DefaultOptions, Serializer};
+    use serde::Serialize;
+
+    use super::Message;
+    use crate::auth;
+    use crate::clock::Timestamp;
+    use crate::reconcile_engine::{version_hash, ReconcileEngine};
+    use crate::reconcile_store::Config;
+
+    type Tombstoned = (Timestamp, Option<i32>);
+
+    async fn engine(addr: &str) -> ReconcileEngine<i32, Tombstoned> {
+        // Use a distinct port per module to avoid bind conflicts between parallel test runs.
+        let config = Config::default()
+            .with_port(0)
+            .with_listen_addr(addr.parse().unwrap());
+        ReconcileEngine::new(config).await.expect("bind failed")
+    }
+
+    fn ack_bytes(key: i32, version: u64) -> Vec<u8> {
+        let msg =
+            Message::Ack::<i32, Tombstoned, crate::reconcilable::ValueOnly<i32>>((key, version));
+        let mut buf = Vec::new();
+        msg.serialize(&mut Serializer::new(&mut buf, DefaultOptions::new()))
+            .unwrap();
+        buf
+    }
+
+    /// An ack for a key that does not exist locally must not create any entry in
+    /// `tombstone_acks`. Without the fix, `or_default()` allocates on every ack for
+    /// an arbitrary key, enabling unbounded growth.
+    #[tokio::test]
+    async fn ack_for_unknown_key_does_not_grow_tombstone_acks() {
+        let eng = engine("127.0.0.93").await;
+        let peer: SocketAddr = "127.0.0.94:9000".parse().unwrap();
+
+        let bytes = ack_bytes(42, 999);
+        let payload = auth::Authenticator::new(None, false)
+            .open(&bytes)
+            .expect("unauthenticated open");
+        let mut send_buf = Vec::new();
+        eng.handle_messages(payload, peer, &mut send_buf).await;
+
+        assert_eq!(
+            eng.tombstone_acks_len(),
+            0,
+            "ack for unknown key must not insert into tombstone_acks"
+        );
+    }
+
+    /// An ack for a key that exists locally but is a *live* (non-tombstone) value must
+    /// likewise be dropped.
+    #[tokio::test]
+    async fn ack_for_live_key_does_not_grow_tombstone_acks() {
+        let eng = engine("127.0.0.95").await;
+        let key = 10;
+        // Insert a live value (Some(_) = not a tombstone).
+        eng.just_insert(key, (Timestamp::new(1, 0, 0), Some(42)));
+
+        let peer: SocketAddr = "127.0.0.96:9000".parse().unwrap();
+        let bytes = ack_bytes(key, 123);
+        let payload = auth::Authenticator::new(None, false)
+            .open(&bytes)
+            .expect("unauthenticated open");
+        let mut send_buf = Vec::new();
+        eng.handle_messages(payload, peer, &mut send_buf).await;
+
+        assert_eq!(
+            eng.tombstone_acks_len(),
+            0,
+            "ack for a live (non-tombstone) key must not insert into tombstone_acks"
+        );
+    }
+
+    /// An ack for a key that IS a local tombstone must be recorded normally; the
+    /// decommission test verifies tombstone GC still completes.
+    #[tokio::test]
+    async fn ack_for_local_tombstone_is_recorded() {
+        let eng = engine("127.0.0.97").await;
+        let key = 20;
+        let tombstone: Tombstoned = (Timestamp::new(2, 0, 0), None);
+        let version = version_hash(&tombstone);
+        eng.just_insert(key, tombstone);
+
+        let peer: SocketAddr = "127.0.0.98:9000".parse().unwrap();
+        let bytes = ack_bytes(key, version);
+        let payload = auth::Authenticator::new(None, false)
+            .open(&bytes)
+            .expect("unauthenticated open");
+        let mut send_buf = Vec::new();
+        eng.handle_messages(payload, peer, &mut send_buf).await;
+
+        assert_eq!(
+            eng.tombstone_acks_len(),
+            1,
+            "ack for a local tombstone must be recorded in tombstone_acks"
+        );
+
+        // Causal-stability GC still completes: with one member who has acked and no
+        // other members, the tombstone is stable and bookkeeping is cleared on forget.
+        eng.members.write().insert(peer.ip());
+        assert!(
+            eng.is_tombstone_stable(&key, version),
+            "tombstone should be stable after the only member has acked"
+        );
+        eng.forget_tombstone(&key);
+        assert_eq!(
+            eng.tombstone_acks_len(),
+            0,
+            "forget_tombstone must clear tombstone_acks for the key"
+        );
+    }
+}
+
+#[cfg(test)]
+mod dump_budget {
+    use crate::reconcile_store::Config;
+
+    /// Default budget is 4, matching DEFAULT_MAX_CONCURRENT_BULK_DUMPS.
+    #[test]
+    fn default_budget_is_four() {
+        assert_eq!(Config::default().max_concurrent_bulk_dumps, 4);
+    }
+
+    /// `with_max_concurrent_bulk_dumps` overrides the value.
+    #[test]
+    fn builder_sets_budget() {
+        let cfg = Config::default().with_max_concurrent_bulk_dumps(1);
+        assert_eq!(cfg.max_concurrent_bulk_dumps, 1);
+    }
+
+    /// With a budget of 1, claiming a second slot before the first is released must fail.
+    /// After the first slot is dropped its count returns to zero and a fresh claim succeeds.
+    #[tokio::test]
+    async fn budget_guard_limits_and_releases_slots() {
+        use crate::clock::Timestamp;
+        use crate::reconcile_engine::ReconcileEngine;
+
+        type Tombstoned = (Timestamp, Option<i32>);
+
+        let config = Config::default()
+            .with_port(0)
+            .with_listen_addr("127.0.0.99".parse().unwrap())
+            .with_max_concurrent_bulk_dumps(1);
+        let eng = ReconcileEngine::<i32, Tombstoned>::new(config)
+            .await
+            .expect("bind failed");
+
+        let peer_a: std::net::SocketAddr = "127.0.0.100:9001".parse().unwrap();
+        let peer_b: std::net::SocketAddr = "127.0.0.101:9001".parse().unwrap();
+
+        // First claim succeeds.
+        let slot_a = eng.try_claim_dump_slot(peer_a);
+        assert!(slot_a.is_some(), "first slot must be available");
+        assert_eq!(eng.bulk_dumps_in_flight_count(), 1);
+
+        // Second claim (different peer) is rejected — budget exhausted.
+        let slot_b = eng.try_claim_dump_slot(peer_b);
+        assert!(slot_b.is_none(), "second slot must be rejected at budget 1");
+        assert_eq!(eng.bulk_dumps_in_flight_count(), 1);
+
+        // Releasing the first slot (drop) frees it for the next caller.
+        drop(slot_a);
+        assert_eq!(eng.bulk_dumps_in_flight_count(), 0);
+
+        // Now peer_b's retry succeeds.
+        let slot_b_retry = eng.try_claim_dump_slot(peer_b);
+        assert!(
+            slot_b_retry.is_some(),
+            "slot must be available after release"
+        );
+        drop(slot_b_retry);
     }
 }

--- a/src/reconcile_engine.rs
+++ b/src/reconcile_engine.rs
@@ -726,16 +726,10 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
                         match self.authenticator.open(&recv_buf[..size]) {
                             Some(payload) => {
                                 let sender = peer.ip();
-                                // Per-peer cap check: if this sender is not yet tracked (not a
-                                // member) and the membership set is at capacity, drop the datagram
-                                // before allocating any per-sender state (replay filter entry,
-                                // peers map slot, or membership slot). Authenticated datagrams are
-                                // verified first (above), so this gate cannot be triggered by a
-                                // forged source address in authenticated mode.
-                                //
-                                // The check is intentionally placed *before* the replay filter so
-                                // that no replay-filter entry is created for a capped-out sender.
-                                // Known senders (already in `members`) bypass the cap.
+                                // If this sender is new and membership is at capacity, drop before
+                                // allocating any per-sender state (replay filter, peers map,
+                                // membership). Placed ahead of the replay filter so a capped-out
+                                // sender never gets an entry there either. Known senders bypass it.
                                 let is_known = self.members.read().contains(&sender);
                                 if !is_known {
                                     let current_len = self.members.read().len();
@@ -951,16 +945,11 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
                 let map_guard = self.map.read();
                 let mut guard = self.tombstone_acks.write();
                 for (key, version) in acks {
-                    // Accept an ack only for a key we locally hold as a tombstone. Acks for
-                    // never-existent or non-tombstone keys are dropped here so they cannot
-                    // accumulate in `tombstone_acks` without bound.
-                    //
-                    // Ordering hazard: this gate cannot tell "a key we will never hold" from
-                    // "a key we don't hold YET". In a cluster of three or more nodes an ack
-                    // can arrive before the deletion it acknowledges (the acking peer may have
-                    // learned the deletion via a different gossip edge), and a dropped ack is
-                    // not re-delivered. Any future change to causal-stability GC must account
-                    // for this rather than rely on early acks being retained.
+                    // Only accept an ack for a key we locally hold as a tombstone, so acks for
+                    // never-existent or non-tombstone keys cannot accumulate unbounded. Ordering
+                    // hazard: at three nodes or more an ack can arrive before its deletion (via a
+                    // different gossip edge) and is dropped, not re-delivered — future
+                    // causal-stability GC changes must not assume early acks are retained.
                     let local_tombstone = map_guard.get(&key).filter(|v| v.is_tombstone());
                     let Some(local_v) = local_tombstone else {
                         trace!(

--- a/src/reconcile_store.rs
+++ b/src/reconcile_store.rs
@@ -860,35 +860,22 @@ pub struct Config {
     pub freshness_window: Duration,
     /// Maximum number of distinct remote peers (members) this node will track.
     ///
-    /// When the membership set is at capacity, datagrams from completely unknown senders are
-    /// dropped **before** any per-sender state (membership, gossip-peer record, or replay-filter
-    /// entry) is allocated. Senders that are already tracked are unaffected at cap, and calling
-    /// [`forget_peer`](crate::ReconcileStore::forget_peer) on a member immediately frees its slot.
+    /// At capacity, a datagram from a completely unknown sender is dropped before any per-sender
+    /// state is allocated; already-tracked senders are unaffected, and
+    /// [`forget_peer`](crate::ReconcileStore::forget_peer) frees a slot immediately. Defence in
+    /// depth for unauthenticated deployments, a hard ceiling for authenticated ones. Default 1024
+    /// — see [`with_max_peers`](Config::with_max_peers).
     ///
-    /// The cap is defence-in-depth for unauthenticated deployments (where any spoofed source
-    /// address would otherwise grow the maps without bound), and a hard ceiling for authenticated
-    /// ones. The default of 1024 is generous for most clusters; raise it if your cluster has more
-    /// active members. See [`with_max_peers`](Config::with_max_peers).
-    ///
-    /// The cap applies to *all* unknown senders, including read-only mirrors, which never become
-    /// members themselves: while the membership set is saturated, a newly connecting mirror is
-    /// also rejected and cannot sync until a member slot frees up. Size the cap for members
-    /// *plus* expected mirrors.
+    /// Applies to read-only mirrors too, which never become members: a saturated set also blocks
+    /// new mirrors from syncing. Size for members *plus* expected mirrors.
     pub max_peers: usize,
     /// Maximum number of concurrently active paced bulk dumps across all peers.
     ///
-    /// A paced bulk dump holds a full snapshot `Vec` of the differing range (potentially the
-    /// whole dataset) for the duration of the transfer. Without a global cap, M peers diffing
-    /// simultaneously would each hold such a snapshot — M × dataset memory plus M × egress
-    /// at [`bulk_send_rate`](Self::bulk_send_rate). This field limits the total number of
-    /// in-flight dump tasks regardless of peer count.
-    ///
-    /// When the budget is exhausted a new dump is skipped **before** the snapshot Vec is
-    /// allocated; the protocol is retry-driven, so the requesting peer's next diff round
-    /// re-triggers the dump once a slot is free.
-    ///
-    /// Defaults to 4. Raise if your cluster has many simultaneous cold peers and the host has
-    /// sufficient memory; lower for tighter memory caps. See
+    /// A bulk dump holds a full snapshot `Vec` of the differing range — potentially the whole
+    /// dataset — for the transfer's duration, so M simultaneous cold peers would otherwise cost
+    /// M × dataset memory. Exhausting the budget skips a new dump before the snapshot is
+    /// allocated; the protocol is retry-driven, so the peer's next diff round retries once a slot
+    /// frees. Default 4 — see
     /// [`with_max_concurrent_bulk_dumps`](Config::with_max_concurrent_bulk_dumps).
     pub max_concurrent_bulk_dumps: usize,
 }
@@ -1048,12 +1035,7 @@ impl Config {
         self
     }
 
-    /// Set the maximum number of concurrently active paced bulk dumps (default 4).
-    ///
-    /// When the budget is exhausted a new dump is skipped before allocating its snapshot Vec;
-    /// the protocol is retry-driven, so the peer re-triggers the dump on its next diff round once
-    /// a slot is free.
-    /// See [`max_concurrent_bulk_dumps`](Config::max_concurrent_bulk_dumps) for the full semantics.
+    /// Set [`max_concurrent_bulk_dumps`](Config::max_concurrent_bulk_dumps) (default 4).
     pub fn with_max_concurrent_bulk_dumps(mut self, max: usize) -> Self {
         self.max_concurrent_bulk_dumps = max;
         self

--- a/src/reconcile_store.rs
+++ b/src/reconcile_store.rs
@@ -58,6 +58,19 @@ const DEFAULT_BULK_SEND_RATE: usize = 32 * 1024 * 1024;
 /// before the application ever sees them.
 const DEFAULT_SOCKET_BUFFER_SIZE: usize = 8 * 1024 * 1024;
 
+/// Default cap on the number of distinct tracked peers (see [`Config::max_peers`]).
+///
+/// 1024 is generous for a gossip cluster that typically spans tens to a few hundred nodes;
+/// raise the limit via [`Config::with_max_peers`] for larger deployments.
+const DEFAULT_MAX_PEERS: usize = 1024;
+
+/// Default cap on the number of concurrently active paced bulk dumps (see
+/// [`Config::max_concurrent_bulk_dumps`]).
+///
+/// 4 is a conservative default that bounds total in-flight snapshot memory without
+/// starving small clusters; raise via [`Config::with_max_concurrent_bulk_dumps`].
+const DEFAULT_MAX_CONCURRENT_BULK_DUMPS: usize = 4;
+
 /// Core service wrapping a key-value map to enable reconciliation between different instances over a network.
 ///
 /// The store also keeps track of the addresses of other instances.
@@ -488,6 +501,38 @@ impl<K: Key, V: Value> ReconcileStore<K, V> {
         self.engine.members_snapshot()
     }
 
+    /// Number of entries in the peers gossip-routing map.
+    ///
+    /// Exposed for integration-test assertions under the `internal-testing` feature gate.
+    #[cfg(any(test, feature = "internal-testing"))]
+    pub fn peers_map_len(&self) -> usize {
+        self.engine.peers_map_len()
+    }
+
+    /// Number of entries in the per-peer replay filter.
+    ///
+    /// Exposed for integration-test assertions under the `internal-testing` feature gate.
+    #[cfg(any(test, feature = "internal-testing"))]
+    pub fn replay_filter_len(&self) -> usize {
+        self.engine.replay_filter_len()
+    }
+
+    /// Number of keys currently tracked in the tombstone-acknowledgment map.
+    ///
+    /// Exposed for integration-test assertions under the `internal-testing` feature gate.
+    #[cfg(any(test, feature = "internal-testing"))]
+    pub fn tombstone_acks_len(&self) -> usize {
+        self.engine.tombstone_acks_len()
+    }
+
+    /// Number of bulk dump tasks currently in flight across all peers.
+    ///
+    /// Exposed for integration-test assertions under the `internal-testing` feature gate.
+    #[cfg(any(test, feature = "internal-testing"))]
+    pub fn bulk_dumps_in_flight_count(&self) -> usize {
+        self.engine.bulk_dumps_in_flight_count()
+    }
+
     /// (runtime) Replace the declared geographical networks, retuning the gossip topology **without
     /// recreating the node**. The local network is re-derived automatically (whichever new net
     /// contains the listen address). See [`Config::nets`].
@@ -813,6 +858,39 @@ pub struct Config {
     /// dropped as a replay. Authenticated modes only; ignored unkeyed. Default 5 minutes — see
     /// [`with_freshness_window`](Config::with_freshness_window).
     pub freshness_window: Duration,
+    /// Maximum number of distinct remote peers (members) this node will track.
+    ///
+    /// When the membership set is at capacity, datagrams from completely unknown senders are
+    /// dropped **before** any per-sender state (membership, gossip-peer record, or replay-filter
+    /// entry) is allocated. Senders that are already tracked are unaffected at cap, and calling
+    /// [`forget_peer`](crate::ReconcileStore::forget_peer) on a member immediately frees its slot.
+    ///
+    /// The cap is defence-in-depth for unauthenticated deployments (where any spoofed source
+    /// address would otherwise grow the maps without bound), and a hard ceiling for authenticated
+    /// ones. The default of 1024 is generous for most clusters; raise it if your cluster has more
+    /// active members. See [`with_max_peers`](Config::with_max_peers).
+    ///
+    /// The cap applies to *all* unknown senders, including read-only mirrors, which never become
+    /// members themselves: while the membership set is saturated, a newly connecting mirror is
+    /// also rejected and cannot sync until a member slot frees up. Size the cap for members
+    /// *plus* expected mirrors.
+    pub max_peers: usize,
+    /// Maximum number of concurrently active paced bulk dumps across all peers.
+    ///
+    /// A paced bulk dump holds a full snapshot `Vec` of the differing range (potentially the
+    /// whole dataset) for the duration of the transfer. Without a global cap, M peers diffing
+    /// simultaneously would each hold such a snapshot — M × dataset memory plus M × egress
+    /// at [`bulk_send_rate`](Self::bulk_send_rate). This field limits the total number of
+    /// in-flight dump tasks regardless of peer count.
+    ///
+    /// When the budget is exhausted a new dump is skipped **before** the snapshot Vec is
+    /// allocated; the protocol is retry-driven, so the requesting peer's next diff round
+    /// re-triggers the dump once a slot is free.
+    ///
+    /// Defaults to 4. Raise if your cluster has many simultaneous cold peers and the host has
+    /// sufficient memory; lower for tighter memory caps. See
+    /// [`with_max_concurrent_bulk_dumps`](Config::with_max_concurrent_bulk_dumps).
+    pub max_concurrent_bulk_dumps: usize,
 }
 impl Default for Config {
     fn default() -> Self {
@@ -830,6 +908,8 @@ impl Default for Config {
             recv_buffer_size: Some(DEFAULT_SOCKET_BUFFER_SIZE),
             send_buffer_size: Some(DEFAULT_SOCKET_BUFFER_SIZE),
             freshness_window: crate::replay::FRESHNESS_WINDOW_DEFAULT,
+            max_peers: DEFAULT_MAX_PEERS,
+            max_concurrent_bulk_dumps: DEFAULT_MAX_CONCURRENT_BULK_DUMPS,
         }
     }
 }
@@ -958,6 +1038,27 @@ impl Config {
         self
     }
 
+    /// Set the maximum number of distinct peers this node will track (default 1024).
+    ///
+    /// Datagrams from unknown senders are silently dropped when the membership set is at capacity,
+    /// before any per-sender state is created. Already-tracked peers are unaffected.
+    /// See [`max_peers`](Config::max_peers) for the full semantics.
+    pub fn with_max_peers(mut self, max: usize) -> Self {
+        self.max_peers = max;
+        self
+    }
+
+    /// Set the maximum number of concurrently active paced bulk dumps (default 4).
+    ///
+    /// When the budget is exhausted a new dump is skipped before allocating its snapshot Vec;
+    /// the protocol is retry-driven, so the peer re-triggers the dump on its next diff round once
+    /// a slot is free.
+    /// See [`max_concurrent_bulk_dumps`](Config::max_concurrent_bulk_dumps) for the full semantics.
+    pub fn with_max_concurrent_bulk_dumps(mut self, max: usize) -> Self {
+        self.max_concurrent_bulk_dumps = max;
+        self
+    }
+
     /// Encrypt datagram payloads with XChaCha20-Poly1305, upgrading the keyed protocol from
     /// authentication-only to authenticated **encryption**.
     ///
@@ -1010,6 +1111,8 @@ mod reconcile_store_tests {
             recv_buffer_size: Some(super::DEFAULT_SOCKET_BUFFER_SIZE),
             send_buffer_size: Some(super::DEFAULT_SOCKET_BUFFER_SIZE),
             freshness_window: crate::replay::FRESHNESS_WINDOW_DEFAULT,
+            max_peers: super::DEFAULT_MAX_PEERS,
+            max_concurrent_bulk_dumps: super::DEFAULT_MAX_CONCURRENT_BULK_DUMPS,
         }
     }
 
@@ -1452,5 +1555,274 @@ mod reconcile_store_tests {
             std::io::ErrorKind::AddrInUse,
             "bind failure should surface as AddrInUse, got {err:?}"
         );
+    }
+
+    // ── per-peer cap ──────────────────────────────────────────────────────────
+
+    /// The default cap must be 1024.
+    #[test]
+    fn peer_cap_default_is_1024() {
+        assert_eq!(Config::default().max_peers, 1024);
+    }
+
+    /// Helper: craft a raw bincode payload containing a single `ComparisonItem` drawn from an empty
+    /// tree, suitable for sending to an unauthenticated store.  The engine deserializes any
+    /// `ComparisonItem` as a dated message, so `spoke_dated` becomes `true` and the receive path
+    /// would add the sender to `members` — unless the cap fires first.
+    fn dated_comparison_payload() -> Vec<u8> {
+        use crate::proto;
+        use crate::reconcile_engine::Message;
+        use crate::HRTree;
+        use bincode::{DefaultOptions, Serializer};
+        use serde::Serialize as _;
+
+        let tree = HRTree::<i32, (crate::clock::Timestamp, Option<i32>)>::new();
+        let segments = proto::start_diff(&tree);
+        let mut buf = Vec::new();
+        for seg in segments {
+            Message::<
+                i32,
+                (crate::clock::Timestamp, Option<i32>),
+                (crate::clock::Timestamp, Option<i32>),
+            >::ComparisonItem(seg)
+            .serialize(&mut Serializer::new(&mut buf, DefaultOptions::new()))
+            .expect("serializing ComparisonItem into a Vec cannot fail");
+        }
+        buf
+    }
+
+    /// When the membership set is at capacity, datagrams from a completely unknown sender are
+    /// dropped silently: the sender is not added to `members`, `peers`, or the replay filter.
+    /// Known members (already in `members`) are unaffected at cap.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn peer_cap_blocks_unknown_sender_at_capacity() {
+        let port = 9801u16;
+        let target_addr: std::net::IpAddr = "127.0.0.180".parse().unwrap();
+        let peer1: std::net::IpAddr = "127.0.0.181".parse().unwrap();
+        let peer2: std::net::IpAddr = "127.0.0.182".parse().unwrap();
+        let newcomer: std::net::IpAddr = "127.0.0.183".parse().unwrap();
+
+        let config = Config::default()
+            .with_port(port)
+            .with_listen_addr(target_addr)
+            .with_net("127.0.0.180/30".parse().unwrap())
+            .with_max_peers(2);
+
+        let store = ReconcileStore::<i32, i32>::new(config)
+            .await
+            .expect("bind failed");
+
+        // Seed two known members directly (simulates two peers that already completed a
+        // dated handshake with this store before the test window).
+        store.engine.members.write().insert(peer1);
+        store.engine.members.write().insert(peer2);
+
+        let task = tokio::spawn(store.clone().run());
+
+        // Give the run loop time to enter its receive wait.
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        // Send a valid dated payload from the newcomer's IP several times to ensure at least one
+        // reaches the receive loop; all must be dropped by the cap.
+        let payload = dated_comparison_payload();
+        let sender = tokio::net::UdpSocket::bind(std::net::SocketAddr::new(newcomer, 0))
+            .await
+            .expect("bind sender");
+        for _ in 0..5 {
+            let _ = sender
+                .send_to(&payload, std::net::SocketAddr::new(target_addr, port))
+                .await;
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+
+        // Give the receive loop time to process any remaining datagrams.
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+        // The newcomer must not appear in any map regardless of how many datagrams arrived.
+        assert!(
+            !store.engine.members.read().contains(&newcomer),
+            "capped-out sender must not be added to members"
+        );
+        assert!(
+            !store.engine.peers.read().contains_key(&newcomer),
+            "capped-out sender must not be added to peers"
+        );
+
+        task.abort();
+    }
+
+    /// A sender that is already a member continues to be processed normally when the cap is reached.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn peer_cap_allows_known_member_at_capacity() {
+        let port = 9802u16;
+        let target_addr: std::net::IpAddr = "127.0.0.184".parse().unwrap();
+        let peer1: std::net::IpAddr = "127.0.0.185".parse().unwrap();
+        let peer2: std::net::IpAddr = "127.0.0.186".parse().unwrap();
+
+        let config = Config::default()
+            .with_port(port)
+            .with_listen_addr(target_addr)
+            .with_net("127.0.0.184/30".parse().unwrap())
+            .with_max_peers(2);
+
+        let store = ReconcileStore::<i32, i32>::new(config)
+            .await
+            .expect("bind failed");
+
+        store.engine.members.write().insert(peer1);
+        store.engine.members.write().insert(peer2);
+
+        let task = tokio::spawn(store.clone().run());
+
+        // Give the run loop time to enter its receive wait.
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        // Send a valid dated payload FROM a known member (peer1), retrying until accepted.
+        let payload = dated_comparison_payload();
+        let sender = tokio::net::UdpSocket::bind(std::net::SocketAddr::new(peer1, 0))
+            .await
+            .expect("bind sender");
+
+        let mut peers_refreshed = false;
+        for _ in 0..50 {
+            let _ = sender
+                .send_to(&payload, std::net::SocketAddr::new(target_addr, port))
+                .await;
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+            if store.engine.peers.read().contains_key(&peer1) {
+                peers_refreshed = true;
+                break;
+            }
+        }
+
+        // Known member must still be present (not evicted).
+        assert!(
+            store.engine.members.read().contains(&peer1),
+            "known member must not be evicted by the cap"
+        );
+        // The peers entry is (re-)inserted when the datagram is processed.
+        assert!(
+            peers_refreshed,
+            "known member's peers entry must be refreshed normally"
+        );
+
+        task.abort();
+    }
+
+    /// Decommissioning a member frees its slot: the engine's membership set shrinks and the
+    /// cap check allows a new sender through once a slot becomes available.
+    ///
+    /// This test verifies the state invariants directly (without the network path, which is
+    /// already exercised by [`peer_cap_blocks_unknown_sender_at_capacity`]).
+    #[tokio::test]
+    async fn decommission_frees_peer_cap_slot() {
+        let peer1: std::net::IpAddr = "127.1.0.1".parse().unwrap();
+        let peer2: std::net::IpAddr = "127.1.0.2".parse().unwrap();
+        let newcomer: std::net::IpAddr = "127.1.0.3".parse().unwrap();
+
+        let config = Config::default()
+            .with_port(0)
+            .with_listen_addr("127.0.0.1".parse().unwrap())
+            .with_max_peers(2);
+
+        let store = ReconcileStore::<i32, i32>::new(config)
+            .await
+            .expect("bind failed");
+
+        // Seed two members (simulates two peers that completed a dated exchange).
+        store.engine.members.write().insert(peer1);
+        store.engine.members.write().insert(peer2);
+        assert_eq!(store.engine.members.read().len(), 2);
+
+        // At cap: a newcomer would be blocked.
+        assert!(
+            store.engine.members.read().len() >= 2,
+            "precondition: at cap"
+        );
+        assert!(
+            !store.engine.members.read().contains(&newcomer),
+            "precondition: newcomer not yet in members"
+        );
+
+        // Decommission peer2, freeing one slot.
+        store.forget_peer(peer2);
+        assert_eq!(
+            store.engine.members.read().len(),
+            1,
+            "one member after decommission"
+        );
+        assert!(
+            !store.engine.members.read().contains(&peer2),
+            "peer2 must be removed from members"
+        );
+        // The peers gossip-routing entry must also be gone (so capacity is visible to the
+        // cap check path, and decommission does not leave a ghost entry in the peers map).
+        assert!(
+            !store.engine.peers.read().contains_key(&peer2),
+            "peer2 must be removed from peers by decommission"
+        );
+
+        // After decommission: members.len() == 1 < max_peers == 2.
+        // The cap check allows the newcomer through: current_len < 2.
+        let current_len = store.engine.members.read().len();
+        let is_known = store.engine.members.read().contains(&newcomer);
+        assert!(
+            is_known || current_len < 2,
+            "newcomer must not be capped out (members.len={current_len}) after decommission freed a slot"
+        );
+    }
+
+    /// In authenticated mode, datagrams from a capped-out sender must not create a replay-filter
+    /// entry.  The cap check runs before `replay_filter.check_and_record` for unknown senders.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn peer_cap_no_replay_entry_for_capped_sender() {
+        let port = 9804u16;
+        let target_addr: std::net::IpAddr = "127.0.0.192".parse().unwrap();
+        let peer1: std::net::IpAddr = "127.0.0.193".parse().unwrap();
+        let peer2: std::net::IpAddr = "127.0.0.194".parse().unwrap();
+        let newcomer: std::net::IpAddr = "127.0.0.195".parse().unwrap();
+        let cluster_key = [0x55u8; 32];
+
+        let config = Config::default()
+            .with_port(port)
+            .with_listen_addr(target_addr)
+            .with_net("127.0.0.192/30".parse().unwrap())
+            .with_cluster_key(cluster_key)
+            .with_max_peers(2);
+
+        let store = ReconcileStore::<i32, i32>::new(config)
+            .await
+            .expect("bind failed");
+
+        store.engine.members.write().insert(peer1);
+        store.engine.members.write().insert(peer2);
+
+        let task = tokio::spawn(store.clone().run());
+
+        // Craft a sealed (authenticated) dated datagram from the newcomer's IP.
+        let payload = dated_comparison_payload();
+        let counter = crate::replay::SenderCounter::new();
+        let sealed = crate::auth::Authenticator::new(Some(cluster_key), false)
+            .seal(counter.next_seq(), counter.next_stamp(), &payload)
+            .expect("enabled authenticator always seals");
+
+        let sender = tokio::net::UdpSocket::bind(std::net::SocketAddr::new(newcomer, 0))
+            .await
+            .expect("bind sender");
+        sender
+            .send_to(&sealed, std::net::SocketAddr::new(target_addr, port))
+            .await
+            .expect("send");
+
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+        // The cap fired before the replay filter: no replay entry must have been created.
+        assert_eq!(
+            store.engine.replay_filter_len(),
+            0,
+            "no replay-filter entry must be created for a capped-out sender"
+        );
+
+        task.abort();
     }
 }

--- a/src/replay.rs
+++ b/src/replay.rs
@@ -313,6 +313,14 @@ impl ReplayFilter {
         }
     }
 
+    /// Number of peers currently tracked by the filter.
+    ///
+    /// Exposed for test assertions under the `internal-testing` feature gate.
+    #[cfg(any(test, feature = "internal-testing"))]
+    pub(crate) fn len(&self) -> usize {
+        self.peers.lock().len()
+    }
+
     /// Remove the replay state for a peer, freeing its memory immediately.
     ///
     /// This is an explicit escape hatch for tests. Production code does not call this — per-peer


### PR DESCRIPTION
**Problem.** Three unbounded-resource vectors (#150 rescope + #200): (1) any sender — in unauthenticated mode, any *spoofed source address* — created entries in the peers/members maps that only explicit decommission reclaimed; (2) `Ack((key, version))` was recorded via `entry(key).or_default()` with no check that the key exists locally, so a key-holding insider could flood `tombstone_acks` with millions of synthetic keys retained forever; (3) bulk dumps were guarded per-peer only, so M cold (or spoofed) peers diffing concurrently held M full-dataset `Vec` snapshots in memory at once.

**Fixes** (defaults user-approved):
- **`Config::max_peers`** (default 1024, `with_max_peers`): while membership is at cap, datagrams from unknown senders are dropped **before any per-sender state allocates** — receive-path ordering is authentication → cap → replay-filter → message handling → state creation, in both the engine and the mirror. **Reject-new over eviction, deliberately**: eviction policies let an identity-churning attacker flush legitimate peers. Known senders are unaffected at cap; `forget_peer` now clears `members`, `peers`, and `tombstone_acks`, freeing the slot immediately.
- **Ack admission gate**: acks are recorded only for keys locally held as tombstones, bounding `tombstone_acks` to live tombstones × members. The gate's known ordering hazard (an ack arriving before its deletion propagates locally is dropped and not re-delivered — relevant only at ≥3 nodes) is documented in-code for future GC work; see the review note below.
- **`Config::max_concurrent_bulk_dumps`** (default 4, builder): a global budget enforced *before* the snapshot allocates, via an atomic claim with rollback and RAII slot guards that release on completion, panic, or abort (mirroring the existing per-peer `bulk_in_flight` idiom). At budget the dump is skipped; the retry-driven protocol re-triggers it when a slot frees. Worst-case dump memory is budget × dataset regardless of peer count. Chunked/lazy snapshotting is a separate future refactor.

**Review provenance.** Implemented and adversarially reviewed (verdict: approve-with-fixes; both fixes were documentation and are applied). The review verified by code-walk and experiment: every peers/members insertion site is cap-gated against attacker-reachable paths (seed/discovery inserts are operator-controlled, by design); the receive loop is single-writer so the cap cannot be overshot by racing datagrams; the ack gate holds the map read-lock across check+insert so a tombstone cannot be GC'd mid-ack (no recurrence of the leak in miniature, no new ABBA lock cycle); dump-slot accounting cannot leak or double-release; capped-out senders allocate no replay-filter entry, and the replay map's worst case is ≈ `max_peers` + recently-decommissioned-within-freshness-window.

**Notable side discovery (pre-existing, NOT caused by this change):** the reviewer demonstrated that 3-node tombstone GC already fails to converge on the base commit (acks recorded but stability never reached, full-mesh and line topologies alike; 2-node GC converges fine). This change preserves all behavior that works on the base. Filed separately with the experiment details.

Closes #200. Closes #150.

**Stack** — base: `claude/p1-1-antireplay` (#214). Merge after #214.

https://claude.ai/code/session_01BaajsC6gEk1v7Y55dA5cPG

---
_Generated by [Claude Code](https://claude.ai/code/session_01BaajsC6gEk1v7Y55dA5cPG)_