### PR TITLE
feat(discovery): wall-time floor guards DNS-driven decommission while tombstone acks are pending

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,4 +158,52 @@ pub mod testing {
     {
         store.members_snapshot()
     }
+
+    /// Number of entries in the peers gossip-routing map.
+    ///
+    /// Exposed for integration-test assertions so the peer-cap tests can verify that no new
+    /// gossip-peer record is created for a capped-out sender.
+    pub fn peers_map_len<K, V>(store: &crate::ReconcileStore<K, V>) -> usize
+    where
+        K: crate::bounds::Key,
+        V: crate::bounds::Value,
+    {
+        store.peers_map_len()
+    }
+
+    /// Number of entries in the per-peer replay filter.
+    ///
+    /// Exposed for integration-test assertions so the peer-cap tests can verify that no new
+    /// replay-filter entry is created for a capped-out sender.
+    pub fn replay_filter_len<K, V>(store: &crate::ReconcileStore<K, V>) -> usize
+    where
+        K: crate::bounds::Key,
+        V: crate::bounds::Value,
+    {
+        store.replay_filter_len()
+    }
+
+    /// Number of keys currently tracked in the tombstone-acknowledgment map.
+    ///
+    /// Exposed for integration-test assertions so tests can verify that acks for
+    /// non-tombstone keys are dropped without growing bookkeeping.
+    pub fn tombstone_acks_len<K, V>(store: &crate::ReconcileStore<K, V>) -> usize
+    where
+        K: crate::bounds::Key,
+        V: crate::bounds::Value,
+    {
+        store.tombstone_acks_len()
+    }
+
+    /// Number of bulk dump tasks currently in flight across all peers.
+    ///
+    /// Exposed for integration-test assertions so tests can verify that the global dump
+    /// budget is respected and slots are released after completion.
+    pub fn bulk_dumps_in_flight_count<K, V>(store: &crate::ReconcileStore<K, V>) -> usize
+    where
+        K: crate::bounds::Key,
+        V: crate::bounds::Value,
+    {
+        store.bulk_dumps_in_flight_count()
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -171,6 +171,19 @@ pub mod testing {
         store.peers_map_len()
     }
 
+    /// Whether `peer` is currently in the gossip-routing peers map.
+    ///
+    /// Exposed so discovery integration tests can deterministically confirm that at least one
+    /// discovery round has seeded a peer before mutating the scripted resolver — eliminating the
+    /// `seen_ever` race that caused intermittent failures in the floor tests.
+    pub fn peers_contains<K, V>(store: &crate::ReconcileStore<K, V>, peer: std::net::IpAddr) -> bool
+    where
+        K: crate::bounds::Key,
+        V: crate::bounds::Value,
+    {
+        store.peers_contains(peer)
+    }
+
     /// Number of entries in the per-peer replay filter.
     ///
     /// Exposed for integration-test assertions so the peer-cap tests can verify that no new

--- a/src/mirror.rs
+++ b/src/mirror.rs
@@ -108,6 +108,10 @@ pub struct ReconcileMirror<K, V> {
     replay_filter: Arc<replay::ReplayFilter>,
     /// Invoked just before each inbound value is integrated, so callers can be notified of changes.
     on_update: Arc<RwLock<OnUpdateCallback<K, V>>>,
+    /// Hard cap on the number of dated-cluster peers the mirror tracks. Datagrams from unknown
+    /// senders are dropped before any per-sender state is allocated when the peers map reaches
+    /// this size. Sourced from [`Config::max_peers`].
+    max_peers: usize,
 }
 
 impl<K, V> Clone for ReconcileMirror<K, V> {
@@ -123,6 +127,7 @@ impl<K, V> Clone for ReconcileMirror<K, V> {
             sender_counter: self.sender_counter.clone(),
             replay_filter: self.replay_filter.clone(),
             on_update: self.on_update.clone(),
+            max_peers: self.max_peers,
         }
     }
 }
@@ -172,6 +177,7 @@ impl<K: Key, V: Clone + Debug + DeserializeOwned + Hash + Send + Serialize + Syn
             sender_counter: Arc::new(replay::SenderCounter::new()),
             replay_filter: Arc::new(replay::ReplayFilter::new(config.freshness_window)),
             on_update: Arc::new(RwLock::new(Box::new(|_, _| {}))),
+            max_peers: config.max_peers,
         })
     }
 
@@ -382,25 +388,41 @@ impl<K: Key, V: Clone + Debug + DeserializeOwned + Hash + Send + Serialize + Syn
                     } else {
                         match self.authenticator.open(&recv_buf[..size]) {
                             Some(payload) => {
-                                if self.authenticator.is_enabled() {
-                                    let sender = peer.ip();
-                                    if !self.replay_filter.check_and_record(
-                                        sender,
-                                        payload.seq,
-                                        payload.stamp,
-                                    ) {
+                                let sender = peer.ip();
+                                // Per-peer cap check: drop datagrams from unknown senders when the
+                                // peers map is at capacity, before any per-sender state is
+                                // allocated (peers slot or replay-filter entry).
+                                {
+                                    let guard = self.peers.read();
+                                    if !guard.contains_key(&sender) && guard.len() >= self.max_peers
+                                    {
                                         trace!(
-                                            "mirror dropped replayed datagram from {peer}: \
-                                             seq={} stamp={}",
-                                            payload.seq,
-                                            payload.stamp
+                                            "mirror dropped datagram from {peer}: peer cap \
+                                             reached ({}/{})",
+                                            guard.len(),
+                                            self.max_peers
                                         );
                                         continue;
                                     }
                                 }
+                                if self.authenticator.is_enabled()
+                                    && !self.replay_filter.check_and_record(
+                                        sender,
+                                        payload.seq,
+                                        payload.stamp,
+                                    )
+                                {
+                                    trace!(
+                                        "mirror dropped replayed datagram from {peer}: \
+                                         seq={} stamp={}",
+                                        payload.seq,
+                                        payload.stamp
+                                    );
+                                    continue;
+                                }
                                 self.handle_messages(payload, peer, &mut send_buf).await;
                                 // Record the sender so we keep gossiping value-only diffs to it.
-                                self.peers.write().insert(peer.ip(), Instant::now());
+                                self.peers.write().insert(sender, Instant::now());
                             }
                             None => trace!(
                                 "mirror dropped datagram from {peer}: missing or invalid MAC"

--- a/src/reconcile_engine.rs
+++ b/src/reconcile_engine.rs
@@ -184,6 +184,14 @@ pub(crate) struct Inner<K, V: Projectable> {
     /// Entries are inserted before a dump is spawned and removed (via an RAII guard, so it survives a
     /// panic in the send task) when it finishes.
     bulk_in_flight: Arc<RwLock<HashSet<SocketAddr>>>,
+    /// Count of bulk dump tasks currently in flight across all peers. When this reaches
+    /// [`max_concurrent_bulk_dumps`](Self::max_concurrent_bulk_dumps), new dumps are skipped before
+    /// allocating their snapshot Vec; the protocol is retry-driven, so the requesting peer's next
+    /// diff round re-triggers the dump once a slot is free. Decremented by an RAII guard on the
+    /// spawned task, so a panicking task never leaks a slot.
+    bulk_dumps_in_flight: Arc<AtomicUsize>,
+    /// Global cap on the number of concurrently active paced bulk dumps.
+    max_concurrent_bulk_dumps: usize,
     /// Monotonic reconciliation-round counter, shared across clones, gating the cross-network cadence.
     round: Arc<AtomicU32>,
     rng: Arc<RwLock<StdRng>>,
@@ -229,6 +237,9 @@ pub(crate) struct Inner<K, V: Projectable> {
     /// Exposed via [`node_id_is_random`](ReconcileEngine::node_id_is_random) so that the store
     /// layer can warn operators when persistence is configured but the identity is ephemeral.
     pub(crate) node_id_is_random: bool,
+    /// Hard cap on the number of tracked remote peers. Datagrams from unknown senders are dropped
+    /// before any per-sender state is allocated when the membership set reaches this size.
+    max_peers: usize,
 }
 
 impl<K, V: Projectable> Clone for ReconcileEngine<K, V> {
@@ -359,6 +370,8 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
                 reconcile_interval: Arc::new(RwLock::new(config.reconcile_interval)),
                 bulk_send_rate: config.bulk_send_rate,
                 bulk_in_flight: Arc::new(RwLock::new(HashSet::new())),
+                bulk_dumps_in_flight: Arc::new(AtomicUsize::new(0)),
+                max_concurrent_bulk_dumps: config.max_concurrent_bulk_dumps,
                 round: Arc::new(AtomicU32::new(0)),
                 rng,
                 probe,
@@ -371,6 +384,7 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
                 tombstone_acks: Arc::new(RwLock::new(HashMap::new())),
                 clock,
                 node_id_is_random,
+                max_peers: config.max_peers,
             }),
         })
     }
@@ -532,6 +546,50 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
         });
     }
 
+    /// Try to claim both a per-peer in-flight slot and a global concurrent-dump slot.
+    ///
+    /// Returns `Some((peer_guard, global_guard))` when both slots are available, or `None` when
+    /// either is already taken. The caller checks this **before** snapshotting the differing range
+    /// into a `Vec`, so a skipped dump allocates nothing. The guards release their slots on drop,
+    /// ensuring cleanup even if the spawned task panics.
+    fn try_claim_dump_slot(
+        &self,
+        peer: SocketAddr,
+    ) -> Option<(BulkInFlightGuard, BulkDumpCountGuard)> {
+        // Per-peer guard: at most one dump per peer at a time.
+        if !self.bulk_in_flight.write().insert(peer) {
+            return None;
+        }
+        // Global budget: at most `max_concurrent_bulk_dumps` across all peers. The
+        // compare-exchange loop increments only if currently below the cap. If at cap, release the
+        // per-peer mark before returning so that slot is not leaked.
+        let budget = self.max_concurrent_bulk_dumps;
+        let claimed = self
+            .bulk_dumps_in_flight
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |n| {
+                if n < budget {
+                    Some(n + 1)
+                } else {
+                    None
+                }
+            })
+            .is_ok();
+        if !claimed {
+            self.bulk_in_flight.write().remove(&peer);
+            trace!("skipped bulk dump to {peer}: global dump budget ({budget}) exhausted");
+            return None;
+        }
+        Some((
+            BulkInFlightGuard {
+                set: Arc::clone(&self.bulk_in_flight),
+                peer,
+            },
+            BulkDumpCountGuard {
+                counter: Arc::clone(&self.bulk_dumps_in_flight),
+            },
+        ))
+    }
+
     /// Send a bulk batch of differing values to one peer on a detached, **rate-paced** task.
     ///
     /// This is the cold/bulk anti-entropy path: when a peer differs over a whole range it must
@@ -550,23 +608,26 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
     ///    re-dump ranges still in transit, which is the byte amplification we are removing. Anything
     ///    genuinely still missing (e.g. a dropped datagram) is picked up by the next reconcile round
     ///    once the current dump finishes.
-    fn spawn_paced_send(&self, messages: Vec<Message<K, V, V::Projected>>, peer: SocketAddr) {
-        // Admit at most one in-flight dump per peer. `insert` returns false if already present.
-        if !self.bulk_in_flight.write().insert(peer) {
-            return;
-        }
-        // RAII: clears the in-flight mark when the dump finishes *or* if the send task panics, so a
-        // failed dump can never wedge a peer into "permanently transferring" and starve its sync.
-        let guard = BulkInFlightGuard {
-            set: Arc::clone(&self.bulk_in_flight),
-            peer,
-        };
+    /// 3. A **global concurrent-dump budget** (`max_concurrent_bulk_dumps`): even with the per-peer
+    ///    guard, M peers diffing simultaneously would each hold a full snapshot Vec. This cap limits
+    ///    total in-flight dump tasks. The caller checks the budget via [`try_claim_dump_slot`](Self::try_claim_dump_slot)
+    ///    **before** building the snapshot Vec, so a skipped dump allocates nothing.
+    fn spawn_paced_send(
+        &self,
+        messages: Vec<Message<K, V, V::Projected>>,
+        peer: SocketAddr,
+        peer_guard: BulkInFlightGuard,
+        global_guard: BulkDumpCountGuard,
+    ) {
         let socket = Arc::clone(&self.socket);
         let authenticator = self.authenticator.clone();
         let sender_counter = Arc::clone(&self.sender_counter);
         let rate = self.bulk_send_rate;
         tokio::spawn(async move {
-            let _guard = guard;
+            // Hold both RAII guards for the lifetime of the task: they release their respective
+            // slots on drop, even if this task is aborted or panics.
+            let _peer_guard = peer_guard;
+            let _global_guard = global_guard;
             let mut send_buf = Vec::new();
             send_messages_paced(
                 &messages,
@@ -664,27 +725,50 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
                         // dropped silently (trace-only, to avoid attacker-driven log flooding).
                         match self.authenticator.open(&recv_buf[..size]) {
                             Some(payload) => {
+                                let sender = peer.ip();
+                                // Per-peer cap check: if this sender is not yet tracked (not a
+                                // member) and the membership set is at capacity, drop the datagram
+                                // before allocating any per-sender state (replay filter entry,
+                                // peers map slot, or membership slot). Authenticated datagrams are
+                                // verified first (above), so this gate cannot be triggered by a
+                                // forged source address in authenticated mode.
+                                //
+                                // The check is intentionally placed *before* the replay filter so
+                                // that no replay-filter entry is created for a capped-out sender.
+                                // Known senders (already in `members`) bypass the cap.
+                                let is_known = self.members.read().contains(&sender);
+                                if !is_known {
+                                    let current_len = self.members.read().len();
+                                    if current_len >= self.max_peers {
+                                        trace!(
+                                            "dropped datagram from {peer}: peer cap reached \
+                                             ({current_len}/{})",
+                                            self.max_peers
+                                        );
+                                        observability::record_datagram_dropped("peer_cap");
+                                        continue;
+                                    }
+                                }
                                 // In authenticated modes, perform the replay check *after*
                                 // authentication (so forgeries cannot poison the per-peer state)
                                 // and *before* message processing. In unauthenticated mode
                                 // seq/stamp are both 0 and `is_enabled()` is false, so the check
                                 // is skipped entirely.
-                                if self.authenticator.is_enabled() {
-                                    let sender = peer.ip();
-                                    if !self.replay_filter.check_and_record(
+                                if self.authenticator.is_enabled()
+                                    && !self.replay_filter.check_and_record(
                                         sender,
                                         payload.seq,
                                         payload.stamp,
-                                    ) {
-                                        trace!(
-                                            "dropped replayed or stale datagram from {peer}: \
-                                             seq={} stamp={}",
-                                            payload.seq,
-                                            payload.stamp
-                                        );
-                                        observability::record_datagram_dropped("replay");
-                                        continue;
-                                    }
+                                    )
+                                {
+                                    trace!(
+                                        "dropped replayed or stale datagram from {peer}: \
+                                         seq={} stamp={}",
+                                        payload.seq,
+                                        payload.stamp
+                                    );
+                                    observability::record_datagram_dropped("replay");
+                                    continue;
                                 }
                                 let spoke_dated =
                                     self.handle_messages(payload, peer, &mut send_buf).await;
@@ -701,9 +785,8 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
                                 // forever (the very regression we must avoid). Such a mirror is
                                 // served reactively off `peer` and is not tracked as a peer/member.
                                 if spoke_dated {
-                                    let addr = peer.ip();
-                                    self.peers.write().insert(addr, Instant::now());
-                                    self.members.write().insert(addr);
+                                    self.peers.write().insert(sender, Instant::now());
+                                    self.members.write().insert(sender);
                                 }
                             }
                             None => {
@@ -868,13 +951,29 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
                 let map_guard = self.map.read();
                 let mut guard = self.tombstone_acks.write();
                 for (key, version) in acks {
+                    // Accept an ack only for a key we locally hold as a tombstone. Acks for
+                    // never-existent or non-tombstone keys are dropped here so they cannot
+                    // accumulate in `tombstone_acks` without bound.
+                    //
+                    // Ordering hazard: this gate cannot tell "a key we will never hold" from
+                    // "a key we don't hold YET". In a cluster of three or more nodes an ack
+                    // can arrive before the deletion it acknowledges (the acking peer may have
+                    // learned the deletion via a different gossip edge), and a dropped ack is
+                    // not re-delivered. Any future change to causal-stability GC must account
+                    // for this rather than rely on early acks being retained.
+                    let local_tombstone = map_guard.get(&key).filter(|v| v.is_tombstone());
+                    let Some(local_v) = local_tombstone else {
+                        trace!(
+                            "dropped ack from {peer_ip} for key with no local tombstone; \
+                             ignoring to prevent unbounded bookkeeping"
+                        );
+                        continue;
+                    };
                     let entry = guard.entry(key.clone()).or_default();
                     let already = entry.get(&peer_ip) == Some(&version);
                     entry.insert(peer_ip, version);
                     if !already {
-                        let holds_same_tombstone = map_guard
-                            .get(&key)
-                            .is_some_and(|v| v.is_tombstone() && version_hash(v) == version);
+                        let holds_same_tombstone = version_hash(local_v) == version;
                         if holds_same_tombstone {
                             reciprocal_acks
                                 .push(Message::Ack::<K, V, V::Projected>((key, version)));
@@ -927,18 +1026,24 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
             if !differences.is_empty() {
                 debug!("returning {} diff_ranges", differences.len());
                 trace!("diff_ranges: {differences:?}");
-                let updates: Vec<Message<K, V, V::Projected>> = {
-                    let guard = self.map.read();
-                    let mut updates = Vec::new();
-                    for range in differences {
-                        for (k, v) in guard.get_range(&range) {
-                            updates.push(Message::Update((k.clone(), v.clone())));
+                // Claim both slots (per-peer + global budget) *before* snapshotting the range
+                // into a Vec. A skipped dump allocates nothing; the peer re-initiates on its
+                // next diff round once a slot is free.
+                if let Some((peer_guard, global_guard)) = self.try_claim_dump_slot(peer) {
+                    let updates: Vec<Message<K, V, V::Projected>> = {
+                        let guard = self.map.read();
+                        let mut updates = Vec::new();
+                        for range in differences {
+                            for (k, v) in guard.get_range(&range) {
+                                updates.push(Message::Update((k.clone(), v.clone())));
+                            }
                         }
+                        updates
+                    };
+                    if !updates.is_empty() {
+                        self.spawn_paced_send(updates, peer, peer_guard, global_guard);
                     }
-                    updates
-                };
-                if !updates.is_empty() {
-                    self.spawn_paced_send(updates, peer);
+                    // If updates is empty the guards drop here, releasing both slots.
                 }
             }
         }
@@ -1050,18 +1155,20 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
             // Bulk value-only payload — a dateless mirror pulling the dataset. Rate-pace it on a
             // background task, exactly like the dated bulk path.
             if !differences.is_empty() {
-                let updates: Vec<Message<K, V, V::Projected>> = {
-                    let guard = self.projection.read();
-                    let mut updates = Vec::new();
-                    for range in differences {
-                        for (k, p) in guard.get_range(&range) {
-                            updates.push(Message::ValueUpdate((k.clone(), p.clone())));
+                if let Some((peer_guard, global_guard)) = self.try_claim_dump_slot(peer) {
+                    let updates: Vec<Message<K, V, V::Projected>> = {
+                        let guard = self.projection.read();
+                        let mut updates = Vec::new();
+                        for range in differences {
+                            for (k, p) in guard.get_range(&range) {
+                                updates.push(Message::ValueUpdate((k.clone(), p.clone())));
+                            }
                         }
+                        updates
+                    };
+                    if !updates.is_empty() {
+                        self.spawn_paced_send(updates, peer, peer_guard, global_guard);
                     }
-                    updates
-                };
-                if !updates.is_empty() {
-                    self.spawn_paced_send(updates, peer);
                 }
             }
         }
@@ -1104,6 +1211,7 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
     /// peer to membership. Keeping the replay state lets the bitmap reject the captured datagram.
     pub(crate) fn decommission_peer(&self, peer: IpAddr) {
         self.members.write().remove(&peer);
+        self.peers.write().remove(&peer);
         for key_acks in self.tombstone_acks.write().values_mut() {
             key_acks.remove(&peer);
         }
@@ -1125,6 +1233,38 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
     /// A snapshot of the monotonic membership set (peers that gate tombstone GC).
     pub(crate) fn members_snapshot(&self) -> HashSet<IpAddr> {
         self.members.read().clone()
+    }
+
+    /// Number of entries currently in the peers gossip-routing map.
+    ///
+    /// Exposed for test assertions under the `internal-testing` feature gate.
+    #[cfg(any(test, feature = "internal-testing"))]
+    pub(crate) fn peers_map_len(&self) -> usize {
+        self.peers.read().len()
+    }
+
+    /// Number of entries currently in the per-peer replay filter.
+    ///
+    /// Exposed for test assertions under the `internal-testing` feature gate.
+    #[cfg(any(test, feature = "internal-testing"))]
+    pub(crate) fn replay_filter_len(&self) -> usize {
+        self.replay_filter.len()
+    }
+
+    /// Number of keys currently tracked in the tombstone-acknowledgment map.
+    ///
+    /// Exposed for test assertions under the `internal-testing` feature gate.
+    #[cfg(any(test, feature = "internal-testing"))]
+    pub(crate) fn tombstone_acks_len(&self) -> usize {
+        self.tombstone_acks.read().len()
+    }
+
+    /// Number of bulk dump tasks currently in flight across all peers.
+    ///
+    /// Exposed for test assertions under the `internal-testing` feature gate.
+    #[cfg(any(test, feature = "internal-testing"))]
+    pub(crate) fn bulk_dumps_in_flight_count(&self) -> usize {
+        self.bulk_dumps_in_flight.load(Ordering::Acquire)
     }
 
     /// This node's configured listen address, used by discovery to never decommission itself.
@@ -1274,6 +1414,19 @@ struct BulkInFlightGuard {
 impl Drop for BulkInFlightGuard {
     fn drop(&mut self) {
         self.set.write().remove(&self.peer);
+    }
+}
+
+/// RAII counter-decrement for the global concurrent-dump budget. Decrements the shared atomic on
+/// `Drop`, guaranteeing the slot is freed even if the task holding it panics or is aborted. See
+/// [`ReconcileEngine::try_claim_dump_slot`].
+struct BulkDumpCountGuard {
+    counter: Arc<AtomicUsize>,
+}
+
+impl Drop for BulkDumpCountGuard {
+    fn drop(&mut self) {
+        self.counter.fetch_sub(1, Ordering::Release);
     }
 }
 
@@ -1735,5 +1888,184 @@ mod socket_buffers {
         // only check the call path does not panic and yields a positive buffer.
         let buf = SockRef::from(&*eng.socket).recv_buffer_size().unwrap();
         assert!(buf > 0, "a socket always has a positive receive buffer");
+    }
+}
+
+#[cfg(test)]
+mod tombstone_ack_bounds {
+    use std::net::SocketAddr;
+
+    use bincode::{DefaultOptions, Serializer};
+    use serde::Serialize;
+
+    use super::Message;
+    use crate::auth;
+    use crate::clock::Timestamp;
+    use crate::reconcile_engine::{version_hash, ReconcileEngine};
+    use crate::reconcile_store::Config;
+
+    type Tombstoned = (Timestamp, Option<i32>);
+
+    async fn engine(addr: &str) -> ReconcileEngine<i32, Tombstoned> {
+        // Use a distinct port per module to avoid bind conflicts between parallel test runs.
+        let config = Config::default()
+            .with_port(0)
+            .with_listen_addr(addr.parse().unwrap());
+        ReconcileEngine::new(config).await.expect("bind failed")
+    }
+
+    fn ack_bytes(key: i32, version: u64) -> Vec<u8> {
+        let msg =
+            Message::Ack::<i32, Tombstoned, crate::reconcilable::ValueOnly<i32>>((key, version));
+        let mut buf = Vec::new();
+        msg.serialize(&mut Serializer::new(&mut buf, DefaultOptions::new()))
+            .unwrap();
+        buf
+    }
+
+    /// An ack for a key that does not exist locally must not create any entry in
+    /// `tombstone_acks`. Without the fix, `or_default()` allocates on every ack for
+    /// an arbitrary key, enabling unbounded growth.
+    #[tokio::test]
+    async fn ack_for_unknown_key_does_not_grow_tombstone_acks() {
+        let eng = engine("127.0.0.93").await;
+        let peer: SocketAddr = "127.0.0.94:9000".parse().unwrap();
+
+        let bytes = ack_bytes(42, 999);
+        let payload = auth::Authenticator::new(None, false)
+            .open(&bytes)
+            .expect("unauthenticated open");
+        let mut send_buf = Vec::new();
+        eng.handle_messages(payload, peer, &mut send_buf).await;
+
+        assert_eq!(
+            eng.tombstone_acks_len(),
+            0,
+            "ack for unknown key must not insert into tombstone_acks"
+        );
+    }
+
+    /// An ack for a key that exists locally but is a *live* (non-tombstone) value must
+    /// likewise be dropped.
+    #[tokio::test]
+    async fn ack_for_live_key_does_not_grow_tombstone_acks() {
+        let eng = engine("127.0.0.95").await;
+        let key = 10;
+        // Insert a live value (Some(_) = not a tombstone).
+        eng.just_insert(key, (Timestamp::new(1, 0, 0), Some(42)));
+
+        let peer: SocketAddr = "127.0.0.96:9000".parse().unwrap();
+        let bytes = ack_bytes(key, 123);
+        let payload = auth::Authenticator::new(None, false)
+            .open(&bytes)
+            .expect("unauthenticated open");
+        let mut send_buf = Vec::new();
+        eng.handle_messages(payload, peer, &mut send_buf).await;
+
+        assert_eq!(
+            eng.tombstone_acks_len(),
+            0,
+            "ack for a live (non-tombstone) key must not insert into tombstone_acks"
+        );
+    }
+
+    /// An ack for a key that IS a local tombstone must be recorded normally; the
+    /// decommission test verifies tombstone GC still completes.
+    #[tokio::test]
+    async fn ack_for_local_tombstone_is_recorded() {
+        let eng = engine("127.0.0.97").await;
+        let key = 20;
+        let tombstone: Tombstoned = (Timestamp::new(2, 0, 0), None);
+        let version = version_hash(&tombstone);
+        eng.just_insert(key, tombstone);
+
+        let peer: SocketAddr = "127.0.0.98:9000".parse().unwrap();
+        let bytes = ack_bytes(key, version);
+        let payload = auth::Authenticator::new(None, false)
+            .open(&bytes)
+            .expect("unauthenticated open");
+        let mut send_buf = Vec::new();
+        eng.handle_messages(payload, peer, &mut send_buf).await;
+
+        assert_eq!(
+            eng.tombstone_acks_len(),
+            1,
+            "ack for a local tombstone must be recorded in tombstone_acks"
+        );
+
+        // Causal-stability GC still completes: with one member who has acked and no
+        // other members, the tombstone is stable and bookkeeping is cleared on forget.
+        eng.members.write().insert(peer.ip());
+        assert!(
+            eng.is_tombstone_stable(&key, version),
+            "tombstone should be stable after the only member has acked"
+        );
+        eng.forget_tombstone(&key);
+        assert_eq!(
+            eng.tombstone_acks_len(),
+            0,
+            "forget_tombstone must clear tombstone_acks for the key"
+        );
+    }
+}
+
+#[cfg(test)]
+mod dump_budget {
+    use crate::reconcile_store::Config;
+
+    /// Default budget is 4, matching DEFAULT_MAX_CONCURRENT_BULK_DUMPS.
+    #[test]
+    fn default_budget_is_four() {
+        assert_eq!(Config::default().max_concurrent_bulk_dumps, 4);
+    }
+
+    /// `with_max_concurrent_bulk_dumps` overrides the value.
+    #[test]
+    fn builder_sets_budget() {
+        let cfg = Config::default().with_max_concurrent_bulk_dumps(1);
+        assert_eq!(cfg.max_concurrent_bulk_dumps, 1);
+    }
+
+    /// With a budget of 1, claiming a second slot before the first is released must fail.
+    /// After the first slot is dropped its count returns to zero and a fresh claim succeeds.
+    #[tokio::test]
+    async fn budget_guard_limits_and_releases_slots() {
+        use crate::clock::Timestamp;
+        use crate::reconcile_engine::ReconcileEngine;
+
+        type Tombstoned = (Timestamp, Option<i32>);
+
+        let config = Config::default()
+            .with_port(0)
+            .with_listen_addr("127.0.0.99".parse().unwrap())
+            .with_max_concurrent_bulk_dumps(1);
+        let eng = ReconcileEngine::<i32, Tombstoned>::new(config)
+            .await
+            .expect("bind failed");
+
+        let peer_a: std::net::SocketAddr = "127.0.0.100:9001".parse().unwrap();
+        let peer_b: std::net::SocketAddr = "127.0.0.101:9001".parse().unwrap();
+
+        // First claim succeeds.
+        let slot_a = eng.try_claim_dump_slot(peer_a);
+        assert!(slot_a.is_some(), "first slot must be available");
+        assert_eq!(eng.bulk_dumps_in_flight_count(), 1);
+
+        // Second claim (different peer) is rejected — budget exhausted.
+        let slot_b = eng.try_claim_dump_slot(peer_b);
+        assert!(slot_b.is_none(), "second slot must be rejected at budget 1");
+        assert_eq!(eng.bulk_dumps_in_flight_count(), 1);
+
+        // Releasing the first slot (drop) frees it for the next caller.
+        drop(slot_a);
+        assert_eq!(eng.bulk_dumps_in_flight_count(), 0);
+
+        // Now peer_b's retry succeeds.
+        let slot_b_retry = eng.try_claim_dump_slot(peer_b);
+        assert!(
+            slot_b_retry.is_some(),
+            "slot must be available after release"
+        );
+        drop(slot_b_retry);
     }
 }

--- a/src/reconcile_engine.rs
+++ b/src/reconcile_engine.rs
@@ -1217,6 +1217,40 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
         }
     }
 
+    /// Returns `true` when `peer` has at least one tombstone it has not yet acknowledged.
+    ///
+    /// The predicate iterates the local map (the authoritative domain) looking for tombstone
+    /// entries. For each tombstone it checks whether `peer` has acknowledged the exact current
+    /// version via `tombstone_acks`. A tombstone whose key has NO entry in `tombstone_acks` at
+    /// all (fresh deletion, no ack has arrived yet) is also treated as pending — exactly the
+    /// condition that `is_tombstone_stable` blocks on.
+    ///
+    /// Locks taken: `map` read, then `tombstone_acks` read — the established lock order
+    /// (map before tombstone_acks) so this can be called from the discovery task without
+    /// risk of deadlock. Cost: O(local map entries) — acceptable for the discovery cadence
+    /// (~5 s intervals, only when a member is missing from DNS).
+    pub(crate) fn has_pending_tombstone_acks(&self, peer: IpAddr) -> bool {
+        let map = self.map.read();
+        let acks = self.tombstone_acks.read();
+        for (key, value) in map.iter() {
+            if !value.is_tombstone() {
+                continue;
+            }
+            let current_version = version_hash(value);
+            // Mirror the per-key ack test that `is_tombstone_stable` uses: the peer must have
+            // acknowledged exactly this version. If the key has no ack entry at all (fresh
+            // deletion, nobody has acked yet), the peer is pending.
+            let peer_acked = acks
+                .get(key)
+                .and_then(|key_acks| key_acks.get(&peer))
+                .is_some_and(|v| *v == current_version);
+            if !peer_acked {
+                return true;
+            }
+        }
+        false
+    }
+
     /// Register (or refresh) a known peer at runtime, the `&self` counterpart of the
     /// [`with_seed`](crate::ReconcileStore::with_seed) builder.
     ///
@@ -1241,6 +1275,17 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
     #[cfg(any(test, feature = "internal-testing"))]
     pub(crate) fn peers_map_len(&self) -> usize {
         self.peers.read().len()
+    }
+
+    /// Whether `peer` is present in the gossip-routing peers map (i.e. discovery has seeded it
+    /// at least once and the entry has not yet expired). Used as a deterministic signal in tests
+    /// to confirm that at least one discovery round has observed a peer before the test mutates
+    /// the discovery source.
+    ///
+    /// Exposed for test assertions under the `internal-testing` feature gate.
+    #[cfg(any(test, feature = "internal-testing"))]
+    pub(crate) fn peers_contains(&self, peer: IpAddr) -> bool {
+        self.peers.read().contains_key(&peer)
     }
 
     /// Number of entries currently in the per-peer replay filter.
@@ -1726,6 +1771,48 @@ mod causal_stability {
         // Forgetting the tombstone clears its bookkeeping.
         eng.forget_tombstone(&key);
         assert!(eng.tombstone_acks.read().get(&key).is_none());
+    }
+
+    /// Regression: `has_pending_tombstone_acks` must detect a freshly-deleted tombstone that
+    /// has ZERO acks recorded (the `tombstone_acks` map has no entry for that key yet).
+    ///
+    /// The original implementation iterated `tombstone_acks.iter()` — which yields nothing when
+    /// the map is empty — and returned `false` ("no pending acks").  That is wrong: a tombstone
+    /// with no ack entry is the *most* pending of all states.  The fixed implementation iterates
+    /// the local map and treats any tombstone with a missing or mismatched ack as pending.
+    ///
+    /// If this test fails, the old predicate has been restored (see commit history).  The test
+    /// is intentionally self-contained so it can be run against either version of the predicate
+    /// to confirm the regression.
+    #[tokio::test]
+    async fn fresh_tombstone_with_zero_acks_is_pending() {
+        let eng = engine("127.0.0.66").await;
+        let peer: IpAddr = "127.0.0.67".parse().unwrap();
+        let key = 11i32;
+        let tombstone: Tombstoned = (Timestamp::new(2, 0, 0), None);
+
+        // B is a known member — gates tombstone GC.
+        eng.members.write().insert(peer);
+
+        // Insert the tombstone directly into the engine map (no gossip round needed).
+        eng.just_insert(key, tombstone);
+        assert!(eng.map.read().get(&key).is_some());
+
+        // No ack entry exists for this key yet — the tombstone is "fresh".
+        assert!(
+            eng.tombstone_acks.read().is_empty(),
+            "tombstone_acks must be empty — no ack has arrived"
+        );
+
+        // The predicate must report the peer as having pending work: `tombstone_acks` has no
+        // entry for this key, so `is_tombstone_stable` would also block.
+        assert!(
+            eng.has_pending_tombstone_acks(peer),
+            "has_pending_tombstone_acks returned false for a fresh tombstone with zero acks \
+             (resurrection hazard: the old tombstone_acks.iter() predicate iterates an empty map \
+             and returns false, triggering the fast-path decommission while the tombstone is \
+             still active)"
+        );
     }
 }
 

--- a/src/reconcile_engine.rs
+++ b/src/reconcile_engine.rs
@@ -726,16 +726,10 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
                         match self.authenticator.open(&recv_buf[..size]) {
                             Some(payload) => {
                                 let sender = peer.ip();
-                                // Per-peer cap check: if this sender is not yet tracked (not a
-                                // member) and the membership set is at capacity, drop the datagram
-                                // before allocating any per-sender state (replay filter entry,
-                                // peers map slot, or membership slot). Authenticated datagrams are
-                                // verified first (above), so this gate cannot be triggered by a
-                                // forged source address in authenticated mode.
-                                //
-                                // The check is intentionally placed *before* the replay filter so
-                                // that no replay-filter entry is created for a capped-out sender.
-                                // Known senders (already in `members`) bypass the cap.
+                                // If this sender is new and membership is at capacity, drop before
+                                // allocating any per-sender state (replay filter, peers map,
+                                // membership). Placed ahead of the replay filter so a capped-out
+                                // sender never gets an entry there either. Known senders bypass it.
                                 let is_known = self.members.read().contains(&sender);
                                 if !is_known {
                                     let current_len = self.members.read().len();
@@ -951,16 +945,11 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
                 let map_guard = self.map.read();
                 let mut guard = self.tombstone_acks.write();
                 for (key, version) in acks {
-                    // Accept an ack only for a key we locally hold as a tombstone. Acks for
-                    // never-existent or non-tombstone keys are dropped here so they cannot
-                    // accumulate in `tombstone_acks` without bound.
-                    //
-                    // Ordering hazard: this gate cannot tell "a key we will never hold" from
-                    // "a key we don't hold YET". In a cluster of three or more nodes an ack
-                    // can arrive before the deletion it acknowledges (the acking peer may have
-                    // learned the deletion via a different gossip edge), and a dropped ack is
-                    // not re-delivered. Any future change to causal-stability GC must account
-                    // for this rather than rely on early acks being retained.
+                    // Only accept an ack for a key we locally hold as a tombstone, so acks for
+                    // never-existent or non-tombstone keys cannot accumulate unbounded. Ordering
+                    // hazard: at three nodes or more an ack can arrive before its deletion (via a
+                    // different gossip edge) and is dropped, not re-delivered — future
+                    // causal-stability GC changes must not assume early acks are retained.
                     let local_tombstone = map_guard.get(&key).filter(|v| v.is_tombstone());
                     let Some(local_v) = local_tombstone else {
                         trace!(
@@ -1217,18 +1206,12 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
         }
     }
 
-    /// Returns `true` when `peer` has at least one tombstone it has not yet acknowledged.
+    /// Returns `true` when `peer` has at least one tombstone it has not yet acknowledged — the
+    /// same per-key test `is_tombstone_stable` blocks on, including a key with no ack entry at
+    /// all (fresh deletion) counting as pending.
     ///
-    /// The predicate iterates the local map (the authoritative domain) looking for tombstone
-    /// entries. For each tombstone it checks whether `peer` has acknowledged the exact current
-    /// version via `tombstone_acks`. A tombstone whose key has NO entry in `tombstone_acks` at
-    /// all (fresh deletion, no ack has arrived yet) is also treated as pending — exactly the
-    /// condition that `is_tombstone_stable` blocks on.
-    ///
-    /// Locks taken: `map` read, then `tombstone_acks` read — the established lock order
-    /// (map before tombstone_acks) so this can be called from the discovery task without
-    /// risk of deadlock. Cost: O(local map entries) — acceptable for the discovery cadence
-    /// (~5 s intervals, only when a member is missing from DNS).
+    /// Locks `map` then `tombstone_acks`, the established order, so this is safe to call from the
+    /// discovery task. `O(local map entries)`, acceptable at the ~5 s discovery cadence.
     pub(crate) fn has_pending_tombstone_acks(&self, peer: IpAddr) -> bool {
         let map = self.map.read();
         let acks = self.tombstone_acks.read();
@@ -1237,9 +1220,6 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
                 continue;
             }
             let current_version = version_hash(value);
-            // Mirror the per-key ack test that `is_tombstone_stable` uses: the peer must have
-            // acknowledged exactly this version. If the key has no ack entry at all (fresh
-            // deletion, nobody has acked yet), the peer is pending.
             let peer_acked = acks
                 .get(key)
                 .and_then(|key_acks| key_acks.get(&peer))
@@ -1773,17 +1753,9 @@ mod causal_stability {
         assert!(eng.tombstone_acks.read().get(&key).is_none());
     }
 
-    /// Regression: `has_pending_tombstone_acks` must detect a freshly-deleted tombstone that
-    /// has ZERO acks recorded (the `tombstone_acks` map has no entry for that key yet).
-    ///
-    /// The original implementation iterated `tombstone_acks.iter()` — which yields nothing when
-    /// the map is empty — and returned `false` ("no pending acks").  That is wrong: a tombstone
-    /// with no ack entry is the *most* pending of all states.  The fixed implementation iterates
-    /// the local map and treats any tombstone with a missing or mismatched ack as pending.
-    ///
-    /// If this test fails, the old predicate has been restored (see commit history).  The test
-    /// is intentionally self-contained so it can be run against either version of the predicate
-    /// to confirm the regression.
+    /// Regression: a freshly-deleted tombstone with zero acks recorded must count as pending. An
+    /// earlier implementation iterated `tombstone_acks` (empty for a fresh key) and returned
+    /// `false` — the opposite of correct, since no ack is the most pending state there is.
     #[tokio::test]
     async fn fresh_tombstone_with_zero_acks_is_pending() {
         let eng = engine("127.0.0.66").await;

--- a/src/reconcile_store.rs
+++ b/src/reconcile_store.rs
@@ -71,6 +71,16 @@ const DEFAULT_MAX_PEERS: usize = 1024;
 /// starving small clusters; raise via [`Config::with_max_concurrent_bulk_dumps`].
 const DEFAULT_MAX_CONCURRENT_BULK_DUMPS: usize = 4;
 
+/// Default wall-time floor before a member with pending unacked tombstones may be decommissioned
+/// by the discovery task (see [`ReconcileStore::with_discovery_decommission_floor`]).
+///
+/// 10 minutes is long enough to absorb a readiness-probe blip that drops a pod from a Kubernetes
+/// headless Service (the event this floor was designed for) while still reclaiming the GC gate
+/// within a reasonable horizon when a member is genuinely gone. Members with **no** pending
+/// tombstone acks are not subject to the floor and are decommissioned as soon as
+/// `miss_threshold` rounds have elapsed.
+const DEFAULT_DISCOVERY_DECOMMISSION_FLOOR: Duration = Duration::from_secs(600);
+
 /// Core service wrapping a key-value map to enable reconciliation between different instances over a network.
 ///
 /// The store also keeps track of the addresses of other instances.
@@ -102,6 +112,10 @@ where
     discovery_interval: Duration,
     /// Consecutive missed discovery rounds before a vanished member is decommissioned.
     discovery_miss_threshold: u32,
+    /// Minimum continuous absence time before a member with pending unacked tombstones is
+    /// decommissioned by the discovery task. Members with no pending tombstone acks skip this
+    /// floor and are decommissioned as soon as `miss_threshold` rounds elapse.
+    discovery_decommission_floor: Duration,
 }
 
 impl<K, V> Clone for ReconcileStore<K, V>
@@ -118,6 +132,7 @@ where
             discovery: self.discovery.clone(),
             discovery_interval: self.discovery_interval,
             discovery_miss_threshold: self.discovery_miss_threshold,
+            discovery_decommission_floor: self.discovery_decommission_floor,
         }
     }
 }
@@ -138,6 +153,7 @@ impl<K: Key, V: Value> ReconcileStore<K, V> {
             discovery: None,
             discovery_interval: DEFAULT_DISCOVERY_INTERVAL,
             discovery_miss_threshold: DEFAULT_DISCOVERY_MISS_THRESHOLD,
+            discovery_decommission_floor: DEFAULT_DISCOVERY_DECOMMISSION_FLOOR,
         };
         svc.add_pre_insert(|_, _| {});
         Ok(svc)
@@ -160,6 +176,7 @@ impl<K: Key, V: Value> ReconcileStore<K, V> {
             discovery: None,
             discovery_interval: DEFAULT_DISCOVERY_INTERVAL,
             discovery_miss_threshold: DEFAULT_DISCOVERY_MISS_THRESHOLD,
+            discovery_decommission_floor: DEFAULT_DISCOVERY_DECOMMISSION_FLOOR,
         };
         svc.add_pre_insert(|_, _| {});
         Ok(svc)
@@ -326,6 +343,30 @@ impl<K: Key, V: Value> ReconcileStore<K, V> {
     /// restarts at the cost of holding tombstones (and their GC gate) longer.
     pub fn with_discovery_miss_threshold(mut self, threshold: u32) -> Self {
         self.discovery_miss_threshold = threshold;
+        self
+    }
+
+    /// Set the minimum continuous absence before a member with **pending unacked tombstones**
+    /// may be decommissioned by the discovery task (default 10 minutes).
+    ///
+    /// When a member has been absent from consecutive discovery rounds for at least
+    /// `miss_threshold` but still has tombstones it has never acknowledged, the discovery task
+    /// will not release the member's causal-stability gate until it has been absent continuously
+    /// for at least this duration. The absence clock resets whenever the member reappears in a
+    /// discovery round, so a transient blip — including a Kubernetes readiness-probe hiccup that
+    /// momentarily drops a pod from the headless Service — cannot advance it.
+    ///
+    /// Members with **no** pending tombstone acks are unaffected by this floor: they are
+    /// decommissioned as soon as `miss_threshold` rounds have elapsed, preserving the existing
+    /// fast-path behaviour for the common case.
+    ///
+    /// **Trade-off**: a longer floor provides stronger protection against tombstone resurrection
+    /// (a member that was briefly absent cannot cause a deleted value to reappear on its return),
+    /// at the cost of delaying the GC-slot release for members that are genuinely gone. Tune
+    /// this value to be comfortably larger than the longest expected transient absence
+    /// (readiness-probe blip, rolling restart, brief network partition) in your environment.
+    pub fn with_discovery_decommission_floor(mut self, floor: Duration) -> Self {
+        self.discovery_decommission_floor = floor;
         self
     }
 
@@ -509,6 +550,16 @@ impl<K: Key, V: Value> ReconcileStore<K, V> {
         self.engine.peers_map_len()
     }
 
+    /// Whether `peer` is currently in the gossip-routing peers map (discovery has seeded it at
+    /// least once and the entry has not yet expired). Used in tests to deterministically confirm
+    /// that at least one discovery round has observed the peer before the resolver is mutated.
+    ///
+    /// Exposed for integration-test assertions under the `internal-testing` feature gate.
+    #[cfg(any(test, feature = "internal-testing"))]
+    pub fn peers_contains(&self, peer: std::net::IpAddr) -> bool {
+        self.engine.peers_contains(peer)
+    }
+
     /// Number of entries in the per-peer replay filter.
     ///
     /// Exposed for integration-test assertions under the `internal-testing` feature gate.
@@ -635,9 +686,13 @@ impl<K: Key, V: Value> ReconcileStore<K, V> {
     ///   as a known peer, re-arming its expiration and feeding it to the next gossip round.
     /// - A previously-seen **member** that is now absent has its miss count incremented; once it
     ///   reaches [`discovery_miss_threshold`](Self::with_discovery_miss_threshold) it is
-    ///   decommissioned, releasing the causal-stability gate it held on tombstone GC.
-    /// - A **failed** resolution (DNS blip) is skipped entirely — it never counts as a miss — so a
-    ///   transient resolver hiccup cannot decommission a healthy peer.
+    ///   decommissioned, releasing the causal-stability gate it held on tombstone GC. When the
+    ///   member has pending unacked tombstones, decommissioning additionally requires that its
+    ///   continuous absence has lasted at least
+    ///   [`discovery_decommission_floor`](Self::with_discovery_decommission_floor).
+    /// - A **failed** resolution (DNS blip) is skipped entirely — it never counts as a miss and
+    ///   never advances the absence clock — so a transient resolver hiccup cannot decommission a
+    ///   healthy peer.
     ///
     /// Only `members` are considered for decommissioning: membership is what gates tombstone GC, it
     /// is earned through a real authenticated datagram, and discovery never writes to it — so a
@@ -647,17 +702,20 @@ impl<K: Key, V: Value> ReconcileStore<K, V> {
             return; // no discovery source: leave peer-finding to the engine's per-net probing
         };
         let own_addr = self.engine.listen_addr();
-        // Consecutive missed rounds per member, and the set of addresses discovery has ever
-        // reported (so we only grace-decommission members we actually discovered, never peers
-        // learned by other means).
+        // Consecutive missed rounds per member, the set of addresses discovery has ever reported
+        // (so we only grace-decommission members we actually discovered, never peers learned by
+        // other means), and the wall-clock instant at which each member first went absent in the
+        // current consecutive run (reset whenever the member reappears).
         let mut miss_counts: HashMap<IpAddr, u32> = HashMap::new();
         let mut seen_ever: HashSet<IpAddr> = HashSet::new();
+        let mut absent_since: HashMap<IpAddr, Instant> = HashMap::new();
         loop {
             tokio::time::sleep(self.discovery_interval).await;
             let resolved = match discovery.discover().await {
                 Ok(addrs) => addrs,
                 Err(err) => {
-                    // Transient failure: do not touch miss counts, do not decommission anyone.
+                    // Transient failure: do not touch miss counts or absence clocks; never
+                    // decommission anyone.
                     debug!("discovery round failed, skipping: {err}");
                     continue;
                 }
@@ -666,25 +724,50 @@ impl<K: Key, V: Value> ReconcileStore<K, V> {
                 .into_iter()
                 .filter(|addr| *addr != own_addr)
                 .collect();
-            // 1) Refresh every currently-present peer.
+            // 1) Refresh every currently-present peer; reset the absence clock on reappearance.
             for addr in &current {
                 seen_ever.insert(*addr);
                 self.engine.seed_peer(*addr);
                 miss_counts.remove(addr);
+                absent_since.remove(addr);
             }
             // 2) Grace-account members that were discovered before but are now absent.
             for member in self.engine.members_snapshot() {
                 if member == own_addr || current.contains(&member) || !seen_ever.contains(&member) {
                     continue;
                 }
+                // Record the first moment of this consecutive absence run.
+                let first_absent = *absent_since.entry(member).or_insert_with(Instant::now);
                 let misses = miss_counts.entry(member).or_insert(0);
                 *misses += 1;
-                if *misses >= self.discovery_miss_threshold {
-                    info!("decommissioning vanished peer {member} after {misses} missed discovery rounds");
+                if *misses < self.discovery_miss_threshold {
+                    continue;
+                }
+                // miss_threshold reached. Fast path: no pending acks → decommission immediately.
+                if !self.engine.has_pending_tombstone_acks(member) {
+                    info!(
+                        "decommissioning vanished peer {member} after {misses} missed discovery rounds"
+                    );
                     self.engine.decommission_peer(member);
                     miss_counts.remove(&member);
                     seen_ever.remove(&member);
+                    absent_since.remove(&member);
+                    continue;
                 }
+                // Slow path: member has pending unacked tombstones — require the floor to have
+                // elapsed before releasing its causal-stability gate.
+                if first_absent.elapsed() >= self.discovery_decommission_floor {
+                    info!(
+                        "decommissioning vanished peer {member} after {misses} missed discovery \
+                         rounds and {} s of continuous absence (pending tombstone acks present)",
+                        first_absent.elapsed().as_secs()
+                    );
+                    self.engine.decommission_peer(member);
+                    miss_counts.remove(&member);
+                    seen_ever.remove(&member);
+                    absent_since.remove(&member);
+                }
+                // Otherwise: floor not yet elapsed; keep waiting.
             }
         }
     }

--- a/src/reconcile_store.rs
+++ b/src/reconcile_store.rs
@@ -58,6 +58,19 @@ const DEFAULT_BULK_SEND_RATE: usize = 32 * 1024 * 1024;
 /// before the application ever sees them.
 const DEFAULT_SOCKET_BUFFER_SIZE: usize = 8 * 1024 * 1024;
 
+/// Default cap on the number of distinct tracked peers (see [`Config::max_peers`]).
+///
+/// 1024 is generous for a gossip cluster that typically spans tens to a few hundred nodes;
+/// raise the limit via [`Config::with_max_peers`] for larger deployments.
+const DEFAULT_MAX_PEERS: usize = 1024;
+
+/// Default cap on the number of concurrently active paced bulk dumps (see
+/// [`Config::max_concurrent_bulk_dumps`]).
+///
+/// 4 is a conservative default that bounds total in-flight snapshot memory without
+/// starving small clusters; raise via [`Config::with_max_concurrent_bulk_dumps`].
+const DEFAULT_MAX_CONCURRENT_BULK_DUMPS: usize = 4;
+
 /// Core service wrapping a key-value map to enable reconciliation between different instances over a network.
 ///
 /// The store also keeps track of the addresses of other instances.
@@ -488,6 +501,38 @@ impl<K: Key, V: Value> ReconcileStore<K, V> {
         self.engine.members_snapshot()
     }
 
+    /// Number of entries in the peers gossip-routing map.
+    ///
+    /// Exposed for integration-test assertions under the `internal-testing` feature gate.
+    #[cfg(any(test, feature = "internal-testing"))]
+    pub fn peers_map_len(&self) -> usize {
+        self.engine.peers_map_len()
+    }
+
+    /// Number of entries in the per-peer replay filter.
+    ///
+    /// Exposed for integration-test assertions under the `internal-testing` feature gate.
+    #[cfg(any(test, feature = "internal-testing"))]
+    pub fn replay_filter_len(&self) -> usize {
+        self.engine.replay_filter_len()
+    }
+
+    /// Number of keys currently tracked in the tombstone-acknowledgment map.
+    ///
+    /// Exposed for integration-test assertions under the `internal-testing` feature gate.
+    #[cfg(any(test, feature = "internal-testing"))]
+    pub fn tombstone_acks_len(&self) -> usize {
+        self.engine.tombstone_acks_len()
+    }
+
+    /// Number of bulk dump tasks currently in flight across all peers.
+    ///
+    /// Exposed for integration-test assertions under the `internal-testing` feature gate.
+    #[cfg(any(test, feature = "internal-testing"))]
+    pub fn bulk_dumps_in_flight_count(&self) -> usize {
+        self.engine.bulk_dumps_in_flight_count()
+    }
+
     /// (runtime) Replace the declared geographical networks, retuning the gossip topology **without
     /// recreating the node**. The local network is re-derived automatically (whichever new net
     /// contains the listen address). See [`Config::nets`].
@@ -819,6 +864,39 @@ pub struct Config {
     /// Defaults to 5 minutes. Increase if nodes have large, legitimate clock skew; decrease for
     /// tighter replay protection. See [`with_freshness_window`](Config::with_freshness_window).
     pub freshness_window: Duration,
+    /// Maximum number of distinct remote peers (members) this node will track.
+    ///
+    /// When the membership set is at capacity, datagrams from completely unknown senders are
+    /// dropped **before** any per-sender state (membership, gossip-peer record, or replay-filter
+    /// entry) is allocated. Senders that are already tracked are unaffected at cap, and calling
+    /// [`forget_peer`](crate::ReconcileStore::forget_peer) on a member immediately frees its slot.
+    ///
+    /// The cap is defence-in-depth for unauthenticated deployments (where any spoofed source
+    /// address would otherwise grow the maps without bound), and a hard ceiling for authenticated
+    /// ones. The default of 1024 is generous for most clusters; raise it if your cluster has more
+    /// active members. See [`with_max_peers`](Config::with_max_peers).
+    ///
+    /// The cap applies to *all* unknown senders, including read-only mirrors, which never become
+    /// members themselves: while the membership set is saturated, a newly connecting mirror is
+    /// also rejected and cannot sync until a member slot frees up. Size the cap for members
+    /// *plus* expected mirrors.
+    pub max_peers: usize,
+    /// Maximum number of concurrently active paced bulk dumps across all peers.
+    ///
+    /// A paced bulk dump holds a full snapshot `Vec` of the differing range (potentially the
+    /// whole dataset) for the duration of the transfer. Without a global cap, M peers diffing
+    /// simultaneously would each hold such a snapshot — M × dataset memory plus M × egress
+    /// at [`bulk_send_rate`](Self::bulk_send_rate). This field limits the total number of
+    /// in-flight dump tasks regardless of peer count.
+    ///
+    /// When the budget is exhausted a new dump is skipped **before** the snapshot Vec is
+    /// allocated; the protocol is retry-driven, so the requesting peer's next diff round
+    /// re-triggers the dump once a slot is free.
+    ///
+    /// Defaults to 4. Raise if your cluster has many simultaneous cold peers and the host has
+    /// sufficient memory; lower for tighter memory caps. See
+    /// [`with_max_concurrent_bulk_dumps`](Config::with_max_concurrent_bulk_dumps).
+    pub max_concurrent_bulk_dumps: usize,
 }
 impl Default for Config {
     fn default() -> Self {
@@ -836,6 +914,8 @@ impl Default for Config {
             recv_buffer_size: Some(DEFAULT_SOCKET_BUFFER_SIZE),
             send_buffer_size: Some(DEFAULT_SOCKET_BUFFER_SIZE),
             freshness_window: crate::replay::FRESHNESS_WINDOW_DEFAULT,
+            max_peers: DEFAULT_MAX_PEERS,
+            max_concurrent_bulk_dumps: DEFAULT_MAX_CONCURRENT_BULK_DUMPS,
         }
     }
 }
@@ -968,6 +1048,27 @@ impl Config {
         self
     }
 
+    /// Set the maximum number of distinct peers this node will track (default 1024).
+    ///
+    /// Datagrams from unknown senders are silently dropped when the membership set is at capacity,
+    /// before any per-sender state is created. Already-tracked peers are unaffected.
+    /// See [`max_peers`](Config::max_peers) for the full semantics.
+    pub fn with_max_peers(mut self, max: usize) -> Self {
+        self.max_peers = max;
+        self
+    }
+
+    /// Set the maximum number of concurrently active paced bulk dumps (default 4).
+    ///
+    /// When the budget is exhausted a new dump is skipped before allocating its snapshot Vec;
+    /// the protocol is retry-driven, so the peer re-triggers the dump on its next diff round once
+    /// a slot is free.
+    /// See [`max_concurrent_bulk_dumps`](Config::max_concurrent_bulk_dumps) for the full semantics.
+    pub fn with_max_concurrent_bulk_dumps(mut self, max: usize) -> Self {
+        self.max_concurrent_bulk_dumps = max;
+        self
+    }
+
     /// Encrypt datagram payloads with XChaCha20-Poly1305, upgrading the keyed protocol from
     /// authentication-only to authenticated **encryption**.
     ///
@@ -1020,6 +1121,8 @@ mod reconcile_store_tests {
             recv_buffer_size: Some(super::DEFAULT_SOCKET_BUFFER_SIZE),
             send_buffer_size: Some(super::DEFAULT_SOCKET_BUFFER_SIZE),
             freshness_window: crate::replay::FRESHNESS_WINDOW_DEFAULT,
+            max_peers: super::DEFAULT_MAX_PEERS,
+            max_concurrent_bulk_dumps: super::DEFAULT_MAX_CONCURRENT_BULK_DUMPS,
         }
     }
 
@@ -1462,5 +1565,274 @@ mod reconcile_store_tests {
             std::io::ErrorKind::AddrInUse,
             "bind failure should surface as AddrInUse, got {err:?}"
         );
+    }
+
+    // ── per-peer cap ──────────────────────────────────────────────────────────
+
+    /// The default cap must be 1024.
+    #[test]
+    fn peer_cap_default_is_1024() {
+        assert_eq!(Config::default().max_peers, 1024);
+    }
+
+    /// Helper: craft a raw bincode payload containing a single `ComparisonItem` drawn from an empty
+    /// tree, suitable for sending to an unauthenticated store.  The engine deserializes any
+    /// `ComparisonItem` as a dated message, so `spoke_dated` becomes `true` and the receive path
+    /// would add the sender to `members` — unless the cap fires first.
+    fn dated_comparison_payload() -> Vec<u8> {
+        use crate::proto;
+        use crate::reconcile_engine::Message;
+        use crate::HRTree;
+        use bincode::{DefaultOptions, Serializer};
+        use serde::Serialize as _;
+
+        let tree = HRTree::<i32, (crate::clock::Timestamp, Option<i32>)>::new();
+        let segments = proto::start_diff(&tree);
+        let mut buf = Vec::new();
+        for seg in segments {
+            Message::<
+                i32,
+                (crate::clock::Timestamp, Option<i32>),
+                (crate::clock::Timestamp, Option<i32>),
+            >::ComparisonItem(seg)
+            .serialize(&mut Serializer::new(&mut buf, DefaultOptions::new()))
+            .expect("serializing ComparisonItem into a Vec cannot fail");
+        }
+        buf
+    }
+
+    /// When the membership set is at capacity, datagrams from a completely unknown sender are
+    /// dropped silently: the sender is not added to `members`, `peers`, or the replay filter.
+    /// Known members (already in `members`) are unaffected at cap.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn peer_cap_blocks_unknown_sender_at_capacity() {
+        let port = 9801u16;
+        let target_addr: std::net::IpAddr = "127.0.0.180".parse().unwrap();
+        let peer1: std::net::IpAddr = "127.0.0.181".parse().unwrap();
+        let peer2: std::net::IpAddr = "127.0.0.182".parse().unwrap();
+        let newcomer: std::net::IpAddr = "127.0.0.183".parse().unwrap();
+
+        let config = Config::default()
+            .with_port(port)
+            .with_listen_addr(target_addr)
+            .with_net("127.0.0.180/30".parse().unwrap())
+            .with_max_peers(2);
+
+        let store = ReconcileStore::<i32, i32>::new(config)
+            .await
+            .expect("bind failed");
+
+        // Seed two known members directly (simulates two peers that already completed a
+        // dated handshake with this store before the test window).
+        store.engine.members.write().insert(peer1);
+        store.engine.members.write().insert(peer2);
+
+        let task = tokio::spawn(store.clone().run());
+
+        // Give the run loop time to enter its receive wait.
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        // Send a valid dated payload from the newcomer's IP several times to ensure at least one
+        // reaches the receive loop; all must be dropped by the cap.
+        let payload = dated_comparison_payload();
+        let sender = tokio::net::UdpSocket::bind(std::net::SocketAddr::new(newcomer, 0))
+            .await
+            .expect("bind sender");
+        for _ in 0..5 {
+            let _ = sender
+                .send_to(&payload, std::net::SocketAddr::new(target_addr, port))
+                .await;
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+
+        // Give the receive loop time to process any remaining datagrams.
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+        // The newcomer must not appear in any map regardless of how many datagrams arrived.
+        assert!(
+            !store.engine.members.read().contains(&newcomer),
+            "capped-out sender must not be added to members"
+        );
+        assert!(
+            !store.engine.peers.read().contains_key(&newcomer),
+            "capped-out sender must not be added to peers"
+        );
+
+        task.abort();
+    }
+
+    /// A sender that is already a member continues to be processed normally when the cap is reached.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn peer_cap_allows_known_member_at_capacity() {
+        let port = 9802u16;
+        let target_addr: std::net::IpAddr = "127.0.0.184".parse().unwrap();
+        let peer1: std::net::IpAddr = "127.0.0.185".parse().unwrap();
+        let peer2: std::net::IpAddr = "127.0.0.186".parse().unwrap();
+
+        let config = Config::default()
+            .with_port(port)
+            .with_listen_addr(target_addr)
+            .with_net("127.0.0.184/30".parse().unwrap())
+            .with_max_peers(2);
+
+        let store = ReconcileStore::<i32, i32>::new(config)
+            .await
+            .expect("bind failed");
+
+        store.engine.members.write().insert(peer1);
+        store.engine.members.write().insert(peer2);
+
+        let task = tokio::spawn(store.clone().run());
+
+        // Give the run loop time to enter its receive wait.
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        // Send a valid dated payload FROM a known member (peer1), retrying until accepted.
+        let payload = dated_comparison_payload();
+        let sender = tokio::net::UdpSocket::bind(std::net::SocketAddr::new(peer1, 0))
+            .await
+            .expect("bind sender");
+
+        let mut peers_refreshed = false;
+        for _ in 0..50 {
+            let _ = sender
+                .send_to(&payload, std::net::SocketAddr::new(target_addr, port))
+                .await;
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+            if store.engine.peers.read().contains_key(&peer1) {
+                peers_refreshed = true;
+                break;
+            }
+        }
+
+        // Known member must still be present (not evicted).
+        assert!(
+            store.engine.members.read().contains(&peer1),
+            "known member must not be evicted by the cap"
+        );
+        // The peers entry is (re-)inserted when the datagram is processed.
+        assert!(
+            peers_refreshed,
+            "known member's peers entry must be refreshed normally"
+        );
+
+        task.abort();
+    }
+
+    /// Decommissioning a member frees its slot: the engine's membership set shrinks and the
+    /// cap check allows a new sender through once a slot becomes available.
+    ///
+    /// This test verifies the state invariants directly (without the network path, which is
+    /// already exercised by [`peer_cap_blocks_unknown_sender_at_capacity`]).
+    #[tokio::test]
+    async fn decommission_frees_peer_cap_slot() {
+        let peer1: std::net::IpAddr = "127.1.0.1".parse().unwrap();
+        let peer2: std::net::IpAddr = "127.1.0.2".parse().unwrap();
+        let newcomer: std::net::IpAddr = "127.1.0.3".parse().unwrap();
+
+        let config = Config::default()
+            .with_port(0)
+            .with_listen_addr("127.0.0.1".parse().unwrap())
+            .with_max_peers(2);
+
+        let store = ReconcileStore::<i32, i32>::new(config)
+            .await
+            .expect("bind failed");
+
+        // Seed two members (simulates two peers that completed a dated exchange).
+        store.engine.members.write().insert(peer1);
+        store.engine.members.write().insert(peer2);
+        assert_eq!(store.engine.members.read().len(), 2);
+
+        // At cap: a newcomer would be blocked.
+        assert!(
+            store.engine.members.read().len() >= 2,
+            "precondition: at cap"
+        );
+        assert!(
+            !store.engine.members.read().contains(&newcomer),
+            "precondition: newcomer not yet in members"
+        );
+
+        // Decommission peer2, freeing one slot.
+        store.forget_peer(peer2);
+        assert_eq!(
+            store.engine.members.read().len(),
+            1,
+            "one member after decommission"
+        );
+        assert!(
+            !store.engine.members.read().contains(&peer2),
+            "peer2 must be removed from members"
+        );
+        // The peers gossip-routing entry must also be gone (so capacity is visible to the
+        // cap check path, and decommission does not leave a ghost entry in the peers map).
+        assert!(
+            !store.engine.peers.read().contains_key(&peer2),
+            "peer2 must be removed from peers by decommission"
+        );
+
+        // After decommission: members.len() == 1 < max_peers == 2.
+        // The cap check allows the newcomer through: current_len < 2.
+        let current_len = store.engine.members.read().len();
+        let is_known = store.engine.members.read().contains(&newcomer);
+        assert!(
+            is_known || current_len < 2,
+            "newcomer must not be capped out (members.len={current_len}) after decommission freed a slot"
+        );
+    }
+
+    /// In authenticated mode, datagrams from a capped-out sender must not create a replay-filter
+    /// entry.  The cap check runs before `replay_filter.check_and_record` for unknown senders.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn peer_cap_no_replay_entry_for_capped_sender() {
+        let port = 9804u16;
+        let target_addr: std::net::IpAddr = "127.0.0.192".parse().unwrap();
+        let peer1: std::net::IpAddr = "127.0.0.193".parse().unwrap();
+        let peer2: std::net::IpAddr = "127.0.0.194".parse().unwrap();
+        let newcomer: std::net::IpAddr = "127.0.0.195".parse().unwrap();
+        let cluster_key = [0x55u8; 32];
+
+        let config = Config::default()
+            .with_port(port)
+            .with_listen_addr(target_addr)
+            .with_net("127.0.0.192/30".parse().unwrap())
+            .with_cluster_key(cluster_key)
+            .with_max_peers(2);
+
+        let store = ReconcileStore::<i32, i32>::new(config)
+            .await
+            .expect("bind failed");
+
+        store.engine.members.write().insert(peer1);
+        store.engine.members.write().insert(peer2);
+
+        let task = tokio::spawn(store.clone().run());
+
+        // Craft a sealed (authenticated) dated datagram from the newcomer's IP.
+        let payload = dated_comparison_payload();
+        let counter = crate::replay::SenderCounter::new();
+        let sealed = crate::auth::Authenticator::new(Some(cluster_key), false)
+            .seal(counter.next_seq(), counter.next_stamp(), &payload)
+            .expect("enabled authenticator always seals");
+
+        let sender = tokio::net::UdpSocket::bind(std::net::SocketAddr::new(newcomer, 0))
+            .await
+            .expect("bind sender");
+        sender
+            .send_to(&sealed, std::net::SocketAddr::new(target_addr, port))
+            .await
+            .expect("send");
+
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+        // The cap fired before the replay filter: no replay entry must have been created.
+        assert_eq!(
+            store.engine.replay_filter_len(),
+            0,
+            "no replay-filter entry must be created for a capped-out sender"
+        );
+
+        task.abort();
     }
 }

--- a/src/reconcile_store.rs
+++ b/src/reconcile_store.rs
@@ -72,13 +72,9 @@ const DEFAULT_MAX_PEERS: usize = 1024;
 const DEFAULT_MAX_CONCURRENT_BULK_DUMPS: usize = 4;
 
 /// Default wall-time floor before a member with pending unacked tombstones may be decommissioned
-/// by the discovery task (see [`ReconcileStore::with_discovery_decommission_floor`]).
-///
-/// 10 minutes is long enough to absorb a readiness-probe blip that drops a pod from a Kubernetes
-/// headless Service (the event this floor was designed for) while still reclaiming the GC gate
-/// within a reasonable horizon when a member is genuinely gone. Members with **no** pending
-/// tombstone acks are not subject to the floor and are decommissioned as soon as
-/// `miss_threshold` rounds have elapsed.
+/// (see [`ReconcileStore::with_discovery_decommission_floor`]). 10 minutes absorbs a Kubernetes
+/// readiness-probe blip without stalling GC reclaim when a member is genuinely gone. Members with
+/// no pending acks skip the floor and decommission as soon as `miss_threshold` rounds elapse.
 const DEFAULT_DISCOVERY_DECOMMISSION_FLOOR: Duration = Duration::from_secs(600);
 
 /// Core service wrapping a key-value map to enable reconciliation between different instances over a network.
@@ -346,25 +342,11 @@ impl<K: Key, V: Value> ReconcileStore<K, V> {
         self
     }
 
-    /// Set the minimum continuous absence before a member with **pending unacked tombstones**
-    /// may be decommissioned by the discovery task (default 10 minutes).
-    ///
-    /// When a member has been absent from consecutive discovery rounds for at least
-    /// `miss_threshold` but still has tombstones it has never acknowledged, the discovery task
-    /// will not release the member's causal-stability gate until it has been absent continuously
-    /// for at least this duration. The absence clock resets whenever the member reappears in a
-    /// discovery round, so a transient blip — including a Kubernetes readiness-probe hiccup that
-    /// momentarily drops a pod from the headless Service — cannot advance it.
-    ///
-    /// Members with **no** pending tombstone acks are unaffected by this floor: they are
-    /// decommissioned as soon as `miss_threshold` rounds have elapsed, preserving the existing
-    /// fast-path behaviour for the common case.
-    ///
-    /// **Trade-off**: a longer floor provides stronger protection against tombstone resurrection
-    /// (a member that was briefly absent cannot cause a deleted value to reappear on its return),
-    /// at the cost of delaying the GC-slot release for members that are genuinely gone. Tune
-    /// this value to be comfortably larger than the longest expected transient absence
-    /// (readiness-probe blip, rolling restart, brief network partition) in your environment.
+    /// Set the minimum *continuous* absence (default 10 minutes) — the clock resets on every
+    /// reappearance — before a member with pending unacked tombstones is decommissioned. Longer
+    /// resists resurrection more strongly at the cost of a slower GC-slot release for members that
+    /// are genuinely gone; tune it above the longest expected transient absence in your
+    /// environment.
     pub fn with_discovery_decommission_floor(mut self, floor: Duration) -> Self {
         self.discovery_decommission_floor = floor;
         self
@@ -949,35 +931,22 @@ pub struct Config {
     pub freshness_window: Duration,
     /// Maximum number of distinct remote peers (members) this node will track.
     ///
-    /// When the membership set is at capacity, datagrams from completely unknown senders are
-    /// dropped **before** any per-sender state (membership, gossip-peer record, or replay-filter
-    /// entry) is allocated. Senders that are already tracked are unaffected at cap, and calling
-    /// [`forget_peer`](crate::ReconcileStore::forget_peer) on a member immediately frees its slot.
+    /// At capacity, a datagram from a completely unknown sender is dropped before any per-sender
+    /// state is allocated; already-tracked senders are unaffected, and
+    /// [`forget_peer`](crate::ReconcileStore::forget_peer) frees a slot immediately. Defence in
+    /// depth for unauthenticated deployments, a hard ceiling for authenticated ones. Default 1024
+    /// — see [`with_max_peers`](Config::with_max_peers).
     ///
-    /// The cap is defence-in-depth for unauthenticated deployments (where any spoofed source
-    /// address would otherwise grow the maps without bound), and a hard ceiling for authenticated
-    /// ones. The default of 1024 is generous for most clusters; raise it if your cluster has more
-    /// active members. See [`with_max_peers`](Config::with_max_peers).
-    ///
-    /// The cap applies to *all* unknown senders, including read-only mirrors, which never become
-    /// members themselves: while the membership set is saturated, a newly connecting mirror is
-    /// also rejected and cannot sync until a member slot frees up. Size the cap for members
-    /// *plus* expected mirrors.
+    /// Applies to read-only mirrors too, which never become members: a saturated set also blocks
+    /// new mirrors from syncing. Size for members *plus* expected mirrors.
     pub max_peers: usize,
     /// Maximum number of concurrently active paced bulk dumps across all peers.
     ///
-    /// A paced bulk dump holds a full snapshot `Vec` of the differing range (potentially the
-    /// whole dataset) for the duration of the transfer. Without a global cap, M peers diffing
-    /// simultaneously would each hold such a snapshot — M × dataset memory plus M × egress
-    /// at [`bulk_send_rate`](Self::bulk_send_rate). This field limits the total number of
-    /// in-flight dump tasks regardless of peer count.
-    ///
-    /// When the budget is exhausted a new dump is skipped **before** the snapshot Vec is
-    /// allocated; the protocol is retry-driven, so the requesting peer's next diff round
-    /// re-triggers the dump once a slot is free.
-    ///
-    /// Defaults to 4. Raise if your cluster has many simultaneous cold peers and the host has
-    /// sufficient memory; lower for tighter memory caps. See
+    /// A bulk dump holds a full snapshot `Vec` of the differing range — potentially the whole
+    /// dataset — for the transfer's duration, so M simultaneous cold peers would otherwise cost
+    /// M × dataset memory. Exhausting the budget skips a new dump before the snapshot is
+    /// allocated; the protocol is retry-driven, so the peer's next diff round retries once a slot
+    /// frees. Default 4 — see
     /// [`with_max_concurrent_bulk_dumps`](Config::with_max_concurrent_bulk_dumps).
     pub max_concurrent_bulk_dumps: usize,
 }
@@ -1141,12 +1110,7 @@ impl Config {
         self
     }
 
-    /// Set the maximum number of concurrently active paced bulk dumps (default 4).
-    ///
-    /// When the budget is exhausted a new dump is skipped before allocating its snapshot Vec;
-    /// the protocol is retry-driven, so the peer re-triggers the dump on its next diff round once
-    /// a slot is free.
-    /// See [`max_concurrent_bulk_dumps`](Config::max_concurrent_bulk_dumps) for the full semantics.
+    /// Set [`max_concurrent_bulk_dumps`](Config::max_concurrent_bulk_dumps) (default 4).
     pub fn with_max_concurrent_bulk_dumps(mut self, max: usize) -> Self {
         self.max_concurrent_bulk_dumps = max;
         self

--- a/src/replay.rs
+++ b/src/replay.rs
@@ -378,6 +378,14 @@ impl ReplayFilter {
         }
     }
 
+    /// Number of peers currently tracked by the filter.
+    ///
+    /// Exposed for test assertions under the `internal-testing` feature gate.
+    #[cfg(any(test, feature = "internal-testing"))]
+    pub(crate) fn len(&self) -> usize {
+        self.peers.lock().len()
+    }
+
     /// Remove the replay state for a peer, freeing its memory immediately.
     ///
     /// This is an explicit escape hatch for tests. Production code does not call this — per-peer

--- a/tests/discovery.rs
+++ b/tests/discovery.rs
@@ -6,9 +6,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-//! End-to-end test of dynamic discovery through the public `run()` path: a peer that disappears
-//! from the discovery source is decommissioned after the grace period, releasing the causal
-//! stability gate that was holding back a tombstone's garbage collection.
+//! End-to-end tests of dynamic discovery through the public `run()` path: decommissioning,
+//! tombstone-GC gating, and the wall-time floor that guards against resurrection under DNS
+//! flakiness.
 
 use std::net::IpAddr;
 use std::sync::{Arc, Mutex};
@@ -83,7 +83,11 @@ async fn vanished_peer_is_decommissioned_and_tombstone_collected() {
         .with_tombstone_timeout(Duration::from_millis(50))
         .with_discovery(Arc::new(discovery.clone()))
         .with_discovery_interval(Duration::from_millis(20))
-        .with_discovery_miss_threshold(3);
+        .with_discovery_miss_threshold(3)
+        // A short floor so the test completes in reasonable time after the peer vanishes.
+        // The floor only delays decommission when tombstone acks are pending; using 150 ms
+        // here lets the test exercise the slow path (ack pending → wait floor → GC) quickly.
+        .with_discovery_decommission_floor(Duration::from_millis(150));
     let store2 = ReconcileStore::<i32, i32>::new(cfg2)
         .await
         .expect("bind failed")
@@ -112,10 +116,381 @@ async fn vanished_peer_is_decommissioned_and_tombstone_collected() {
         "tombstone collected while the peer was still reported present (resurrection hazard)"
     );
 
-    // The peer now disappears from discovery: after the grace period it is decommissioned and the
-    // tombstone becomes causally stable, so GC proceeds.
+    // The peer now disappears from discovery: after the grace period (miss_threshold rounds) and
+    // the decommission floor (150 ms) the peer is decommissioned and the tombstone is GC'd.
     discovery.set(vec![]);
     assert_until!(store1.fingerprint(..) != hash_with_tombstone);
 
     task1.abort();
+}
+
+// ── Wall-time floor tests ─────────────────────────────────────────────────────────────────────
+//
+// These tests inspect the membership set directly, which requires the `internal-testing` feature
+// gate (the same gate used by the peer-cap and replay tests in `tests/service.rs`).
+
+#[cfg(feature = "internal-testing")]
+mod floor {
+    use super::*;
+    use reconcile::testing::{members_snapshot, peers_contains, tombstone_acks_len};
+
+    /// Helper: build a `Config` for a loopback address + port with an isolated /32 net so random
+    /// probing never escapes to other tests' ports.
+    fn floor_cfg(addr: IpAddr, port: u16) -> Config {
+        let net = format!("{addr}/32").parse().unwrap();
+        Config::default()
+            .with_port(port)
+            .with_listen_addr(addr)
+            .with_net(net)
+    }
+
+    /// **Resurrection regression test (test 1)**: when member B vanishes from DNS and
+    /// `miss_threshold` rounds elapse but the wall-time floor has not, B must NOT be
+    /// decommissioned and the tombstone must NOT be GC'd.
+    ///
+    /// This is the acceptance criterion for the resurrection hazard: the tombstone is kept alive
+    /// exactly because B is still a member of the causal-stability set.  If the floor were absent,
+    /// `miss_threshold` rounds alone would fire `decommission_peer`, remove B from the GC gate, and
+    /// allow the tombstone to be collected — so a returning B could push the deleted value back.
+    /// With a 10 s floor (far beyond the test window) decommission is blocked even after
+    /// `miss_threshold` rounds when pending tombstone acks exist.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn floor_prevents_premature_decommission_and_resurrection() {
+        let port = 8098u16;
+        let addr_a: IpAddr = "127.0.0.88".parse().unwrap();
+        let addr_b: IpAddr = "127.0.0.89".parse().unwrap();
+
+        let discovery = ScriptedDiscovery::new(vec![addr_b]);
+        // Floor is 10 s — far longer than the test runs, so the floor never elapses here.
+        let store_a = ReconcileStore::<i32, i32>::new(floor_cfg(addr_a, port))
+            .await
+            .expect("bind failed")
+            .with_seed(addr_b)
+            .with_tombstone_timeout(Duration::from_millis(50))
+            .with_discovery(Arc::new(discovery.clone()))
+            .with_discovery_interval(Duration::from_millis(20))
+            .with_discovery_miss_threshold(2)
+            .with_discovery_decommission_floor(Duration::from_secs(10));
+        let store_b = ReconcileStore::<i32, i32>::new(floor_cfg(addr_b, port))
+            .await
+            .expect("bind failed")
+            .with_seed(addr_a)
+            .with_tombstone_timeout(Duration::from_millis(50));
+
+        let task_a = tokio::spawn(store_a.clone().run());
+        let task_b = tokio::spawn(store_b.clone().run());
+
+        // Establish mutual membership: both stores exchange dated datagrams.
+        store_a.insert(1, 100);
+        assert_until!(store_b.get(&1).as_deref() == Some(&100));
+        store_b.insert(2, 200);
+        assert_until!(store_a.get(&2).as_deref() == Some(&200));
+
+        // Abort B and delete key 1 on A so a tombstone is outstanding with B's ack pending.
+        task_b.abort();
+        store_a.remove(&1);
+        assert!(store_a.get(&1).is_none());
+        let hash_with_tombstone = store_a.fingerprint(..);
+
+        // Confirm discovery has observed B at least once (B is in the peers map) before clearing
+        // the resolver, so the `seen_ever` guard inside `discover_periodically` cannot skip it.
+        assert_until!(peers_contains(&store_a, addr_b));
+
+        // Remove B from discovery: miss_threshold rounds will elapse but the floor has not.
+        discovery.set(vec![]);
+
+        // Wait long enough for miss_threshold rounds to pass (2 × 20 ms + slack).
+        tokio::time::sleep(Duration::from_millis(300)).await;
+
+        // B must still be a member (floor not elapsed) and the tombstone must not be GC'd.
+        // This is the core of the resurrection guard: as long as B is a member the tombstone
+        // cannot be collected, so B cannot push the value back on its return.
+        assert!(
+            members_snapshot(&store_a).contains(&addr_b),
+            "B was prematurely decommissioned before the floor elapsed"
+        );
+        assert_eq!(
+            store_a.fingerprint(..),
+            hash_with_tombstone,
+            "tombstone was GC'd before the decommission floor elapsed (resurrection hazard)"
+        );
+
+        task_a.abort();
+    }
+
+    /// **Test 2**: when the floor elapses with a pending tombstone ack, the member IS
+    /// decommissioned and the GC slot is released.  Uses a 100 ms floor so the test completes
+    /// quickly without sleeping for 10 minutes.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn floor_elapsed_decommissions_member_with_pending_tombstones() {
+        let port = 8099u16;
+        let addr_a: IpAddr = "127.0.0.90".parse().unwrap();
+        let addr_b: IpAddr = "127.0.0.91".parse().unwrap();
+
+        let discovery = ScriptedDiscovery::new(vec![addr_b]);
+        let store_a = ReconcileStore::<i32, i32>::new(floor_cfg(addr_a, port))
+            .await
+            .expect("bind failed")
+            .with_seed(addr_b)
+            .with_tombstone_timeout(Duration::from_millis(50))
+            .with_discovery(Arc::new(discovery.clone()))
+            .with_discovery_interval(Duration::from_millis(20))
+            .with_discovery_miss_threshold(2)
+            .with_discovery_decommission_floor(Duration::from_millis(100));
+        let store_b = ReconcileStore::<i32, i32>::new(floor_cfg(addr_b, port))
+            .await
+            .expect("bind failed")
+            .with_seed(addr_a)
+            .with_tombstone_timeout(Duration::from_millis(50));
+
+        let task_a = tokio::spawn(store_a.clone().run());
+        let task_b = tokio::spawn(store_b.clone().run());
+
+        // Establish mutual membership.
+        store_a.insert(10, 1000);
+        assert_until!(store_b.get(&10).as_deref() == Some(&1000));
+        store_b.insert(20, 2000);
+        assert_until!(store_a.get(&20).as_deref() == Some(&2000));
+
+        // Abort B and create a tombstone on A.
+        task_b.abort();
+        store_a.remove(&10);
+        let hash_with_tombstone = store_a.fingerprint(..);
+
+        // Confirm discovery has observed B at least once before clearing the resolver.
+        assert_until!(peers_contains(&store_a, addr_b));
+
+        // Remove B from discovery; floor is 100 ms, so after enough time B is decommissioned.
+        discovery.set(vec![]);
+
+        // Wait for decommission: floor (100 ms) + miss_threshold (2 × 20 ms) + slack.
+        assert_until!(!members_snapshot(&store_a).contains(&addr_b));
+
+        // Once B is gone the tombstone should be GC'd.
+        assert_until!(store_a.fingerprint(..) != hash_with_tombstone);
+
+        task_a.abort();
+    }
+
+    /// **Test 3**: a member with NO pending tombstone acks is decommissioned after exactly
+    /// `miss_threshold` rounds, with no wall-time floor delay — the existing fast path is
+    /// preserved.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn no_pending_tombstones_decommissions_at_miss_threshold() {
+        let port = 8100u16;
+        let addr_a: IpAddr = "127.0.0.92".parse().unwrap();
+        let addr_b: IpAddr = "127.0.0.93".parse().unwrap();
+
+        let discovery = ScriptedDiscovery::new(vec![addr_b]);
+        // Floor is 10 s; it must NOT delay decommission when there are no pending acks.
+        let store_a = ReconcileStore::<i32, i32>::new(floor_cfg(addr_a, port))
+            .await
+            .expect("bind failed")
+            .with_seed(addr_b)
+            .with_discovery(Arc::new(discovery.clone()))
+            .with_discovery_interval(Duration::from_millis(20))
+            .with_discovery_miss_threshold(2)
+            .with_discovery_decommission_floor(Duration::from_secs(10));
+        let store_b = ReconcileStore::<i32, i32>::new(floor_cfg(addr_b, port))
+            .await
+            .expect("bind failed")
+            .with_seed(addr_a);
+
+        let task_a = tokio::spawn(store_a.clone().run());
+        let task_b = tokio::spawn(store_b.clone().run());
+
+        // Establish mutual membership (no tombstones involved).
+        store_a.insert(100, 1);
+        assert_until!(store_b.get(&100).as_deref() == Some(&1));
+        store_b.insert(200, 2);
+        assert_until!(store_a.get(&200).as_deref() == Some(&2));
+
+        // Confirm discovery has observed B at least once (so the `seen_ever` guard inside
+        // `discover_periodically` will not skip B when it goes absent) before clearing the
+        // resolver. Without this wait the clear can race ahead of the first discovery round and
+        // B would never enter `seen_ever`, causing the decommission logic to skip it forever.
+        assert_until!(peers_contains(&store_a, addr_b));
+
+        // Abort B and remove it from discovery; no tombstones are outstanding.
+        task_b.abort();
+        discovery.set(vec![]);
+
+        // B should be decommissioned promptly (miss_threshold rounds, no floor delay).
+        assert_until!(!members_snapshot(&store_a).contains(&addr_b));
+
+        task_a.abort();
+    }
+
+    /// **Test 4**: reappearance resets the absence clock.  Scenario: B vanishes, then reappears
+    /// before the floor, then vanishes again.  The floor is measured from the *second* vanish.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn reappearance_resets_absence_clock() {
+        let port = 8101u16;
+        let addr_a: IpAddr = "127.0.0.94".parse().unwrap();
+        let addr_b: IpAddr = "127.0.0.95".parse().unwrap();
+
+        let discovery = ScriptedDiscovery::new(vec![addr_b]);
+        // 200 ms floor; short enough to test elapsed in the second-absence window.
+        let store_a = ReconcileStore::<i32, i32>::new(floor_cfg(addr_a, port))
+            .await
+            .expect("bind failed")
+            .with_seed(addr_b)
+            .with_tombstone_timeout(Duration::from_millis(50))
+            .with_discovery(Arc::new(discovery.clone()))
+            .with_discovery_interval(Duration::from_millis(20))
+            .with_discovery_miss_threshold(2)
+            .with_discovery_decommission_floor(Duration::from_millis(200));
+        let store_b = ReconcileStore::<i32, i32>::new(floor_cfg(addr_b, port))
+            .await
+            .expect("bind failed")
+            .with_seed(addr_a)
+            .with_tombstone_timeout(Duration::from_millis(50));
+
+        let task_a = tokio::spawn(store_a.clone().run());
+        let task_b = tokio::spawn(store_b.clone().run());
+
+        // Establish mutual membership and leave a tombstone pending.
+        store_a.insert(1000, 42);
+        assert_until!(store_b.get(&1000).as_deref() == Some(&42));
+        store_b.insert(2000, 84);
+        assert_until!(store_a.get(&2000).as_deref() == Some(&84));
+
+        task_b.abort();
+        store_a.remove(&1000);
+        let hash_with_tombstone = store_a.fingerprint(..);
+
+        // Confirm discovery has observed B at least once before clearing the resolver so the
+        // `seen_ever` guard inside `discover_periodically` tracks B correctly.
+        assert_until!(peers_contains(&store_a, addr_b));
+
+        // First absence: vanish for a bit but reappear before the floor.
+        discovery.set(vec![]);
+        // Less than the 200 ms floor; absence clock must not yet have triggered decommission.
+        tokio::time::sleep(Duration::from_millis(80)).await;
+        // Reappear: absence clock must reset.
+        discovery.set(vec![addr_b]);
+        tokio::time::sleep(Duration::from_millis(60)).await;
+
+        // B must still be a member (the first-absence clock was reset on reappearance).
+        assert!(
+            members_snapshot(&store_a).contains(&addr_b),
+            "B was decommissioned during or just after the first absence window"
+        );
+        assert_eq!(
+            store_a.fingerprint(..),
+            hash_with_tombstone,
+            "tombstone GC'd during the first absence window"
+        );
+
+        // Second absence: remove B again; floor is 200 ms.
+        discovery.set(vec![]);
+
+        // Wait for the floor measured from the second vanish to elapse.
+        assert_until!(!members_snapshot(&store_a).contains(&addr_b));
+        assert_until!(store_a.fingerprint(..) != hash_with_tombstone);
+
+        task_a.abort();
+    }
+
+    /// **Test 5 — zero-ack deletion**: the floor must hold for a tombstone that has received no
+    /// acknowledgment at all.
+    ///
+    /// A tombstone nobody has acked yet has no `tombstone_acks` entry, so a pending-acks
+    /// predicate that iterates `tombstone_acks` cannot see it and reports "nothing pending" —
+    /// triggering the fast-path decommission while `is_tombstone_stable` is still false, letting
+    /// GC collect the tombstone and opening the resurrection window.  The predicate iterates the
+    /// map itself (the authoritative domain), so a fresh tombstone with zero acks is pending.
+    ///
+    /// Construction: B's run loop is aborted and **awaited to full termination before the
+    /// deletion is issued**, so the tombstone cannot reach B and zero acks is guaranteed by
+    /// ordering (asserted below), not by racing the abort.  A's config deliberately has NO
+    /// probe net: with the usual self-/32 net, A random-probes its own address, reconciles
+    /// with itself, and acks its own tombstone — which would break the zero-ack invariant
+    /// this test exists to exercise.  The `peers_contains` wait ensures discovery observed B
+    /// beforehand (the `seen_ever` guard admits B to the decommission path), and B stays in
+    /// `members` from the pre-deletion exchange.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn zero_ack_deletion_floor_holds() {
+        let port = 8102u16;
+        let addr_a: IpAddr = "127.0.0.96".parse().unwrap();
+        let addr_b: IpAddr = "127.0.0.97".parse().unwrap();
+
+        let discovery = ScriptedDiscovery::new(vec![addr_b]);
+        // Floor is 10 s — far longer than the test window, so it must never elapse here.
+        // No `.with_net(...)`: seeded/discovered peers are contacted every round regardless;
+        // only the self-probing has to go.
+        let store_a = ReconcileStore::<i32, i32>::new(
+            Config::default().with_port(port).with_listen_addr(addr_a),
+        )
+        .await
+        .expect("bind failed")
+        .with_seed(addr_b)
+        .with_tombstone_timeout(Duration::from_millis(50))
+        .with_discovery(Arc::new(discovery.clone()))
+        .with_discovery_interval(Duration::from_millis(20))
+        .with_discovery_miss_threshold(2)
+        .with_discovery_decommission_floor(Duration::from_secs(10));
+        let store_b = ReconcileStore::<i32, i32>::new(floor_cfg(addr_b, port))
+            .await
+            .expect("bind failed")
+            .with_seed(addr_a)
+            .with_tombstone_timeout(Duration::from_millis(50));
+
+        let task_a = tokio::spawn(store_a.clone().run());
+        let task_b = tokio::spawn(store_b.clone().run());
+
+        // Establish mutual membership so B enters the causal-stability gate.
+        store_a.insert(42, 1);
+        assert_until!(store_b.get(&42).as_deref() == Some(&1));
+        store_b.insert(99, 2);
+        assert_until!(store_a.get(&99).as_deref() == Some(&2));
+
+        // Wait until B is in A's membership set (the causal-stability gate that blocks tombstone
+        // GC). This requires a dated datagram from B to have been processed by A, which the data
+        // exchange above triggers. We wait explicitly rather than relying on implicit timing.
+        assert_until!(members_snapshot(&store_a).contains(&addr_b));
+
+        // Wait until discovery has seeded B in the peers map, confirming that at least one
+        // discovery round has run and B will enter `seen_ever` inside `discover_periodically`.
+        assert_until!(peers_contains(&store_a, addr_b));
+
+        // Terminate B completely BEFORE the deletion exists: abort the run loop and await the
+        // join handle, so B can never receive the tombstone, never ack it, and never send
+        // another dated datagram that would re-assert its membership.
+        task_b.abort();
+        let _ = task_b.await;
+        drop(store_b);
+
+        store_a.remove(&42);
+        let hash_with_tombstone = store_a.fingerprint(..);
+        discovery.set(vec![]);
+
+        // Allow miss_threshold rounds to pass (2 × 20 ms + slack) but well within the 10 s floor.
+        tokio::time::sleep(Duration::from_millis(300)).await;
+
+        // Pin the construction: the tombstone for key 42 must have received no acks. If this
+        // ever fires, the ordering guarantee above broke and the test no longer exercises the
+        // zero-ack path it exists for.
+        assert_eq!(
+            tombstone_acks_len(&store_a),
+            0,
+            "construction broken: an ack arrived for the tombstone after B was terminated"
+        );
+
+        // Core assertions: with zero acks, a predicate blind to un-acked tombstones would have
+        // taken the fast path and decommissioned B at miss_threshold (~40 ms); the floor must
+        // instead hold B's membership and keep the tombstone un-GC'd.
+        assert!(
+            members_snapshot(&store_a).contains(&addr_b),
+            "B was prematurely decommissioned despite a zero-ack pending tombstone \
+             (resurrection hazard)"
+        );
+        assert_eq!(
+            store_a.fingerprint(..),
+            hash_with_tombstone,
+            "tombstone GC'd despite zero acks from B (resurrection hazard)"
+        );
+
+        task_a.abort();
+    }
 }


### PR DESCRIPTION
**Problem.** `DnsDiscovery` trusts the resolver wholesale, and a member absent from DNS answers for `miss_threshold` consecutive rounds (default ~15s) was `decommission_peer`'d — silently releasing its claim on the causal-stability tombstone-GC gate with no check for pending unacknowledged tombstones. A spoofed resolver, flaky kube-dns, or readiness-probe blip could decommission a healthy member, let GC collect a tombstone that member never acked, and the returning member would push the deleted value back: **resurrection** (invariant 6).

**Fix** (user-approved design — wall-time floor):
- Members missing from DNS with **no** pending unacked tombstones keep today's fast path (`miss_threshold` rounds).
- Members **with** pending unacked tombstones additionally require continuous absence ≥ `with_discovery_decommission_floor` — default **10 minutes**, far above any DNS blip or probe flap. Absence is tracked per member from the first missing round and resets on reappearance; `miss_counts` and `absent_since` reset together (no desync path).
- Explicit `forget_peer()` remains unconditional (operator override). Residual: an attacker controlling DNS answers for longer than the floor can still force decommission — the floor bounds the attack, the trade-off is documented on the knob.
- The pending predicate `has_pending_tombstone_acks` iterates the **local tombstone set** (map entries that are tombstones), treating the member as pending unless it acked the exact current version — mirroring `is_tombstone_stable`'s per-key test, so the floor holds precisely when GC would be blocked on that member. A tombstone with no ack entry at all (fresh deletion) is pending.

**Review provenance.** Two adversarial rounds with executable experiments:
1. REJECT — the first predicate iterated `tombstone_acks` (entries exist only once an ack *arrives*), making freshly-deleted zero-ack tombstones invisible: the reviewer proved fast-path decommission while `is_tombstone_stable` was still false → GC → resurrection, i.e. the exact hazard in its most likely form. Also caught a flaky floor test (`seen_ever` race, ~25-40% failure under `--all-features`) and a false-passing integration test.
2. APPROVE-WITH-FIXES — predicate fix verified semantically identical to GC's blocking condition (same version-token derivation); determinism re-verified 30/30; remaining fix (applied): the integration regression test was vacuous because `task_b.abort()` doesn't stop B before it acks. Final construction terminates B **and awaits the join handle before the deletion exists**, and removes the test's self-probe net (the `/32` probe config made A reconcile with *itself* and self-ack its own tombstone — an interesting find of its own). The reshaped test was demonstrated to fail against the old predicate at the premature-decommission assertion and passes 10/10 against the fix.

**Tests.** Unit: `fresh_tombstone_with_zero_acks_is_pending` (proven to fail on the old predicate). Integration (scripted resolver, no real DNS): floor holds through DNS omission + return with no resurrection; floor elapses → decommission proceeds; clean members keep the fast path; reappearance resets the absence clock; zero-ack deletion held by the floor (proven to fail pre-fix). All floor tests 10/10 deterministic.

Closes #201.

**Stack** — base: `claude/p1-2-bounded-growth` (#215). Merge after #215.

https://claude.ai/code/session_01BaajsC6gEk1v7Y55dA5cPG

---
_Generated by [Claude Code](https://claude.ai/code/session_01BaajsC6gEk1v7Y55dA5cPG)_