### PR TITLE
persistence: bounded snapshot stalls, crash consistency, fallible loading, configurable cadence

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ the cluster as an empty replica.
 
 In code, this would look like this:
 
-```rust
+```rust,ignore
 let mut store = ReconcileStore::new(Config::default()).await.unwrap();
 tokio::spawn(store.clone().run());
 // use the reconciliation store as a key-value store in the API
@@ -91,7 +91,7 @@ performance limitations.
 
 To close this vector, provide a shared 32-byte cluster secret on **every** node:
 
-```rust
+```rust,ignore
 let key: [u8; 32] = /* same secret on all nodes, e.g. loaded from your secret manager */;
 let config = Config::default().with_cluster_key(key);
 let store = ReconcileStore::new(config).await.unwrap();
@@ -114,7 +114,7 @@ feature, `Config::with_encryption()` upgrades it to authenticated **encryption**
 framed as `nonce || ciphertext || tag` with [XChaCha20-Poly1305] over the same 32-byte cluster key,
 and is decrypted-and-verified before deserialization.
 
-```rust
+```rust,ignore
 // requires the `encryption` feature
 let config = Config::default().with_cluster_key(key).with_encryption();
 ```
@@ -151,15 +151,34 @@ tombstones, and the issue-#109 causal-stability bookkeeping (membership and per-
 acknowledgments) — is reloaded **before** the node rejoins the gossip protocol, so a restart does
 not look like a fresh, empty replica:
 
-```rust
+```rust,no_run
 use std::sync::Arc;
-use reconcile::{reconcile_store::Config, FileSnapshot, ReconcileStore};
+use reconcile::{reconcile_store::Config, FileSnapshot, LoadError, ReconcileStore};
 
-let store = ReconcileStore::new(Config::default())
-    .await
-    .unwrap()
-    .with_persistence(Arc::new(FileSnapshot::new("/var/lib/myapp/reconcile.snapshot")));
-tokio::spawn(store.clone().run()); // periodically snapshots in the background
+async fn start() -> Result<(), Box<dyn std::error::Error>> {
+    let store = ReconcileStore::<String, String>::new(Config::default())
+        .await?
+        .with_persistence(Arc::new(FileSnapshot::new("/var/lib/myapp/reconcile.snapshot")));
+
+    let store = match store {
+        Ok(s) => s,
+        Err(LoadError::Corrupt(msg)) => {
+            // The snapshot file exists but could not be decoded.
+            // Do NOT silently start empty: that drops tombstones and enables resurrection
+            // of previously deleted values. Alert an operator and halt; if data loss is
+            // acceptable, delete the snapshot file and restart.
+            return Err(format!("snapshot corrupt, operator action required: {msg}").into());
+        }
+        Err(LoadError::Io(err)) => {
+            // Transient I/O failure (e.g. volume still mounting). Retry after a short
+            // delay rather than discarding durable state.
+            return Err(format!("transient I/O error loading snapshot, retry later: {err}").into());
+        }
+    };
+
+    tokio::spawn(store.clone().run()); // periodically snapshots in the background
+    Ok(())
+}
 ```
 
 The backend is pluggable: implement the `Persistence` trait to store snapshots in `redb`, `sled`,
@@ -183,7 +202,7 @@ stays lean:
 - `metrics-prometheus` — additionally provides `reconcile::prometheus` to install a Prometheus
   recorder and either serve a `/metrics` endpoint or render the exposition text yourself:
 
-```rust,no_run
+```rust,ignore
 # async fn run() -> Result<(), Box<dyn std::error::Error>> {
 // Serve a /metrics HTTP endpoint (requires a Tokio runtime):
 reconcile::prometheus::serve("0.0.0.0:9000".parse()?).await?;
@@ -239,7 +258,7 @@ value-only projection* of its data and answers a mirror's value-only diff agains
 mirror keeps no tombstone bookkeeping, never acknowledges tombstones, and is never counted as a
 causal-stability member, so it cannot hold back a dated node's garbage collection.
 
-```rust
+```rust,ignore
 use reconcile::{reconcile_store::Config, ReconcileMirror};
 
 // Mirrors a dated cluster reachable at `dated_addr` on the same port.
@@ -262,7 +281,7 @@ cloud region, an availability zone, or a single subnet. The model is intentional
 per location, no rack/host level and no hierarchy), because the CIDR mask already lets you pick the
 granularity. Declare every network with `with_net` — **including this node's own**:
 
-```rust
+```rust,ignore
 use reconcile::{reconcile_store::Config, ReconcileStore};
 
 let config = Config::default()
@@ -302,7 +321,7 @@ re-bind the socket and lose its identity) — useful for elastic deployments: op
 decommissioning one, or retuning WAN traffic on the fly. These `&self` methods on `ReconcileStore`
 take effect on the running `run()` loop:
 
-```rust
+```rust,ignore
 store.add_net("10.4.0.0/16".parse().unwrap()); // start gossiping with a new location
 store.remove_net("10.3.0.0/16".parse().unwrap()); // stop probing a retired one
 store.set_nets(&nets);                          // replace the whole topology at once
@@ -330,7 +349,7 @@ almost never lands on a live pod. Instead, point the store at a **headless `Serv
 (`clusterIP: None`): its DNS name resolves to one address record per ready pod, giving every peer in
 a single lookup — the canonical StatefulSet pattern, with **no Kubernetes API access and no RBAC**.
 
-```rust
+```rust,ignore
 use reconcile::{reconcile_store::Config, ReconcileStore};
 
 let config = Config::default()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,7 +100,7 @@ pub use hrtree::HRTree;
 // mutation path is `HRTree::with_mut`. A correct iterator-based design is future work.
 pub use hrtree_iter::{IntoIter, IntoKeys, IntoValues, Iter, Keys, Values};
 pub use mirror::ReconcileMirror;
-pub use persistence::{FileSnapshot, InMemoryPersistence, PersistedState, Persistence};
+pub use persistence::{FileSnapshot, InMemoryPersistence, LoadError, PersistedState, Persistence};
 pub use reconcilable::{Projectable, ValueOnly};
 pub use reconcile_store::ReconcileStore;
 
@@ -220,3 +220,10 @@ pub mod testing {
         store.bulk_dumps_in_flight_count()
     }
 }
+
+/// Compile-checks the README's code blocks as doctests, so an API change that breaks an
+/// example fails `cargo test --doc`. `#[cfg(doctest)]` keeps it out of builds and rendered
+/// documentation.
+#[doc = include_str!("../README.md")]
+#[cfg(doctest)]
+pub struct ReadmeDoctests;

--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -40,11 +40,17 @@ use std::io;
 use std::net::IpAddr;
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
+use std::time::Duration;
 
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
+use tracing::{debug, warn};
 
 use crate::clock::Timestamp;
+
+/// Backoff parameters for transient-I/O retries in [`FileSnapshot::load`].
+const LOAD_RETRY_ATTEMPTS: u32 = 3;
+const LOAD_RETRY_INITIAL_BACKOFF: Duration = Duration::from_millis(100);
 
 /// The store's keyed entries in their internal dated, tombstone-aware form: each key maps to a
 /// `(timestamp, Option<V>)`, where a `None` payload is a tombstone.
@@ -67,6 +73,61 @@ pub struct PersistedState<K, V> {
     pub members: HashSet<IpAddr>,
     /// Per-tombstone acknowledgments: `key -> (peer -> version token of the tombstone it holds)`.
     pub tombstone_acks: HashMap<K, HashMap<IpAddr, u64>>,
+}
+
+/// Classifies why [`FileSnapshot::load`] failed, so callers can act differently on corruption
+/// versus transient I/O problems.
+///
+/// # Operator guidance
+///
+/// - **Corrupt** — the snapshot file exists but cannot be decoded. The safe choices are to delete
+///   the file (accepts data loss: the node starts empty) or to restore from a backup. **Do not
+///   silently start empty**, as that drops tombstones, enabling resurrection of previously deleted
+///   values. The store exposes this as a distinct error so the calling application can log a clear
+///   message and halt (recommended) or attempt recovery.
+///
+/// - **Io** — a transient I/O error persisted across all retry attempts (e.g. a filesystem still
+///   mounting, a volume remount in progress). Retrying after a longer delay or restarting the
+///   process is appropriate. The error is surfaced rather than causing a panic so the caller can
+///   choose a graceful shutdown path.
+#[derive(Debug)]
+pub enum LoadError {
+    /// The snapshot file exists but its contents could not be decoded. Data corruption or
+    /// truncation. The inner string carries the original error message.
+    Corrupt(String),
+    /// An I/O error that survived all retry attempts; the file may or may not exist.
+    Io(io::Error),
+}
+
+impl std::fmt::Display for LoadError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            LoadError::Corrupt(msg) => write!(
+                f,
+                "snapshot file is corrupt and cannot be loaded: {msg}; \
+                 delete the snapshot to start empty (accepts data loss) or restore from backup"
+            ),
+            LoadError::Io(err) => write!(f, "transient I/O error loading snapshot: {err}"),
+        }
+    }
+}
+
+impl std::error::Error for LoadError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            LoadError::Corrupt(_) => None,
+            LoadError::Io(err) => Some(err),
+        }
+    }
+}
+
+impl From<LoadError> for io::Error {
+    fn from(e: LoadError) -> io::Error {
+        match e {
+            LoadError::Corrupt(msg) => io::Error::new(io::ErrorKind::InvalidData, msg),
+            LoadError::Io(err) => err,
+        }
+    }
 }
 
 /// A pluggable durable backend for a [`ReconcileStore`](crate::ReconcileStore).
@@ -123,8 +184,30 @@ where
 
 /// A durable, file-based [`Persistence`] backend storing a single bincode-encoded snapshot.
 ///
-/// Saves are **atomic**: the snapshot is written to a sibling `*.tmp` file, flushed, then renamed
-/// over the target path, so a crash mid-write never corrupts a previously good snapshot.
+/// # Atomic saves
+///
+/// Saves are **atomic at the file level**: the snapshot is written to a sibling `*.tmp` file,
+/// flushed to the OS page cache (`sync_all` on the file), then renamed over the target path, and
+/// finally the **containing directory** is fsynced so the name binding is durable. This sequence
+/// means a crash after the rename but before the directory fsync may leave the old snapshot in
+/// place (the kernel replays the rename from the journal on most filesystems, but the POSIX
+/// guarantee requires the directory fsync), while a crash before the rename leaves the original
+/// snapshot untouched. In both cases exactly one valid snapshot is recoverable on restart.
+///
+/// A crash after writing the tmp file but before the rename leaves a stale `*.tmp` sibling.
+/// [`FileSnapshot::load`] removes any such stale temporaries on startup so they do not accumulate.
+///
+/// # Fallible load
+///
+/// [`FileSnapshot::load_checked`] — called by
+/// [`ReconcileStore::with_persistence`](crate::ReconcileStore::with_persistence) — returns a
+/// [`LoadError`] rather than panicking:
+///
+/// - **Corrupt** data (`InvalidData`) is surfaced as [`LoadError::Corrupt`] so the caller can
+///   decide whether to halt or attempt recovery.
+/// - **Transient I/O** errors are retried up to three times with exponential backoff before being
+///   surfaced as [`LoadError::Io`].
+/// - **`NotFound`** (no snapshot yet) is a clean fresh start and returns `Ok(None)`.
 #[derive(Clone, Debug)]
 pub struct FileSnapshot {
     path: PathBuf,
@@ -143,6 +226,64 @@ impl FileSnapshot {
         tmp.push(".tmp");
         PathBuf::from(tmp)
     }
+
+    /// Clean up stale `*.tmp` siblings of the snapshot path, logging each removal at debug level.
+    ///
+    /// Called during load so that temporaries left behind by an interrupted save do not accumulate.
+    fn remove_stale_tmp(&self) {
+        let tmp = self.tmp_path();
+        match fs::remove_file(&tmp) {
+            Ok(()) => debug!(path = %tmp.display(), "removed stale snapshot tmp file"),
+            Err(err) if err.kind() == io::ErrorKind::NotFound => {} // nothing to clean
+            Err(err) => {
+                warn!(path = %tmp.display(), "failed to remove stale snapshot tmp file: {err}")
+            }
+        }
+    }
+
+    /// Load state, splitting I/O errors into [`LoadError::Corrupt`] vs. [`LoadError::Io`],
+    /// with bounded retries for transient I/O.
+    ///
+    /// Stale `*.tmp` siblings are removed unconditionally on entry, before the load attempt.
+    pub fn load_checked<K, V>(&self) -> Result<Option<PersistedState<K, V>>, LoadError>
+    where
+        K: DeserializeOwned + Eq + std::hash::Hash,
+        V: DeserializeOwned,
+    {
+        self.remove_stale_tmp();
+
+        let mut attempts = 0u32;
+        let mut backoff = LOAD_RETRY_INITIAL_BACKOFF;
+        loop {
+            attempts += 1;
+            match fs::read(&self.path) {
+                Ok(bytes) => {
+                    return bincode::deserialize::<PersistedState<K, V>>(&bytes)
+                        .map(Some)
+                        .map_err(|err| LoadError::Corrupt(err.to_string()));
+                }
+                Err(err) if err.kind() == io::ErrorKind::NotFound => {
+                    return Ok(None);
+                }
+                Err(err) if err.kind() == io::ErrorKind::InvalidData => {
+                    return Err(LoadError::Corrupt(err.to_string()));
+                }
+                Err(err) => {
+                    if attempts >= LOAD_RETRY_ATTEMPTS {
+                        return Err(LoadError::Io(err));
+                    }
+                    warn!(
+                        path = %self.path.display(),
+                        attempt = attempts,
+                        max = LOAD_RETRY_ATTEMPTS,
+                        "transient I/O error loading snapshot, retrying: {err}"
+                    );
+                    std::thread::sleep(backoff);
+                    backoff *= 2;
+                }
+            }
+        }
+    }
 }
 
 impl<K, V> Persistence<K, V> for FileSnapshot
@@ -151,14 +292,7 @@ where
     V: Serialize + DeserializeOwned + Send + Sync + 'static,
 {
     fn load(&self) -> io::Result<Option<PersistedState<K, V>>> {
-        let bytes = match fs::read(&self.path) {
-            Ok(bytes) => bytes,
-            Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(None),
-            Err(err) => return Err(err),
-        };
-        let state = bincode::deserialize(&bytes)
-            .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
-        Ok(Some(state))
+        self.load_checked().map_err(io::Error::from)
     }
 
     fn save(&self, state: &PersistedState<K, V>) -> io::Result<()> {
@@ -174,6 +308,23 @@ where
             file.sync_all()?;
         }
         fs::rename(&tmp, &self.path)?;
+        // fsync the parent directory so the name binding (the rename) is durable. Without this,
+        // a crash after the rename but before the OS flushes the directory journal may leave the
+        // old snapshot in place on some filesystems. The directory fsync is a no-op on journalling
+        // filesystems that replay the rename on recovery, but it is required for the POSIX
+        // durability guarantee.
+        //
+        // Note: directory fsync durability cannot be unit-tested in-process — the guarantee is
+        // that the kernel persists the rename to storage; verifying that requires a real crash or
+        // raw block-device inspection. The call is tested indirectly by the save/load round-trip
+        // tests; its presence is verified by code inspection.
+        if let Some(parent) = self.path.parent() {
+            // Silently skip if the parent is empty (unlikely, but handle gracefully).
+            if !parent.as_os_str().is_empty() {
+                let dir = fs::File::open(parent)?;
+                dir.sync_all()?;
+            }
+        }
         Ok(())
     }
 }
@@ -278,5 +429,101 @@ mod tests {
         assert!(!dir.path().join("snapshot.bin.tmp").exists());
         let loaded = Persistence::<i32, String>::load(&backend).unwrap().unwrap();
         assert_eq!(loaded.entries[0].1 .1, Some("second".to_string()));
+    }
+
+    /// Interrupted save: tmp written but not renamed → old snapshot still loads, stale tmp is
+    /// cleaned on the next load.
+    #[test]
+    fn stale_tmp_cleaned_on_load_and_old_snapshot_still_readable() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("snapshot.bin");
+        let backend = FileSnapshot::new(&path);
+
+        // Write the first snapshot normally.
+        let mut first = sample_state();
+        first.entries = vec![(1, (Timestamp::new(1, 0, 0), Some("first".to_string())))];
+        Persistence::<i32, String>::save(&backend, &first).unwrap();
+
+        // Simulate an interrupted second save: write the tmp but do NOT rename.
+        let tmp_path = dir.path().join("snapshot.bin.tmp");
+        {
+            use std::io::Write;
+            let mut second = sample_state();
+            second.entries = vec![(1, (Timestamp::new(2, 0, 0), Some("second".to_string())))];
+            let bytes = bincode::serialize(&second).unwrap();
+            let mut file = fs::File::create(&tmp_path).unwrap();
+            file.write_all(&bytes).unwrap();
+            file.sync_all().unwrap();
+        }
+        // The tmp must be present before we call load.
+        assert!(tmp_path.exists(), "precondition: tmp file should exist");
+
+        // Load cleans the stale tmp and returns the original (first) snapshot.
+        let loaded = backend
+            .load_checked::<i32, String>()
+            .expect("load must succeed")
+            .expect("old snapshot must be present");
+        assert_eq!(
+            loaded.entries[0].1 .1,
+            Some("first".to_string()),
+            "old snapshot must load, not the tmp contents"
+        );
+        assert!(!tmp_path.exists(), "stale tmp must be removed on load");
+    }
+
+    /// Completed save → new snapshot loads correctly.
+    #[test]
+    fn completed_save_loads_new_snapshot() {
+        let dir = tempfile::tempdir().unwrap();
+        let backend = FileSnapshot::new(dir.path().join("snapshot.bin"));
+
+        let mut first = sample_state();
+        first.entries = vec![(1, (Timestamp::new(1, 0, 0), Some("first".to_string())))];
+        Persistence::<i32, String>::save(&backend, &first).unwrap();
+
+        let mut second = sample_state();
+        second.entries = vec![(1, (Timestamp::new(2, 0, 0), Some("new".to_string())))];
+        Persistence::<i32, String>::save(&backend, &second).unwrap();
+
+        let loaded = Persistence::<i32, String>::load(&backend)
+            .unwrap()
+            .expect("snapshot must be present");
+        assert_eq!(
+            loaded.entries[0].1 .1,
+            Some("new".to_string()),
+            "completed save must be visible on load"
+        );
+    }
+
+    /// Corrupt snapshot file → `load_checked` returns `LoadError::Corrupt` (no panic).
+    #[test]
+    fn corrupt_snapshot_returns_error_variant() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("snapshot.bin");
+        fs::write(&path, b"not valid bincode at all").unwrap();
+        let backend = FileSnapshot::new(&path);
+        match backend.load_checked::<i32, String>() {
+            Err(LoadError::Corrupt(_)) => {} // expected
+            other => panic!("expected LoadError::Corrupt, got {other:?}"),
+        }
+    }
+
+    /// Transient I/O error (path is a directory) → retries are attempted, then `LoadError::Io`
+    /// is returned (no panic).
+    #[test]
+    fn transient_io_returns_error_variant() {
+        // Use a directory as the snapshot path: `fs::read` on a directory returns an error on all
+        // major platforms (Linux: EISDIR, macOS: EISDIR). We override LOAD_RETRY_ATTEMPTS to 1 via
+        // the public knob by testing load_checked which internally uses the constants; we simply
+        // verify the variant and that no panic occurs.
+        let dir = tempfile::tempdir().unwrap();
+        // The path itself IS a directory, so fs::read will fail with a non-NotFound, non-corrupt error.
+        let backend = FileSnapshot::new(dir.path());
+        match backend.load_checked::<i32, String>() {
+            Err(LoadError::Io(_)) => {} // expected
+            // On some platforms a directory read may look like corrupt data; accept both.
+            Err(LoadError::Corrupt(_)) => {}
+            Ok(_) => panic!("expected an error when the snapshot path is a directory"),
+        }
     }
 }

--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -76,20 +76,12 @@ pub struct PersistedState<K, V> {
 }
 
 /// Classifies why [`FileSnapshot::load`] failed, so callers can act differently on corruption
-/// versus transient I/O problems.
+/// versus transient I/O.
 ///
-/// # Operator guidance
-///
-/// - **Corrupt** — the snapshot file exists but cannot be decoded. The safe choices are to delete
-///   the file (accepts data loss: the node starts empty) or to restore from a backup. **Do not
-///   silently start empty**, as that drops tombstones, enabling resurrection of previously deleted
-///   values. The store exposes this as a distinct error so the calling application can log a clear
-///   message and halt (recommended) or attempt recovery.
-///
-/// - **Io** — a transient I/O error persisted across all retry attempts (e.g. a filesystem still
-///   mounting, a volume remount in progress). Retrying after a longer delay or restarting the
-///   process is appropriate. The error is surfaced rather than causing a panic so the caller can
-///   choose a graceful shutdown path.
+/// - **Corrupt** — undecodable. Delete the file (accepts data loss) or restore from backup; do
+///   **not** silently start empty, since that drops tombstones and re-enables resurrection.
+/// - **Io** — a transient error survived every retry (e.g. a volume still mounting). Retry later
+///   or shut down gracefully rather than panic.
 #[derive(Debug)]
 pub enum LoadError {
     /// The snapshot file exists but its contents could not be decoded. Data corruption or
@@ -184,30 +176,16 @@ where
 
 /// A durable, file-based [`Persistence`] backend storing a single bincode-encoded snapshot.
 ///
-/// # Atomic saves
-///
-/// Saves are **atomic at the file level**: the snapshot is written to a sibling `*.tmp` file,
-/// flushed to the OS page cache (`sync_all` on the file), then renamed over the target path, and
-/// finally the **containing directory** is fsynced so the name binding is durable. This sequence
-/// means a crash after the rename but before the directory fsync may leave the old snapshot in
-/// place (the kernel replays the rename from the journal on most filesystems, but the POSIX
-/// guarantee requires the directory fsync), while a crash before the rename leaves the original
-/// snapshot untouched. In both cases exactly one valid snapshot is recoverable on restart.
-///
-/// A crash after writing the tmp file but before the rename leaves a stale `*.tmp` sibling.
-/// [`FileSnapshot::load`] removes any such stale temporaries on startup so they do not accumulate.
+/// Write to a sibling `*.tmp`, `sync_all`, rename over the target, then fsync the directory so the
+/// name binding is durable. A crash at any point leaves exactly one valid snapshot recoverable; a
+/// stale `*.tmp` is cleaned up on the next load.
 ///
 /// # Fallible load
 ///
-/// [`FileSnapshot::load_checked`] — called by
-/// [`ReconcileStore::with_persistence`](crate::ReconcileStore::with_persistence) — returns a
-/// [`LoadError`] rather than panicking:
-///
-/// - **Corrupt** data (`InvalidData`) is surfaced as [`LoadError::Corrupt`] so the caller can
-///   decide whether to halt or attempt recovery.
-/// - **Transient I/O** errors are retried up to three times with exponential backoff before being
-///   surfaced as [`LoadError::Io`].
-/// - **`NotFound`** (no snapshot yet) is a clean fresh start and returns `Ok(None)`.
+/// [`load_checked`](FileSnapshot::load_checked), used by
+/// [`ReconcileStore::with_persistence`](crate::ReconcileStore::with_persistence), returns
+/// [`LoadError::Corrupt`] for `InvalidData`, [`LoadError::Io`] after three backed-off retries, and
+/// `Ok(None)` for a missing file (a clean fresh start).
 #[derive(Clone, Debug)]
 pub struct FileSnapshot {
     path: PathBuf,
@@ -308,16 +286,10 @@ where
             file.sync_all()?;
         }
         fs::rename(&tmp, &self.path)?;
-        // fsync the parent directory so the name binding (the rename) is durable. Without this,
-        // a crash after the rename but before the OS flushes the directory journal may leave the
-        // old snapshot in place on some filesystems. The directory fsync is a no-op on journalling
-        // filesystems that replay the rename on recovery, but it is required for the POSIX
-        // durability guarantee.
-        //
-        // Note: directory fsync durability cannot be unit-tested in-process — the guarantee is
-        // that the kernel persists the rename to storage; verifying that requires a real crash or
-        // raw block-device inspection. The call is tested indirectly by the save/load round-trip
-        // tests; its presence is verified by code inspection.
+        // Durable name binding for the rename (POSIX requires the directory fsync, even though
+        // most journalling filesystems replay it on recovery anyway). Not unit-testable — the
+        // guarantee is about what the kernel persisted to storage — so this is covered only by
+        // the save/load round-trip and by inspection.
         if let Some(parent) = self.path.parent() {
             // Silently skip if the parent is empty (unlikely, but handle gracefully).
             if !parent.as_os_str().is_empty() {

--- a/src/reconcile_engine.rs
+++ b/src/reconcile_engine.rs
@@ -240,6 +240,21 @@ pub(crate) struct Inner<K, V: Projectable> {
     /// Hard cap on the number of tracked remote peers. Datagrams from unknown senders are dropped
     /// before any per-sender state is allocated when the membership set reaches this size.
     max_peers: usize,
+    /// Running count of map mutations since the last snapshot.
+    ///
+    /// Shared with [`ReconcileStore`](crate::reconcile_store::ReconcileStore): the store keeps a
+    /// clone of the same `Arc` so that local-write methods (`insert`, `remove`, etc.) and the
+    /// gossip apply / GC paths — all of which live in the engine — bump a **single** atomic.
+    /// The store's snapshot loop reads and resets this counter to decide whether to write.
+    ///
+    /// **Increment sites (exactly one per mutation path, no double-counting):**
+    /// - Local writes: incremented by `ReconcileStore`'s public methods (`insert`, `remove`, …)
+    ///   before calling `just_insert` / `just_insert_bulk`.  Those methods call `map_insert`
+    ///   internally, but `map_insert` itself does *not* touch the counter.
+    /// - Gossip applies: incremented here, in `handle_messages`, after the re-reconcile write
+    ///   loop — once per entry actually written to `to_apply`.
+    /// - GC removes: incremented in `gc_remove` — one per tombstone purged.
+    pub(crate) change_counter: Arc<AtomicUsize>,
 }
 
 impl<K, V: Projectable> Clone for ReconcileEngine<K, V> {
@@ -385,6 +400,7 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
                 clock,
                 node_id_is_random,
                 max_peers: config.max_peers,
+                change_counter: Arc::new(AtomicUsize::new(0)),
             }),
         })
     }
@@ -413,7 +429,11 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
     pub(crate) fn gc_remove(&self, key: &K) -> Option<V> {
         let mut guard = self.map.write();
         self.projection.write().remove(key);
-        guard.remove(key)
+        let removed = guard.remove(key);
+        if removed.is_some() {
+            self.change_counter.fetch_add(1, Ordering::Relaxed);
+        }
+        removed
     }
 
     /// Mint a fresh Hybrid Logical Clock timestamp for a local write.
@@ -1094,6 +1114,7 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
             //    order, so re-applying a value that became stale meanwhile is a no-op — the stale
             //    case is handled identically to the direct path.
             if !to_apply.is_empty() {
+                let apply_count = to_apply.len();
                 let mut guard = self.map.write();
                 for (k, v) in to_apply {
                     let merged_v = match guard.get(&k) {
@@ -1106,6 +1127,13 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
                         acks_to_send.push(Message::Ack::<K, V, V::Projected>((k, version)));
                     }
                 }
+                // Count every entry actually written via gossip so the snapshot threshold is met
+                // even on a replica that only receives data through anti-entropy (never writes
+                // locally). This is the only site that bumps the counter for the gossip path;
+                // local-write methods bump it themselves before calling just_insert, so there is
+                // no overlap between the two paths.
+                self.change_counter
+                    .fetch_add(apply_count, Ordering::Relaxed);
             }
             if !acks_to_send.is_empty() {
                 send_messages_to(

--- a/src/reconcile_store.rs
+++ b/src/reconcile_store.rs
@@ -14,6 +14,7 @@ use std::hash::Hash;
 use std::io;
 use std::net::IpAddr;
 use std::ops::RangeBounds;
+use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -26,15 +27,35 @@ use crate::bounds::{Key, Value};
 use crate::clock::Timestamp;
 use crate::discovery::{Discovery, DnsDiscovery};
 use crate::fingerprint::Fingerprint;
-use crate::persistence::{DatedEntries, InMemoryPersistence, PersistedState, Persistence};
+use crate::persistence::{
+    DatedEntries, InMemoryPersistence, LoadError, PersistedState, Persistence,
+};
 use crate::reconcilable::Projectable;
 use crate::reconcile_engine::{version_hash, ReconcileEngine};
 use crate::timeout_wheel::TimeoutWheel;
 
 const TOMBSTONE_CLEARING: Duration = Duration::from_secs(1);
 
-/// How often the background task writes a full snapshot to the persistence backend.
-const SNAPSHOT_INTERVAL: Duration = Duration::from_secs(5);
+/// Default cadence of the periodic snapshot task (see [`ReconcileStore::with_snapshot_interval`]).
+const DEFAULT_SNAPSHOT_INTERVAL: Duration = Duration::from_secs(5);
+
+/// Default minimum number of changes between snapshots (see
+/// [`ReconcileStore::with_snapshot_change_threshold`]).
+///
+/// `1` means any change since the last snapshot triggers a write at the next tick. Set to `0` to
+/// snapshot even when the store is idle (every tick, regardless of changes).
+const DEFAULT_SNAPSHOT_CHANGE_THRESHOLD: usize = 1;
+
+/// Number of map entries collected per lock acquisition during a chunked snapshot.
+///
+/// This bounds the maximum time a single snapshot pass holds the map read lock: the lock is
+/// released after each chunk and re-acquired for the next, so writers are only blocked for the
+/// time it takes to clone at most this many entries. The resulting snapshot is **fuzzy** — entries
+/// are captured at slightly different instants across chunks — but every entry is individually
+/// valid LWW state: a restart followed by reconciliation with peers pulls any delta that changed
+/// between chunks. The fuzziness is equivalent to the store having briefly paused writes for a
+/// fraction of the snapshot window, which the LWW reconciliation protocol already handles.
+const SNAPSHOT_CHUNK_SIZE: usize = 1024;
 
 /// Default cadence of the dynamic-discovery task (see [`ReconcileStore::with_discovery_interval`]).
 const DEFAULT_DISCOVERY_INTERVAL: Duration = Duration::from_secs(5);
@@ -116,6 +137,16 @@ where
     /// decommissioned by the discovery task. Members with no pending tombstone acks skip this
     /// floor and are decommissioned as soon as `miss_threshold` rounds elapse.
     discovery_decommission_floor: Duration,
+    /// How often the snapshot task runs. `None` disables time-based snapshots entirely (snapshots
+    /// can still be triggered on-demand via `snapshot()`).
+    snapshot_interval: Option<Duration>,
+    /// Minimum number of changes (inserts / removes / reconciled applies) since the last snapshot
+    /// before the next timed snapshot is written. `0` means always snapshot at the tick, even when
+    /// idle. The counter is reset to zero after every snapshot.
+    snapshot_change_threshold: usize,
+    /// Running count of map mutations since the last snapshot. Shared so that `insert`, `remove`,
+    /// and the reconciliation apply path can all bump it without taking the map lock.
+    change_counter: Arc<AtomicUsize>,
 }
 
 impl<K, V> Clone for ReconcileStore<K, V>
@@ -133,6 +164,9 @@ where
             discovery_interval: self.discovery_interval,
             discovery_miss_threshold: self.discovery_miss_threshold,
             discovery_decommission_floor: self.discovery_decommission_floor,
+            snapshot_interval: self.snapshot_interval,
+            snapshot_change_threshold: self.snapshot_change_threshold,
+            change_counter: self.change_counter.clone(),
         }
     }
 }
@@ -146,14 +180,19 @@ impl<K: Key, V: Value> ReconcileStore<K, V> {
     /// `(config.listen_addr, config.port)` — for example, because the port is already in use or
     /// the address is not available on this host.
     pub async fn new(config: Config) -> io::Result<Self> {
+        let engine = ReconcileEngine::<K, (Timestamp, Option<V>)>::new(config).await?;
+        let change_counter = Arc::clone(&engine.change_counter);
         let svc = ReconcileStore {
-            engine: ReconcileEngine::<K, (Timestamp, Option<V>)>::new(config).await?,
+            engine,
             tombstones: TimeoutWheel::new(),
             persistence: Arc::new(InMemoryPersistence::default()),
             discovery: None,
             discovery_interval: DEFAULT_DISCOVERY_INTERVAL,
             discovery_miss_threshold: DEFAULT_DISCOVERY_MISS_THRESHOLD,
             discovery_decommission_floor: DEFAULT_DISCOVERY_DECOMMISSION_FLOOR,
+            snapshot_interval: Some(DEFAULT_SNAPSHOT_INTERVAL),
+            snapshot_change_threshold: DEFAULT_SNAPSHOT_CHANGE_THRESHOLD,
+            change_counter,
         };
         svc.add_pre_insert(|_, _| {});
         Ok(svc)
@@ -168,15 +207,20 @@ impl<K: Key, V: Value> ReconcileStore<K, V> {
         config: Config,
         clock: Arc<dyn crate::clock::Clock>,
     ) -> io::Result<Self> {
+        let engine =
+            ReconcileEngine::<K, (Timestamp, Option<V>)>::new_with_clock(config, clock).await?;
+        let change_counter = Arc::clone(&engine.change_counter);
         let svc = ReconcileStore {
-            engine: ReconcileEngine::<K, (Timestamp, Option<V>)>::new_with_clock(config, clock)
-                .await?,
+            engine,
             tombstones: TimeoutWheel::new(),
             persistence: Arc::new(InMemoryPersistence::default()),
             discovery: None,
             discovery_interval: DEFAULT_DISCOVERY_INTERVAL,
             discovery_miss_threshold: DEFAULT_DISCOVERY_MISS_THRESHOLD,
             discovery_decommission_floor: DEFAULT_DISCOVERY_DECOMMISSION_FLOOR,
+            snapshot_interval: Some(DEFAULT_SNAPSHOT_INTERVAL),
+            snapshot_change_threshold: DEFAULT_SNAPSHOT_CHANGE_THRESHOLD,
+            change_counter,
         };
         svc.add_pre_insert(|_, _| {});
         Ok(svc)
@@ -194,11 +238,22 @@ impl<K: Key, V: Value> ReconcileStore<K, V> {
     /// Loaded entries are replayed through the pre-insert hook, which preserves each tombstone's
     /// original deletion timestamp and rebuilds the tombstone-expiry wheel.
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// Panics if the backend fails to load (e.g. a corrupt snapshot file): recovering from a
-    /// damaged durable state is a deliberate, explicit decision rather than a silent fresh start.
-    pub fn with_persistence(mut self, backend: Arc<dyn Persistence<K, V>>) -> Self {
+    /// Returns a [`LoadError`] when the backend cannot load:
+    ///
+    /// - [`LoadError::Corrupt`] — the snapshot file exists but could not be decoded. **Do not
+    ///   silently start empty**: that drops tombstones and enables resurrection of previously
+    ///   deleted values. The recommended action is to log the error, alert an operator, and halt.
+    ///   If data loss is acceptable, delete the snapshot and restart.
+    /// - [`LoadError::Io`] — a transient I/O error persisted across all retries (e.g. a volume
+    ///   still mounting). Retrying after a short delay is appropriate.
+    ///
+    /// `NotFound` (no snapshot yet) is a clean fresh start and does not produce an error.
+    pub fn with_persistence(
+        mut self,
+        backend: Arc<dyn Persistence<K, V>>,
+    ) -> Result<Self, LoadError> {
         // Warn operators when a durable backend is used with a randomly-generated node id.
         // A random id changes on every restart, which silently alters this node's LWW
         // conflict-resolution identity: a write made before the restart by "node X" will now
@@ -217,7 +272,15 @@ impl<K: Key, V: Value> ReconcileStore<K, V> {
                  Config::with_node_id to preserve consistent LWW ordering across restarts."
             );
         }
-        if let Some(state) = backend.load().expect("failed to load persisted state") {
+        if let Some(state) = backend.load().map_err(|e| {
+            // Classify the io::Error coming from a generic Persistence impl: if it carried
+            // InvalidData we treat it as corrupt, otherwise as a transient I/O failure.
+            if e.kind() == io::ErrorKind::InvalidData {
+                LoadError::Corrupt(e.to_string())
+            } else {
+                LoadError::Io(e)
+            }
+        })? {
             *self.engine.members.write() = state.members;
             *self.engine.tombstone_acks.write() = state.tombstone_acks;
             // Advance the clock past every persisted timestamp so that the first post-restart
@@ -246,18 +309,60 @@ impl<K: Key, V: Value> ReconcileStore<K, V> {
             self.engine.just_insert_bulk(&state.entries);
         }
         self.persistence = backend;
+        Ok(self)
+    }
+
+    /// Set how often the background task writes a snapshot to the persistence backend
+    /// (default 5 s).
+    ///
+    /// Pass `None` to disable time-based snapshots entirely — snapshots will then only fire when
+    /// the change threshold is crossed and the caller explicitly triggers one (future on-demand
+    /// API), or not at all. When time-based snapshots are disabled and no on-demand mechanism is
+    /// in place, persistence is effectively write-only (saves never happen automatically).
+    ///
+    /// An incremental/segmented snapshot format (write amplification proportional to change
+    /// volume, not dataset size) is deferred to future work.
+    pub fn with_snapshot_interval(mut self, interval: impl Into<Option<Duration>>) -> Self {
+        self.snapshot_interval = interval.into();
         self
     }
 
-    /// Capture the full store state and hand it to the persistence backend.
+    /// Set the minimum number of changes (inserts, removes, and reconciled applies) since the
+    /// last snapshot before the next timed tick actually writes to the backend (default 1).
+    ///
+    /// - `0` — snapshot every tick unconditionally, even when the store is idle.
+    /// - `N > 0` — skip the tick if fewer than `N` changes have occurred since the last snapshot.
+    ///   Steady-state idle ⇒ zero snapshot I/O.
+    ///
+    /// The change counter is reset to zero after every snapshot write, so the threshold applies
+    /// to the *interval* between snapshots, not to the total lifetime change count.
+    pub fn with_snapshot_change_threshold(mut self, threshold: usize) -> Self {
+        self.snapshot_change_threshold = threshold;
+        self
+    }
+
+    /// Capture the store state and hand it to the persistence backend.
+    ///
+    /// # Chunked (fuzzy) snapshot
+    ///
+    /// The map is iterated in key-order chunks of [`SNAPSHOT_CHUNK_SIZE`] entries. The read lock
+    /// is **released between chunks**, so writers (inserts, removes, reconciliation applies) are
+    /// only blocked for the time it takes to clone one chunk — bounded independently of dataset
+    /// size. The resulting snapshot is **fuzzy**: entries captured in different chunks may reflect
+    /// slightly different instants. Every captured entry is individually valid LWW state, and a
+    /// restart followed by reconciliation with peers will pull any delta that changed between
+    /// chunks. This trade-off is equivalent to briefly pausing writes for a fraction of the
+    /// snapshot window, which the LWW protocol already handles.
+    ///
+    /// After the snapshot write the change counter is reset to zero so the threshold logic in
+    /// [`snapshot_periodically`] starts a fresh accounting window.
     fn snapshot(&self) {
-        let entries: DatedEntries<K, V> = self
-            .engine
-            .map
-            .read()
-            .iter()
-            .map(|(k, v)| (k.clone(), v.clone()))
-            .collect();
+        // Capture the counter BEFORE collecting entries so that any changes that arrive during the
+        // (potentially multi-chunk) collection are still counted in the next snapshot window.
+        // After a successful save we subtract exactly what we captured, not a blind zero: if more
+        // changes arrived during collection they remain pending and the next tick will see them.
+        let captured = self.change_counter.load(AtomicOrdering::Relaxed);
+        let entries = self.collect_entries_chunked();
         let state = PersistedState {
             entries,
             members: self.engine.members.read().clone(),
@@ -265,14 +370,80 @@ impl<K: Key, V: Value> ReconcileStore<K, V> {
         };
         if let Err(err) = self.persistence.save(&state) {
             warn!("failed to persist reconcile store snapshot: {err}");
+        } else {
+            // Subtract only the count we captured, not zero out the whole counter: any change
+            // that arrived during the chunked collection is still reflected after this subtraction
+            // and will trigger a snapshot at the next tick.
+            self.change_counter
+                .fetch_sub(captured, AtomicOrdering::Relaxed);
         }
     }
 
-    /// Periodically snapshot the full store state to the persistence backend.
-    async fn snapshot_periodically(&self) {
+    /// Collect all map entries in key order, releasing the read lock between chunks of
+    /// [`SNAPSHOT_CHUNK_SIZE`] entries. Returns the full `DatedEntries` vector.
+    fn collect_entries_chunked(&self) -> DatedEntries<K, V> {
+        use std::ops::Bound;
+
+        let mut entries: DatedEntries<K, V> = Vec::new();
+        // Cursor: the last key seen in the previous chunk, used to open the next range.
+        let mut cursor: Option<K> = None;
         loop {
-            tokio::time::sleep(SNAPSHOT_INTERVAL).await;
-            self.snapshot();
+            let chunk: Vec<(K, (Timestamp, Option<V>))> = {
+                let guard = self.engine.map.read();
+                match cursor.take() {
+                    None => guard
+                        .iter()
+                        .take(SNAPSHOT_CHUNK_SIZE)
+                        .map(|(k, v)| (k.clone(), v.clone()))
+                        .collect(),
+                    Some(last) => {
+                        // Iterate all keys strictly above `last`.
+                        // `(Bound::Excluded(K), Bound::Unbounded)` implements `RangeBounds<K>`.
+                        let range = (Bound::Excluded(last), Bound::Unbounded);
+                        guard
+                            .get_range(&range)
+                            .take(SNAPSHOT_CHUNK_SIZE)
+                            .map(|(k, v)| (k.clone(), v.clone()))
+                            .collect()
+                    }
+                }
+                // Lock released here (guard drops at end of block).
+            };
+
+            let done = chunk.len() < SNAPSHOT_CHUNK_SIZE;
+            if let Some((last_key, _)) = chunk.last() {
+                cursor = Some(last_key.clone());
+            }
+            entries.extend(chunk);
+            if done {
+                break;
+            }
+        }
+        entries
+    }
+
+    /// Periodically snapshot the full store state to the persistence backend.
+    ///
+    /// Snapshots are skipped when the change counter is below
+    /// [`snapshot_change_threshold`](Self::with_snapshot_change_threshold), so a steady-state idle
+    /// store produces no snapshot I/O. Time-based snapshotting can be disabled entirely via
+    /// [`with_snapshot_interval(None)`](Self::with_snapshot_interval).
+    async fn snapshot_periodically(&self) {
+        let Some(interval) = self.snapshot_interval else {
+            return; // time-based snapshots disabled
+        };
+        loop {
+            tokio::time::sleep(interval).await;
+            let changes = self.change_counter.load(AtomicOrdering::Relaxed);
+            if changes >= self.snapshot_change_threshold {
+                self.snapshot();
+            } else {
+                debug!(
+                    changes,
+                    threshold = self.snapshot_change_threshold,
+                    "skipping snapshot: change count below threshold"
+                );
+            }
         }
     }
 
@@ -438,6 +609,7 @@ impl<K: Key, V: Value> ReconcileStore<K, V> {
     ///
     /// Returns the overwritten value if the key already existed.
     pub fn just_insert(&self, key: K, value: V) -> Option<V> {
+        self.change_counter.fetch_add(1, AtomicOrdering::Relaxed);
         let ret = self
             .engine
             .just_insert(key, (self.engine.clock_now(), Some(value)));
@@ -446,6 +618,7 @@ impl<K: Key, V: Value> ReconcileStore<K, V> {
 
     /// Fully-qualified insert: just_insert + async broadcast.
     pub fn insert(&self, key: K, value: V) -> Option<V> {
+        self.change_counter.fetch_add(1, AtomicOrdering::Relaxed);
         let ret = self
             .engine
             .insert(key, (self.engine.clock_now(), Some(value)));
@@ -459,6 +632,8 @@ impl<K: Key, V: Value> ReconcileStore<K, V> {
     /// 1. Runs the pre-insert hook for each entry (outside any lock).
     /// 2. Acquires the write lock once and inserts all entries.
     pub fn just_insert_bulk(&self, key_values: &[(K, V)]) {
+        self.change_counter
+            .fetch_add(key_values.len(), AtomicOrdering::Relaxed);
         self.engine.just_insert_bulk(
             &key_values
                 .iter()
@@ -469,6 +644,8 @@ impl<K: Key, V: Value> ReconcileStore<K, V> {
 
     /// Bulk-insert + async broadcast.
     pub fn insert_bulk(&self, key_values: &[(K, V)]) {
+        self.change_counter
+            .fetch_add(key_values.len(), AtomicOrdering::Relaxed);
         self.engine.insert_bulk(
             &key_values
                 .iter()
@@ -478,6 +655,7 @@ impl<K: Key, V: Value> ReconcileStore<K, V> {
     }
 
     pub fn just_remove(&self, key: &K) -> Option<V> {
+        self.change_counter.fetch_add(1, AtomicOrdering::Relaxed);
         let ret = self
             .engine
             .just_insert(key.clone(), (self.engine.clock_now(), None));
@@ -485,6 +663,7 @@ impl<K: Key, V: Value> ReconcileStore<K, V> {
     }
 
     pub fn remove(&self, key: &K) -> Option<V> {
+        self.change_counter.fetch_add(1, AtomicOrdering::Relaxed);
         let ret = self
             .engine
             .insert(key.clone(), (self.engine.clock_now(), None));
@@ -492,6 +671,8 @@ impl<K: Key, V: Value> ReconcileStore<K, V> {
     }
 
     pub fn just_remove_bulk(&self, keys: &[K]) {
+        self.change_counter
+            .fetch_add(keys.len(), AtomicOrdering::Relaxed);
         self.engine.just_insert_bulk(
             &keys
                 .iter()
@@ -507,6 +688,8 @@ impl<K: Key, V: Value> ReconcileStore<K, V> {
     /// caller-chosen `DateTime` could collide with another replica's and trigger the
     /// non-commutative tie-break that caused permanent divergence.
     pub fn remove_bulk(&self, keys: &[K]) {
+        self.change_counter
+            .fetch_add(keys.len(), AtomicOrdering::Relaxed);
         self.engine.insert_bulk(
             &keys
                 .iter()
@@ -831,6 +1014,7 @@ impl<K: Key, V: Value> ReconcileStore<K, V> {
         // Notify peers of the re-stamped entry, just like `insert`, so the edit propagates eagerly
         // rather than being left to the next anti-entropy round (or failing to converge at all).
         if let Some(value) = updated {
+            self.change_counter.fetch_add(1, AtomicOrdering::Relaxed);
             self.engine.broadcast_update(k.clone(), value);
         }
     }
@@ -1246,7 +1430,8 @@ mod reconcile_store_tests {
         let store = ReconcileStore::<i32, i32>::new(ephemeral_config())
             .await
             .expect("bind failed")
-            .with_persistence(Arc::new(FileSnapshot::new(&path)));
+            .with_persistence(Arc::new(FileSnapshot::new(&path)))
+            .expect("load failed");
         store.insert(1, 11); // live value
         store.insert(2, 22);
         store.remove(&2); // tombstone
@@ -1257,7 +1442,8 @@ mod reconcile_store_tests {
         let restarted = ReconcileStore::<i32, i32>::new(ephemeral_config())
             .await
             .expect("bind failed")
-            .with_persistence(Arc::new(FileSnapshot::new(&path)));
+            .with_persistence(Arc::new(FileSnapshot::new(&path)))
+            .expect("load failed");
         assert_eq!(restarted.get(&1).as_deref(), Some(&11));
         assert!(restarted.get(&2).is_none(), "tombstone was not recovered");
         assert_eq!(
@@ -1280,7 +1466,8 @@ mod reconcile_store_tests {
         let store = ReconcileStore::<i32, i32>::new(ephemeral_config())
             .await
             .expect("bind failed")
-            .with_persistence(Arc::new(FileSnapshot::new(&path)));
+            .with_persistence(Arc::new(FileSnapshot::new(&path)))
+            .expect("load failed");
         store.engine.members.write().insert(peer);
         store.insert(5, 55);
         store.remove(&5); // tombstone
@@ -1296,7 +1483,8 @@ mod reconcile_store_tests {
         let restarted = ReconcileStore::<i32, i32>::new(ephemeral_config())
             .await
             .expect("bind failed")
-            .with_persistence(Arc::new(FileSnapshot::new(&path)));
+            .with_persistence(Arc::new(FileSnapshot::new(&path)))
+            .expect("load failed");
         assert!(
             restarted.engine.members.read().contains(&peer),
             "membership set was not restored"
@@ -1326,7 +1514,8 @@ mod reconcile_store_tests {
         let store = ReconcileStore::<i32, i32>::new(ephemeral_config())
             .await
             .expect("bind failed")
-            .with_persistence(Arc::new(FileSnapshot::new(&path)));
+            .with_persistence(Arc::new(FileSnapshot::new(&path)))
+            .expect("load failed");
         store.engine.members.write().insert(peer);
         store.insert(1, 11);
         store.remove(&1); // tombstone, never acknowledged by `peer`
@@ -1355,7 +1544,8 @@ mod reconcile_store_tests {
         let restarted = ReconcileStore::<i32, i32>::new(ephemeral_config())
             .await
             .expect("bind failed")
-            .with_persistence(Arc::new(FileSnapshot::new(&path)));
+            .with_persistence(Arc::new(FileSnapshot::new(&path)))
+            .expect("load failed");
         assert!(restarted.get(&1).is_none(), "tombstone was not recovered");
         let version = restarted
             .engine
@@ -1540,7 +1730,8 @@ mod reconcile_store_tests {
             ReconcileStore::<i32, i32>::new_with_clock(ephemeral_config().with_node_id(1), clock)
                 .await
                 .expect("bind failed")
-                .with_persistence(backend);
+                .with_persistence(backend)
+                .expect("load failed");
 
         // Insert a new value; the minted timestamp must be strictly greater than persisted_stamp.
         store.insert(99, 1);
@@ -1593,7 +1784,8 @@ mod reconcile_store_tests {
             ReconcileStore::<i32, i32>::new_with_clock(ephemeral_config().with_node_id(2), clock)
                 .await
                 .expect("bind failed")
-                .with_persistence(backend);
+                .with_persistence(backend)
+                .expect("load failed");
 
         // The tombstone was recovered (key 7 is absent from the live view).
         assert!(
@@ -1917,5 +2109,448 @@ mod reconcile_store_tests {
         );
 
         task.abort();
+    }
+
+    // ── Persistence robustness tests ──────────────────────────────────────────
+
+    /// Corrupt snapshot → `with_persistence` returns `LoadError::Corrupt`, no panic.
+    #[tokio::test]
+    async fn with_persistence_corrupt_snapshot_returns_error() {
+        use crate::persistence::LoadError;
+        use std::fs;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("snapshot.bin");
+        fs::write(&path, b"this is not valid bincode").unwrap();
+
+        let result = ReconcileStore::<i32, i32>::new(ephemeral_config())
+            .await
+            .expect("bind failed")
+            .with_persistence(Arc::new(FileSnapshot::new(&path)));
+
+        match result {
+            Err(LoadError::Corrupt(_)) => {} // expected
+            Err(LoadError::Io(e)) => panic!("expected Corrupt, got Io: {e}"),
+            Ok(_) => panic!("expected Err(Corrupt), got Ok"),
+        }
+    }
+
+    /// Transient I/O error (snapshot path is a directory) → `with_persistence` returns
+    /// `LoadError::Io` after retries, no panic.
+    #[tokio::test]
+    async fn with_persistence_transient_io_returns_error() {
+        use crate::persistence::LoadError;
+
+        // Using a directory as the snapshot path triggers EISDIR on read — a non-NotFound,
+        // non-InvalidData I/O error that should surface as LoadError::Io.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().to_path_buf(); // the directory itself, not a file inside it
+
+        let result = ReconcileStore::<i32, i32>::new(ephemeral_config())
+            .await
+            .expect("bind failed")
+            .with_persistence(Arc::new(FileSnapshot::new(&path)));
+
+        match result {
+            Err(LoadError::Io(_)) => {}      // expected
+            Err(LoadError::Corrupt(_)) => {} // also acceptable on platforms that surface EISDIR as invalid data
+            Ok(_) => panic!("expected Err when the snapshot path is a directory"),
+        }
+    }
+
+    /// `with_persistence` on a path that does not exist yet must return `Ok` (fresh start).
+    #[tokio::test]
+    async fn with_persistence_not_found_is_fresh_start() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("nonexistent.bin");
+
+        let store = ReconcileStore::<i32, i32>::new(ephemeral_config())
+            .await
+            .expect("bind failed")
+            .with_persistence(Arc::new(FileSnapshot::new(&path)))
+            .expect("NotFound must be a clean fresh start, not an error");
+
+        // Store is empty (no state was loaded).
+        assert!(store.get(&1).is_none());
+    }
+
+    // ── Chunked-snapshot stall-bound test ──────────────────────────────────────
+
+    /// Verify that the chunked snapshot path holds the read lock for at most
+    /// `SNAPSHOT_CHUNK_SIZE` entries per acquisition, regardless of total map size.
+    ///
+    /// Rather than asserting wall-clock latency (which is flaky in CI), we instrument
+    /// `collect_entries_chunked` indirectly: insert 3× the chunk size entries, run the chunked
+    /// collector, and verify that we get all entries back. The structural property — at most
+    /// SNAPSHOT_CHUNK_SIZE entries per lock hold — is guaranteed by the implementation; this test
+    /// confirms correct end-to-end assembly of the chunks.
+    #[tokio::test]
+    async fn chunked_snapshot_collects_all_entries() {
+        let n = super::SNAPSHOT_CHUNK_SIZE * 3 + 7; // straddle chunk boundaries
+
+        let store = ReconcileStore::<i32, i32>::new(ephemeral_config())
+            .await
+            .expect("bind failed");
+
+        for i in 0..(n as i32) {
+            store.just_insert(i, i * 2);
+        }
+
+        let entries = store.collect_entries_chunked();
+        assert_eq!(
+            entries.len(),
+            n,
+            "chunked snapshot must collect all {n} entries"
+        );
+
+        // Entries must be in ascending key order (the HRTree is ordered).
+        let keys: Vec<i32> = entries.iter().map(|(k, _)| *k).collect();
+        let mut sorted = keys.clone();
+        sorted.sort();
+        assert_eq!(keys, sorted, "entries must be in ascending key order");
+    }
+
+    // ── Snapshot interval + change threshold tests ────────────────────────────
+
+    /// With a threshold of N and fewer than N changes, no snapshot fires at the next tick.
+    /// With ≥ N changes, the snapshot fires.
+    #[tokio::test]
+    async fn snapshot_threshold_gates_writes() {
+        use crate::persistence::{InMemoryPersistence, Persistence};
+
+        let backend = Arc::new(InMemoryPersistence::<i32, i32>::new());
+
+        let store = ReconcileStore::<i32, i32>::new(ephemeral_config())
+            .await
+            .expect("bind failed")
+            .with_persistence(backend.clone())
+            .expect("load failed")
+            // Require at least 3 changes before a snapshot is written.
+            .with_snapshot_change_threshold(3)
+            // Very short interval so the test does not need to wait long.
+            .with_snapshot_interval(Duration::from_millis(20));
+
+        // Make only 2 changes (below threshold).
+        store.just_insert(1, 10);
+        store.just_insert(2, 20);
+
+        // Wait several tick periods — threshold not met, no snapshot should appear.
+        tokio::time::sleep(Duration::from_millis(120)).await;
+
+        // Simulate what snapshot_periodically does:
+        let changes = store
+            .change_counter
+            .load(std::sync::atomic::Ordering::Relaxed);
+        assert!(
+            changes < 3,
+            "precondition: fewer than threshold changes (got {changes})"
+        );
+        // The backend has never been written to.
+        assert!(
+            Persistence::<i32, i32>::load(backend.as_ref())
+                .unwrap()
+                .is_none(),
+            "snapshot must not fire when change count is below threshold"
+        );
+
+        // Add a third change to cross the threshold.
+        store.just_insert(3, 30);
+        // Manually trigger the snapshot (as snapshot_periodically would).
+        store.snapshot();
+
+        assert!(
+            Persistence::<i32, i32>::load(backend.as_ref())
+                .unwrap()
+                .is_some(),
+            "snapshot must fire once change count reaches threshold"
+        );
+    }
+
+    /// With threshold 0, snapshot fires every tick even when the store is idle.
+    #[tokio::test]
+    async fn snapshot_threshold_zero_always_fires() {
+        use crate::persistence::{InMemoryPersistence, Persistence};
+
+        let backend = Arc::new(InMemoryPersistence::<i32, i32>::new());
+        let store = ReconcileStore::<i32, i32>::new(ephemeral_config())
+            .await
+            .expect("bind failed")
+            .with_persistence(backend.clone())
+            .expect("load failed")
+            .with_snapshot_change_threshold(0);
+
+        // No changes at all — threshold 0 means always snapshot.
+        let changes = store
+            .change_counter
+            .load(std::sync::atomic::Ordering::Relaxed);
+        assert_eq!(changes, 0);
+        // At threshold 0, the condition `changes >= threshold` is `0 >= 0` = true.
+        assert!(
+            changes >= store.snapshot_change_threshold,
+            "threshold 0 must always be met"
+        );
+        store.snapshot();
+        assert!(
+            Persistence::<i32, i32>::load(backend.as_ref())
+                .unwrap()
+                .is_some(),
+            "threshold 0 must snapshot even when idle"
+        );
+    }
+
+    /// `with_snapshot_interval(None)` disables time-based snapshots: `snapshot_periodically`
+    /// returns immediately without writing anything.
+    #[tokio::test]
+    async fn snapshot_interval_none_disables_time_based_snapshots() {
+        use crate::persistence::{InMemoryPersistence, Persistence};
+
+        let backend = Arc::new(InMemoryPersistence::<i32, i32>::new());
+        let store = ReconcileStore::<i32, i32>::new(ephemeral_config())
+            .await
+            .expect("bind failed")
+            .with_persistence(backend.clone())
+            .expect("load failed")
+            .with_snapshot_interval(None);
+
+        assert!(
+            store.snapshot_interval.is_none(),
+            "snapshot_interval must be None after with_snapshot_interval(None)"
+        );
+
+        // snapshot_periodically returns immediately when interval is None.
+        // We verify by running it with a timeout: it must complete well within 50 ms.
+        let store2 = store.clone();
+        tokio::time::timeout(Duration::from_millis(50), async move {
+            store2.snapshot_periodically().await
+        })
+        .await
+        .expect("snapshot_periodically must return immediately when interval is None");
+
+        // No snapshot should have been written.
+        assert!(
+            Persistence::<i32, i32>::load(backend.as_ref())
+                .unwrap()
+                .is_none(),
+            "disabled time-based snapshots must not write anything"
+        );
+    }
+
+    // ── Regression tests for the gossip-path change counter bug ──────────────
+
+    /// **Gossip-durability regression**: a replica that receives entries ONLY via gossip (never
+    /// writes locally) must still snapshot, because the engine-side change counter is now bumped
+    /// by the gossip apply path.
+    ///
+    /// Two-node setup:
+    ///   - Node A writes two entries locally and runs the reconcile loop.
+    ///   - Node B has FileSnapshot + short interval + default threshold=1, but inserts NOTHING
+    ///     itself; it only receives updates via gossip.
+    ///
+    /// Expected: B's snapshot file is written (and contains the entries) within a bounded wait.
+    ///
+    /// This test FAILS against the unfixed code (B's counter stays 0 → no snapshot ever) and
+    /// PASSES with the fix.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn gossip_only_replica_snapshots() {
+        use crate::persistence::Persistence;
+        use tokio::time::{timeout, Duration};
+
+        // Bind on two distinct loopback addresses on the same /29, so they form a cluster.
+        let addr_a: IpAddr = "127.1.0.1".parse().unwrap();
+        let addr_b: IpAddr = "127.1.0.2".parse().unwrap();
+        let port = 9900u16;
+        let net: ipnet::IpNet = "127.1.0.0/29".parse().unwrap();
+
+        let config_a = Config {
+            port,
+            listen_addr: addr_a,
+            nets: {
+                let mut nets = [None; MAX_NETS];
+                nets[0] = Some(net);
+                nets
+            },
+            reconcile_interval: Duration::from_millis(50),
+            ..Config::default()
+        };
+        let config_b = Config {
+            port,
+            listen_addr: addr_b,
+            nets: {
+                let mut nets = [None; MAX_NETS];
+                nets[0] = Some(net);
+                nets
+            },
+            reconcile_interval: Duration::from_millis(50),
+            ..Config::default()
+        };
+
+        // Node A: just writes — no persistence needed.
+        let store_a = ReconcileStore::<i32, i32>::new(config_a)
+            .await
+            .expect("bind A failed")
+            .with_seed(addr_b);
+
+        // Node B: snapshot backend + short interval (100 ms) + threshold=1 (default).
+        let dir = tempfile::tempdir().unwrap();
+        let snap_path = dir.path().join("b.snapshot");
+        let backend_b = Arc::new(FileSnapshot::new(&snap_path));
+        let store_b = ReconcileStore::<i32, i32>::new(config_b)
+            .await
+            .expect("bind B failed")
+            .with_seed(addr_a)
+            .with_persistence(backend_b.clone())
+            .expect("load B failed")
+            .with_snapshot_interval(Duration::from_millis(100))
+            .with_snapshot_change_threshold(1); // default, but explicit for clarity
+
+        // Spawn both loops.
+        let task_a = tokio::spawn(store_a.clone().run());
+        let task_b = tokio::spawn(store_b.clone().run());
+
+        // A writes two entries; B receives them via gossip only.
+        store_a.insert(10, 100);
+        store_a.insert(20, 200);
+
+        // Wait up to 5 s for B's snapshot file to appear (it only takes a few gossip rounds +
+        // one snapshot tick, each ≤ 100 ms, so this is very generous).
+        let snap_written = timeout(Duration::from_secs(5), async {
+            loop {
+                if let Ok(Some(state)) = Persistence::<i32, i32>::load(backend_b.as_ref()) {
+                    if !state.entries.is_empty() {
+                        return state;
+                    }
+                }
+                tokio::time::sleep(Duration::from_millis(50)).await;
+            }
+        })
+        .await
+        .expect("B's snapshot was never written within 5 s — gossip-path counter not bumped");
+
+        // Confirm the snapshot actually contains the right data.
+        let keys: Vec<i32> = snap_written
+            .entries
+            .iter()
+            .filter_map(|(k, (_, v))| v.as_ref().map(|_| *k))
+            .collect();
+        assert!(
+            keys.contains(&10) || keys.contains(&20),
+            "B's snapshot exists but is missing entries from A: {keys:?}"
+        );
+
+        task_a.abort();
+        task_b.abort();
+    }
+
+    /// **Counter-capture regression**: a change that arrives **during** the save — after the
+    /// counter was captured, before the subtraction — must still be pending afterwards
+    /// (fetch_sub of the captured amount, not store-0, which would wipe it).
+    ///
+    /// The mid-save write is injected deterministically: the persistence backend's `save`
+    /// bumps the live change counter before returning, exactly like a concurrent writer
+    /// landing while the snapshot is on disk.
+    #[tokio::test]
+    async fn snapshot_counter_capture_preserves_mid_snapshot_changes() {
+        use crate::persistence::{InMemoryPersistence, PersistedState};
+
+        /// Backend whose `save` simulates one concurrent write landing mid-save.
+        struct MidSaveWrite {
+            inner: InMemoryPersistence<i32, i32>,
+            live_counter: std::sync::OnceLock<Arc<std::sync::atomic::AtomicUsize>>,
+        }
+
+        impl Persistence<i32, i32> for MidSaveWrite {
+            fn load(&self) -> std::io::Result<Option<PersistedState<i32, i32>>> {
+                Persistence::load(&self.inner)
+            }
+
+            fn save(&self, state: &PersistedState<i32, i32>) -> std::io::Result<()> {
+                if let Some(counter) = self.live_counter.get() {
+                    counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                }
+                Persistence::save(&self.inner, state)
+            }
+        }
+
+        let backend = Arc::new(MidSaveWrite {
+            inner: InMemoryPersistence::new(),
+            live_counter: std::sync::OnceLock::new(),
+        });
+        let store = ReconcileStore::<i32, i32>::new(ephemeral_config())
+            .await
+            .expect("bind failed")
+            .with_persistence(backend.clone())
+            .expect("load failed")
+            .with_snapshot_change_threshold(1);
+        backend
+            .live_counter
+            .set(Arc::clone(&store.change_counter))
+            .expect("backend counter wired once");
+
+        store.just_insert(1, 10);
+        let captured = store
+            .change_counter
+            .load(std::sync::atomic::Ordering::Relaxed);
+        assert_eq!(
+            captured, 1,
+            "precondition: one pending change before snapshot"
+        );
+
+        // snapshot() captures 1, collects, saves (the backend injects one more change),
+        // then subtracts the captured 1 — the injected change must survive as pending.
+        store.snapshot();
+        let after = store
+            .change_counter
+            .load(std::sync::atomic::Ordering::Relaxed);
+        assert_eq!(
+            after, 1,
+            "the change injected during save must still be pending (store(0) would wipe it)"
+        );
+
+        // Verify the snapshot was actually written.
+        assert!(
+            Persistence::<i32, i32>::load(backend.as_ref())
+                .unwrap()
+                .is_some(),
+            "snapshot must have been written"
+        );
+    }
+
+    /// **GC-removal counting**: a tombstone that is garbage-collected by `gc_remove` bumps the
+    /// change counter, so the snapshot fires on the next tick even with no other changes.
+    ///
+    /// We directly call `engine.gc_remove` (the path invoked by `clear_expired_tombstones`) and
+    /// assert the counter increases.
+    #[tokio::test]
+    async fn gc_remove_bumps_change_counter() {
+        let store = ReconcileStore::<i32, i32>::new(ephemeral_config())
+            .await
+            .expect("bind failed");
+
+        // Insert a live value so there is something to GC.
+        store.just_insert(42, 1);
+
+        // Reset the counter so we start from a known baseline.
+        store
+            .change_counter
+            .store(0, std::sync::atomic::Ordering::Relaxed);
+
+        let before = store
+            .change_counter
+            .load(std::sync::atomic::Ordering::Relaxed);
+        assert_eq!(
+            before, 0,
+            "precondition: counter must be 0 before gc_remove"
+        );
+
+        // Call gc_remove directly (the internal GC path).
+        store.engine.gc_remove(&42);
+
+        let after = store
+            .change_counter
+            .load(std::sync::atomic::Ordering::Relaxed);
+        assert_eq!(
+            after, 1,
+            "gc_remove must bump the change counter by 1 so the next snapshot tick fires"
+        );
     }
 }

--- a/src/reconcile_store.rs
+++ b/src/reconcile_store.rs
@@ -46,15 +46,11 @@ const DEFAULT_SNAPSHOT_INTERVAL: Duration = Duration::from_secs(5);
 /// snapshot even when the store is idle (every tick, regardless of changes).
 const DEFAULT_SNAPSHOT_CHANGE_THRESHOLD: usize = 1;
 
-/// Number of map entries collected per lock acquisition during a chunked snapshot.
-///
-/// This bounds the maximum time a single snapshot pass holds the map read lock: the lock is
-/// released after each chunk and re-acquired for the next, so writers are only blocked for the
-/// time it takes to clone at most this many entries. The resulting snapshot is **fuzzy** — entries
-/// are captured at slightly different instants across chunks — but every entry is individually
-/// valid LWW state: a restart followed by reconciliation with peers pulls any delta that changed
-/// between chunks. The fuzziness is equivalent to the store having briefly paused writes for a
-/// fraction of the snapshot window, which the LWW reconciliation protocol already handles.
+/// Number of map entries collected per lock acquisition during a chunked snapshot: the lock is
+/// released and re-acquired between chunks, so writers are blocked only for the time to clone this
+/// many entries. The resulting snapshot is fuzzy — entries are captured at slightly different
+/// instants — but every entry is individually valid LWW state, and reconciliation on restart picks
+/// up any delta that changed between chunks, exactly as it would after a brief write pause.
 const SNAPSHOT_CHUNK_SIZE: usize = 1024;
 
 /// Default cadence of the dynamic-discovery task (see [`ReconcileStore::with_discovery_interval`]).
@@ -240,16 +236,8 @@ impl<K: Key, V: Value> ReconcileStore<K, V> {
     ///
     /// # Errors
     ///
-    /// Returns a [`LoadError`] when the backend cannot load:
-    ///
-    /// - [`LoadError::Corrupt`] — the snapshot file exists but could not be decoded. **Do not
-    ///   silently start empty**: that drops tombstones and enables resurrection of previously
-    ///   deleted values. The recommended action is to log the error, alert an operator, and halt.
-    ///   If data loss is acceptable, delete the snapshot and restart.
-    /// - [`LoadError::Io`] — a transient I/O error persisted across all retries (e.g. a volume
-    ///   still mounting). Retrying after a short delay is appropriate.
-    ///
-    /// `NotFound` (no snapshot yet) is a clean fresh start and does not produce an error.
+    /// Returns [`LoadError`] when the backend cannot load — see its docs for how to handle each
+    /// variant. A missing snapshot is a clean fresh start, not an error.
     pub fn with_persistence(
         mut self,
         backend: Arc<dyn Persistence<K, V>>,
@@ -312,30 +300,17 @@ impl<K: Key, V: Value> ReconcileStore<K, V> {
         Ok(self)
     }
 
-    /// Set how often the background task writes a snapshot to the persistence backend
-    /// (default 5 s).
-    ///
-    /// Pass `None` to disable time-based snapshots entirely — snapshots will then only fire when
-    /// the change threshold is crossed and the caller explicitly triggers one (future on-demand
-    /// API), or not at all. When time-based snapshots are disabled and no on-demand mechanism is
-    /// in place, persistence is effectively write-only (saves never happen automatically).
-    ///
-    /// An incremental/segmented snapshot format (write amplification proportional to change
-    /// volume, not dataset size) is deferred to future work.
+    /// Set how often the background task writes a snapshot (default 5 s). `None` disables
+    /// time-based snapshots: with no on-demand trigger in place, persistence becomes write-only
+    /// (saves never happen automatically).
     pub fn with_snapshot_interval(mut self, interval: impl Into<Option<Duration>>) -> Self {
         self.snapshot_interval = interval.into();
         self
     }
 
-    /// Set the minimum number of changes (inserts, removes, and reconciled applies) since the
-    /// last snapshot before the next timed tick actually writes to the backend (default 1).
-    ///
-    /// - `0` — snapshot every tick unconditionally, even when the store is idle.
-    /// - `N > 0` — skip the tick if fewer than `N` changes have occurred since the last snapshot.
-    ///   Steady-state idle ⇒ zero snapshot I/O.
-    ///
-    /// The change counter is reset to zero after every snapshot write, so the threshold applies
-    /// to the *interval* between snapshots, not to the total lifetime change count.
+    /// Set the minimum changes since the last snapshot before a timed tick actually writes
+    /// (default 1; `0` writes every tick unconditionally). The counter resets after every
+    /// snapshot, so this gates the interval between writes, not the lifetime total.
     pub fn with_snapshot_change_threshold(mut self, threshold: usize) -> Self {
         self.snapshot_change_threshold = threshold;
         self
@@ -343,19 +318,9 @@ impl<K: Key, V: Value> ReconcileStore<K, V> {
 
     /// Capture the store state and hand it to the persistence backend.
     ///
-    /// # Chunked (fuzzy) snapshot
-    ///
-    /// The map is iterated in key-order chunks of [`SNAPSHOT_CHUNK_SIZE`] entries. The read lock
-    /// is **released between chunks**, so writers (inserts, removes, reconciliation applies) are
-    /// only blocked for the time it takes to clone one chunk — bounded independently of dataset
-    /// size. The resulting snapshot is **fuzzy**: entries captured in different chunks may reflect
-    /// slightly different instants. Every captured entry is individually valid LWW state, and a
-    /// restart followed by reconciliation with peers will pull any delta that changed between
-    /// chunks. This trade-off is equivalent to briefly pausing writes for a fraction of the
-    /// snapshot window, which the LWW protocol already handles.
-    ///
-    /// After the snapshot write the change counter is reset to zero so the threshold logic in
-    /// [`snapshot_periodically`] starts a fresh accounting window.
+    /// Iterated in chunks of [`SNAPSHOT_CHUNK_SIZE`] with the read lock released between them —
+    /// see that constant for why the resulting fuzziness is safe. The change counter resets to
+    /// zero afterward, starting a fresh accounting window for [`snapshot_periodically`].
     fn snapshot(&self) {
         // Capture the counter BEFORE collecting entries so that any changes that arrive during the
         // (potentially multi-chunk) collection are still counted in the next snapshot window.
@@ -2176,14 +2141,9 @@ mod reconcile_store_tests {
 
     // ── Chunked-snapshot stall-bound test ──────────────────────────────────────
 
-    /// Verify that the chunked snapshot path holds the read lock for at most
-    /// `SNAPSHOT_CHUNK_SIZE` entries per acquisition, regardless of total map size.
-    ///
-    /// Rather than asserting wall-clock latency (which is flaky in CI), we instrument
-    /// `collect_entries_chunked` indirectly: insert 3× the chunk size entries, run the chunked
-    /// collector, and verify that we get all entries back. The structural property — at most
-    /// SNAPSHOT_CHUNK_SIZE entries per lock hold — is guaranteed by the implementation; this test
-    /// confirms correct end-to-end assembly of the chunks.
+    /// Insert 3× `SNAPSHOT_CHUNK_SIZE` entries and confirm the chunked collector returns all of
+    /// them. The per-chunk lock bound is guaranteed by the implementation; this checks the chunks
+    /// reassemble correctly rather than asserting flaky wall-clock lock-hold timing.
     #[tokio::test]
     async fn chunked_snapshot_collects_all_entries() {
         let n = super::SNAPSHOT_CHUNK_SIZE * 3 + 7; // straddle chunk boundaries
@@ -2337,19 +2297,9 @@ mod reconcile_store_tests {
 
     // ── Regression tests for the gossip-path change counter bug ──────────────
 
-    /// **Gossip-durability regression**: a replica that receives entries ONLY via gossip (never
-    /// writes locally) must still snapshot, because the engine-side change counter is now bumped
-    /// by the gossip apply path.
-    ///
-    /// Two-node setup:
-    ///   - Node A writes two entries locally and runs the reconcile loop.
-    ///   - Node B has FileSnapshot + short interval + default threshold=1, but inserts NOTHING
-    ///     itself; it only receives updates via gossip.
-    ///
-    /// Expected: B's snapshot file is written (and contains the entries) within a bounded wait.
-    ///
-    /// This test FAILS against the unfixed code (B's counter stays 0 → no snapshot ever) and
-    /// PASSES with the fix.
+    /// Regression: a replica that only ever receives entries via gossip (node B, never inserting
+    /// locally) must still snapshot, since the gossip apply path now bumps the change counter too.
+    /// Fails against the unfixed code, where B's counter stays 0 and it never snapshots.
     #[tokio::test(flavor = "multi_thread")]
     async fn gossip_only_replica_snapshots() {
         use crate::persistence::Persistence;
@@ -2441,13 +2391,9 @@ mod reconcile_store_tests {
         task_b.abort();
     }
 
-    /// **Counter-capture regression**: a change that arrives **during** the save — after the
-    /// counter was captured, before the subtraction — must still be pending afterwards
-    /// (fetch_sub of the captured amount, not store-0, which would wipe it).
-    ///
-    /// The mid-save write is injected deterministically: the persistence backend's `save`
-    /// bumps the live change counter before returning, exactly like a concurrent writer
-    /// landing while the snapshot is on disk.
+    /// Regression: a change arriving during the save (after the counter is captured, before the
+    /// subtraction) must remain pending — `fetch_sub` of the captured amount, not store-0, which
+    /// would wipe it. Injected deterministically: `save` bumps the live counter before returning.
     #[tokio::test]
     async fn snapshot_counter_capture_preserves_mid_snapshot_changes() {
         use crate::persistence::{InMemoryPersistence, PersistedState};


### PR DESCRIPTION
**Problem (the #202 + #172 persistence work package).** Four operational gaps: (1) `snapshot()` deep-cloned the entire map under the read lock, stalling every writer for the whole clone (multi-hundred-ms on large maps, every 5s); (2) `save()` never fsync'd the containing directory after rename (a crash could lose the name binding and restart on the *old* snapshot), and interrupted saves leaked `*.tmp` files forever; (3) `with_persistence` panicked on any load error, conflating corruption with transient I/O (EACCES during remount, NFS hiccup) into an orchestrator crash-loop; (4) the snapshot interval was a hard-coded 5s constant, rewriting the full dataset even when nothing changed.

**Fixes:**
- **Chunked snapshot**: entries are collected 1024 per `map.read()` acquisition via the HRTree's ordered range cursor (strict `Excluded` bound — duplicate-proof even under concurrent mutation). Writer stall is bounded by chunk size, independent of dataset size. The snapshot is honestly documented as *fuzzy* (entries captured at slightly different instants; every entry is valid LWW state and restart reconciliation pulls any delta — a tombstone GC'd mid-snapshot re-persists the deletion, the safe direction).
- **Crash consistency + hygiene**: `write → fsync(file) → rename → fsync(parent dir)`; stale `*.tmp` siblings removed on load (logged); the doc claim now matches the actual guarantee. In-process crash-matrix tests cover interrupted-save states (old loads + tmp cleaned / new loads; never neither).
- **Fallible loading** (approved API break, rides 0.3): `with_persistence → Result<Self, LoadError>` with `LoadError::Corrupt` (operator action documented: halt, don't silently start empty) vs `LoadError::Io` (3 retries with backoff and warnings first). `NotFound` stays a clean fresh start with no retry penalty. `LoadError` re-exported at the crate root; the README example models the real handling.
- **#172 configurability**: `with_snapshot_interval(Option<Duration>)` (None disables time-based snapshots), `with_snapshot_change_threshold(usize)` (default 1 — idle nodes do zero snapshot IO; 0 = always). The change counter lives in the **engine** and counts every mutation path: local writes, **gossip applies**, and GC removals — counter reset is capture-and-subtract, so changes landing mid-snapshot stay pending. Incremental/segmented snapshot format ("IO proportional to change volume") is deferred — it's a separate project; this PR delivers #172's configurability/trigger acceptance.

**Review provenance.** Adversarially reviewed in two rounds with executable experiments. Round 1 REJECT caught the headline bug: the change counter originally only counted *local* writes, so a replica receiving data purely via gossip never crossed the threshold, never snapshotted, and would restart empty — proven with a live 2-node experiment (entries held in memory, snapshot file never written), the exact inverse of the durability feature. Also caught: a `store(0)` counter reset dropping mid-snapshot changes, the README example broken by the new API, and the missing re-export. Round 2 verified the fixes (gossip-durability regression test proven to fail pre-fix; no double/zero-count path including the mirror and snapshot-restore) and mandated two test-integrity fixes, both applied: the README is now compile-checked as a doctest (`#[cfg(doctest)]` harness — this immediately exposed 8 pre-existing non-compiling README fragments, now explicitly `rust,ignore`; rewriting them as compiling examples is queued for the hygiene batch), and the counter-capture test was rewritten to inject a write *inside* `Persistence::save` (verified to fail against `store(0)`).

Closes #202. Advances #172 (cadence/trigger configurability delivered; incremental snapshot format remains open — left a note there).

**Stack** — base: `claude/p1-3-dns-decommission` (#217). Merge after #217.

https://claude.ai/code/session_01BaajsC6gEk1v7Y55dA5cPG

---
_Generated by [Claude Code](https://claude.ai/code/session_01BaajsC6gEk1v7Y55dA5cPG)_