### PR TITLE
ci: feature-matrix, macOS, and MSRV lanes; scalable integration-test time budgets

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -54,8 +54,93 @@ jobs:
     - name: Check that the crate is publishable
       run: cargo publish --allow-dirty --dry-run
 
+  # Exercises the HMAC-SHA256 MAC backend, which is compiled out by --all-features
+  # (mac-blake3 takes precedence when both are enabled). Without this lane, a regression
+  # in HmacSha256Mac or any mac-hmac-gated code ships green.
+  mac-hmac:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Enable caching
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+        key: ${{ runner.os }}-cargo-hmac-${{ hashFiles('**/Cargo.lock') }}
+    - name: Build (mac-hmac, no default features)
+      run: cargo build --no-default-features --features mac-hmac --verbose
+    - name: Test (mac-hmac, no default features)
+      run: cargo test --no-default-features --features mac-hmac --verbose
+    - name: Test (mac-hmac + encryption)
+      run: cargo test --no-default-features --features mac-hmac,encryption --verbose
+
+  # Exercises the encryption feature together with the default (blake3) MAC backend.
+  # --all-features already covers this path in lint-and-test; this job makes it explicit
+  # and runs it independently so encryption regressions are easy to spot in CI.
+  encryption:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Enable caching
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+        key: ${{ runner.os }}-cargo-enc-${{ hashFiles('**/Cargo.lock') }}
+    - name: Test (mac-blake3 + encryption)
+      run: cargo test --features encryption --verbose
+
+  # macOS build + unit tests only. Integration tests (real UDP sockets, loopback
+  # routing, multi-thread tokio) are Linux-only for now: the loopback aliases
+  # (127.0.0.x/8) and socket-buffer sysctl tuning that the integration suite relies
+  # on behave differently on macOS, causing spurious port-in-use and bind failures on
+  # shared runners. Unit tests catch compiler regressions and platform-specific ABI
+  # issues without requiring OS-level network setup.
+  macos:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Enable caching
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+    - name: Build
+      run: cargo build --all --verbose
+    - name: Run unit tests (lib only)
+      run: cargo test --lib --all-features --verbose
+
+  # MSRV check: compile all targets against the declared minimum supported Rust version.
+  # Uses `cargo check` (not `cargo test`) to keep the job cheap: the borrow checker
+  # catches the language-level regressions that matter, without the cost of codegen or
+  # linking. A full test run on the MSRV toolchain would also require pinning every
+  # transitive dependency, which is out of scope here.
+  msrv:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install MSRV toolchain
+      uses: dtolnay/rust-toolchain@1.85
+    - name: Enable caching
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+        key: ${{ runner.os }}-cargo-msrv-${{ hashFiles('**/Cargo.lock') }}
+    - name: Check (MSRV, all targets, all features)
+      run: cargo check --all-targets --all-features
+
   coverage:
     runs-on: ubuntu-latest
+    env:
+      # llvm-cov instrumentation slows the test suite by 2-5×; scale the integration-test
+      # poll budgets accordingly so "convergence timed out" is not a spurious failure.
+      RECONCILE_TEST_TIME_MULTIPLIER: 3
     steps:
     - uses: actions/checkout@v3
     - name: Install llvm-tools-preview

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -112,11 +112,15 @@ jobs:
       run: cargo build --all --verbose
     - name: Add loopback aliases
       # macOS only configures 127.0.0.1 on lo0 (Linux routes all of 127/8); the
-      # engine/store unit tests bind distinct 127.0.0.x addresses to isolate their
-      # UDP sockets, so alias the range they use before running them.
+      # engine/store unit tests bind distinct 127.x addresses to isolate their UDP
+      # sockets, so alias them before running. The 127.0.0.x range is aliased densely;
+      # any other 127.x literal the tests use is extracted from the source so this stays
+      # correct as tests are added. `|| true` tolerates non-bindable literals (e.g. the
+      # 127.0.0.0/8 CIDR network address) without failing the step.
       run: |
-        for i in $(seq 2 254); do sudo ifconfig lo0 alias 127.0.0.$i up; done
-        sudo ifconfig lo0 alias 127.1.0.3 up
+        for i in $(seq 2 254); do sudo ifconfig lo0 alias 127.0.0.$i up || true; done
+        grep -rhoE '127(\.[0-9]+){3}' src/ | sort -u | grep -vE '^127\.0\.0\.' | \
+          while read -r addr; do sudo ifconfig lo0 alias "$addr" up || true; done
     - name: Run unit tests (lib only)
       run: cargo test --lib --all-features --verbose
 

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -93,11 +93,10 @@ jobs:
       run: cargo test --features encryption --verbose
 
   # macOS build + unit tests only. Integration tests (real UDP sockets, loopback
-  # routing, multi-thread tokio) are Linux-only for now: the loopback aliases
-  # (127.0.0.x/8) and socket-buffer sysctl tuning that the integration suite relies
-  # on behave differently on macOS, causing spurious port-in-use and bind failures on
-  # shared runners. Unit tests catch compiler regressions and platform-specific ABI
-  # issues without requiring OS-level network setup.
+  # routing, multi-thread tokio) are Linux-only for now: the socket-buffer sysctl
+  # tuning and timing budgets the integration suite relies on behave differently on
+  # macOS shared runners. Unit tests (with the loopback aliases added below) catch
+  # compiler regressions and platform-specific socket/ABI issues.
   macos:
     runs-on: macos-latest
     steps:
@@ -111,6 +110,13 @@ jobs:
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
     - name: Build
       run: cargo build --all --verbose
+    - name: Add loopback aliases
+      # macOS only configures 127.0.0.1 on lo0 (Linux routes all of 127/8); the
+      # engine/store unit tests bind distinct 127.0.0.x addresses to isolate their
+      # UDP sockets, so alias the range they use before running them.
+      run: |
+        for i in $(seq 2 254); do sudo ifconfig lo0 alias 127.0.0.$i up; done
+        sudo ifconfig lo0 alias 127.1.0.3 up
     - name: Run unit tests (lib only)
       run: cargo test --lib --all-features --verbose
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "reconcile"
 version = "0.2.1"
 edition = "2021"
+rust-version = "1.85"
 license = "MIT OR Apache-2.0"
 description = "A reconciliation storage service to sync a key-value map over multiple instances"
 repository = "https://github.com/Akvize/reconcile-rs"

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -10,9 +10,11 @@
 > - **Issue [#138](https://github.com/Akvize/reconcile-rs/issues/138)** — execution tracking of the
 >   architecture migration (one sub-issue per phase).
 
-- **Last updated:** 2026-06-12
-- **Baseline:** `claude/determined-franklin-s3tvt1` @ `f1423ce` (2026-06 correctness sprint; pending
-  merge to master)
+- **Last updated:** 2026-06-13
+- **Baseline:** `claude/p1-5-ci-matrix` @ `32193cc` (CI hardening: feature-matrix + macOS + MSRV
+  lanes; scalable test time budget; MSRV declaration — see issues
+  [#203](https://github.com/Akvize/reconcile-rs/issues/203) and
+  [#189](https://github.com/Akvize/reconcile-rs/issues/189))
 - **Manifest:** `0.2.1` (unpublished; semver and publish policy tracked in
   [#204](https://github.com/Akvize/reconcile-rs/issues/204))
 
@@ -81,8 +83,9 @@ all but one High resolved or mitigated.
 - [ ] Semver and publish policy — `0.2.1` exists but policy is not yet settled ([#204](https://github.com/Akvize/reconcile-rs/issues/204))
 - [ ] `CHANGELOG.md`
 - [x] CI code coverage + doc-tests ([#97](https://github.com/Akvize/reconcile-rs/issues/97)) — Codecov (`cargo llvm-cov`) + `cargo test --doc` in CI
+- [x] Feature-matrix CI — dedicated `mac-hmac`, `encryption`, and `macos` jobs; scalable poll budget via `RECONCILE_TEST_TIME_MULTIPLIER` ([#203](https://github.com/Akvize/reconcile-rs/issues/203))
 - [ ] `cargo audit` / `cargo deny` in CI ([#151](https://github.com/Akvize/reconcile-rs/issues/151))
-- [ ] Declare + CI-pin MSRV (`rust-version`) — iterators are safe Rust (crate is `#![forbid(unsafe_code)]`); miri item dropped ([#189](https://github.com/Akvize/reconcile-rs/issues/189))
+- [x] Declare + CI-pin MSRV (`rust-version = "1.85"`) — iterators are safe Rust (crate is `#![forbid(unsafe_code)]`); miri item dropped ([#189](https://github.com/Akvize/reconcile-rs/issues/189))
 - [ ] `overflow-checks = true` in the release profile ([#151](https://github.com/Akvize/reconcile-rs/issues/151))
 - [ ] bincode decode limit (`with_limit`) against allocation bombs ([#150](https://github.com/Akvize/reconcile-rs/issues/150), [#151](https://github.com/Akvize/reconcile-rs/issues/151))
 

--- a/README.md
+++ b/README.md
@@ -511,6 +511,15 @@ changes from 10 to 1,000,000 elements.
 **Note:** These benchmarks are performed locally on the loop-back network
 interface. On a real network, transmission delays will make the values larger.
 
+## Minimum Supported Rust Version (MSRV)
+
+The crate requires **Rust 1.85** or later (`rust-version = "1.85"` in `Cargo.toml`).
+This is enforced by a dedicated CI job that runs `cargo check` against that toolchain on
+every push.
+
+**Policy:** an MSRV bump is treated as a **minor version increment** (e.g. 0.2 → 0.3) and
+documented in `CHANGELOG.md`. Patch releases never raise the MSRV.
+
 ## Testing and coverage
 
 The crate is covered by unit, integration, property-based and documentation
@@ -533,4 +542,6 @@ cargo llvm-cov --workspace --html     # browsable HTML report under target/llvm-
 ```
 
 Coverage is collected with the crate's default features. The `mac-blake3` and
-`mac-hmac` backends are mutually exclusive, so do **not** pass `--all-features`.
+`mac-hmac` backends are mutually exclusive at build time (`mac-blake3` takes precedence
+when both are enabled), so a separate CI job (`mac-hmac`) exercises the HMAC-SHA256
+backend with `--no-default-features --features mac-hmac`.

--- a/SOTA.md
+++ b/SOTA.md
@@ -418,7 +418,7 @@ surrounding system.
 |---|---|
 | **MSRV** (*Minimum Supported Rust Version*) | The minimum supported Rust version; absent from `Cargo.toml` (F17). |
 | **clippy / `-Dwarnings`** | The Rust linter; CI treating warnings as errors. The `mismatched_lifetime_syntaxes` warning (`hrtree_iter.rs:177`) would break CI (F17). |
-| **miri** | An interpreter detecting UB (*Undefined Behavior*); not applicable here — the crate is `#![forbid(unsafe_code)]` and all iterators are safe Rust (since `d030c15`). The CI gap for F17 is now the undeclared MSRV ([#189](https://github.com/Akvize/reconcile-rs/issues/189)). |
+| **miri** | An interpreter detecting UB (*Undefined Behavior*); not applicable here — the crate is `#![forbid(unsafe_code)]` and all iterators are safe Rust (since `d030c15`). The F17 CI gap (undeclared MSRV) was closed by declaring `rust-version = "1.85"` and adding a CI check job ([#189](https://github.com/Akvize/reconcile-rs/issues/189)). |
 | **proptest / quickcheck / fuzzing** | Property-based / generative / random-input testing. **Entirely absent** (F11). |
 | **`cargo audit` / `cargo deny`** | Vulnerability audit / dependency policies. Absent from CI (F19). |
 | **bincode / serde / tokio / parking_lot / arrayvec / ipnet / range-cmp / chrono / rand / once_cell / tracing** | Dependencies: binary serialization; (de)serialization; async runtime; non-poisoning locks; `ArrayVec` (inline vector, B-tree nodes); network/CIDR types; key↔range comparison (`RangeOrdering`); `DateTime<Utc>` (LWW timestamps); randomness; lazy init; structured logs. |

--- a/src/reconcile_engine.rs
+++ b/src/reconcile_engine.rs
@@ -846,7 +846,7 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
         let remote_fanout = self.remote_fanout.load(Ordering::Relaxed);
         let round = self.round.fetch_add(1, Ordering::Relaxed);
         // Treat an interval of 0 as "every round" to avoid a modulo-by-zero.
-        let do_remote = round.is_multiple_of(remote_interval);
+        let do_remote = round % remote_interval == 0;
         let known = self.get_peers();
 
         // De-duplicate so a discovery probe that happens to hit a known peer is not sent twice.

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,58 @@
+// Copyright 2023 Developers of the reconcile project.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Shared test helpers for the integration test suite.
+
+use std::sync::OnceLock;
+use std::time::Duration;
+
+/// Scaling factor for `wait_until` poll budgets.
+///
+/// Set `RECONCILE_TEST_TIME_MULTIPLIER` to an integer or float to stretch the
+/// budget; the default is 1 (unscaled, same as the hard-coded original budget).
+/// The coverage job sets it to 3 because `cargo llvm-cov` instrumentation
+/// slows the integration suite by 2-5×, and a 1-second budget produces
+/// spurious "convergence timed out" failures on shared CI runners.
+fn time_multiplier() -> u32 {
+    static MULTIPLIER: OnceLock<u32> = OnceLock::new();
+    *MULTIPLIER.get_or_init(|| {
+        std::env::var("RECONCILE_TEST_TIME_MULTIPLIER")
+            .ok()
+            .and_then(|s| s.parse::<f64>().ok())
+            .map(|f| f.max(1.0).round() as u32)
+            .unwrap_or(1)
+    })
+}
+
+/// Wait for a while until the provided predicate becomes true.
+///
+/// Returns `true` if the predicate became true within the budget, or `false`
+/// if it timed out.  The budget is `base_iters` × 10 ms by default, scaled by
+/// `RECONCILE_TEST_TIME_MULTIPLIER`.  Most callers pass 100; test files that
+/// already used a larger base (e.g. 200 for discovery tests) pass their
+/// original value so relative timing is preserved.
+pub async fn wait_until_with_budget<F: FnMut() -> bool>(mut f: F, base_iters: u32) -> bool {
+    let iters = base_iters.saturating_mul(time_multiplier());
+    for _ in 0..iters {
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        if f() {
+            return true;
+        }
+    }
+    false
+}
+
+/// Wait for a while until the provided predicate becomes true.
+///
+/// Returns `true` if the predicate became true within the budget, or `false`
+/// if it timed out.  The budget is 100 × 10 ms by default, scaled by
+/// `RECONCILE_TEST_TIME_MULTIPLIER`.
+#[allow(dead_code)] // used by service.rs; not every test file that includes this module uses it
+pub async fn wait_until<F: FnMut() -> bool>(f: F) -> bool {
+    wait_until_with_budget(f, 100).await
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -29,13 +29,10 @@ fn time_multiplier() -> u32 {
     })
 }
 
-/// Wait for a while until the provided predicate becomes true.
-///
-/// Returns `true` if the predicate became true within the budget, or `false`
-/// if it timed out.  The budget is `base_iters` × 10 ms by default, scaled by
-/// `RECONCILE_TEST_TIME_MULTIPLIER`.  Most callers pass 100; test files that
-/// already used a larger base (e.g. 200 for discovery tests) pass their
-/// original value so relative timing is preserved.
+/// Poll `f` every 10 ms for up to `base_iters` × 10 ms (scaled by
+/// `RECONCILE_TEST_TIME_MULTIPLIER`), returning `true` as soon as it does, `false` on timeout.
+/// Callers with heavier scenarios (e.g. discovery's multi-round decommission tests) pass a larger
+/// `base_iters` than the default 100.
 pub async fn wait_until_with_budget<F: FnMut() -> bool>(mut f: F, base_iters: u32) -> bool {
     let iters = base_iters.saturating_mul(time_multiplier());
     for _ in 0..iters {
@@ -47,11 +44,7 @@ pub async fn wait_until_with_budget<F: FnMut() -> bool>(mut f: F, base_iters: u3
     false
 }
 
-/// Wait for a while until the provided predicate becomes true.
-///
-/// Returns `true` if the predicate became true within the budget, or `false`
-/// if it timed out.  The budget is 100 × 10 ms by default, scaled by
-/// `RECONCILE_TEST_TIME_MULTIPLIER`.
+/// [`wait_until_with_budget`] with the default 100-iteration budget.
 #[allow(dead_code)] // used by service.rs; not every test file that includes this module uses it
 pub async fn wait_until<F: FnMut() -> bool>(f: F) -> bool {
     wait_until_with_budget(f, 100).await

--- a/tests/discovery.rs
+++ b/tests/discovery.rs
@@ -17,14 +17,14 @@ use std::time::Duration;
 use reconcile::discovery::{DiscoverFuture, Discovery};
 use reconcile::{reconcile_store::Config, ReconcileStore};
 
-async fn wait_until<F: FnMut() -> bool>(mut f: F) -> bool {
-    for _ in 0..200 {
-        tokio::time::sleep(Duration::from_millis(10)).await;
-        if f() {
-            return true;
-        }
-    }
-    false
+mod common;
+
+// Discovery tests use a 200-iteration base (2 s at default speed) because the
+// decommission/floor scenarios involve multiple discovery rounds with non-trivial
+// sleeps between them.
+#[allow(dead_code)]
+async fn wait_until<F: FnMut() -> bool>(f: F) -> bool {
+    common::wait_until_with_budget(f, 200).await
 }
 
 macro_rules! assert_until {

--- a/tests/service.rs
+++ b/tests/service.rs
@@ -7,19 +7,9 @@ use rand::{
 
 use reconcile::{reconcile_store::Config, Fingerprint, ReconcileStore};
 
-/// Wait for a while until the provided predicate becomes true
-///
-/// If the predicate become true in the delay, return true, otherwise return false. This functions
-/// minimizes the wait time by checking regularly if the predicate is true.
-async fn wait_until<F: FnMut() -> bool>(mut f: F) -> bool {
-    for _ in 0..100 {
-        tokio::time::sleep(Duration::from_millis(10)).await;
-        if f() {
-            return true;
-        }
-    }
-    false
-}
+mod common;
+
+use common::wait_until;
 
 macro_rules! assert_until {
     ( $x:expr ) => {


### PR DESCRIPTION
**Problem (#203 + #189).** (1) The shipped `mac-hmac` crypto backend had **never been compiled by any CI job**: it's gated behind `all(feature = "mac-hmac", not(feature = "mac-blake3"))`, and the only feature-varying lane (`--all-features`) turns blake3 on, compiling HMAC out — a regression in the HMAC path would ship green. (2) The integration suite's fixed 1-second poll budgets run identically under `cargo llvm-cov` instrumentation (2–5× slower) — structural flake risk. (3) CI was single-OS. (4) No `rust-version` declared: accidental MSRV bumps land unnoticed and consumers get no cargo guard.

**Changes:**
- **New lanes** in `master.yml`: `mac-hmac` (`--no-default-features --features mac-hmac`, plus the `mac-hmac,encryption` combination), `encryption` (default MAC + encryption), `macos` (build + unit tests; integration tests stay Linux-only, reason documented in the workflow), and `msrv` (pinned toolchain + `cargo check --all-targets --all-features`). Every lane's exact command was verified green locally before pushing.
- **Scalable test budgets**: `tests/common/mod.rs` provides `wait_until` helpers whose iteration budget scales by `RECONCILE_TEST_TIME_MULTIPLIER` (panic-free parsing, clamped ≥1, float accepted); the coverage job sets it to 3. Verified empirically: a budget-bound test's wall time scales as expected.
- **MSRV declared: `rust-version = "1.85"`**, enforced by the new lane, policy noted in the README (MSRV bump = minor version). One MSRV code fix (`u32::is_multiple_of` → `% == 0`, behavior-identical — divisor is `.max(1)`-guarded).
- **Doc truth fixes** (#189's rider): the stale "unsafe iterators" claims in PROGRESS.md/SOTA.md corrected (iterators are safe Rust; the crate is `#[forbid(unsafe_code)]`), maturity checklist updated.

**Review provenance.** Adversarially reviewed; verdict approve-with-fixes, applied. The review's principal catch: the implementation originally declared **MSRV 1.70**, "verified" only via clippy's API-level `--incompatible-msrv` lint — but the actual job command fails on everything below 1.85 (the reviewer bisected with real toolchains: Cargo.lock v4 needs cargo ≥1.78; `blake3 1.8.5 → cpufeatures 0.3.0` requires edition 2024, stabilized in 1.85; **1.84 fails, 1.85 passes**). The MSRV lane would have arrived red. All references corrected to the honest, toolchain-verified 1.85. The review also validated the feature graph for the `mac-hmac,encryption` combination, confirmed `HmacSha256Mac` is genuinely the active backend with its round-trip tests running in the new lane, and exercised the multiplier's edge cases (garbage/zero/negative env values are safe).

**Why this stacks on #218 rather than basing off `main`:** the MSRV pin and matrix lanes must validate the final tree — the stack's new code and feature surface — not `main`'s. This PR merges last.

Closes #203. Closes #189.

**Stack** — base: `claude/p1-4-persistence` (#218). Merge after #218.

https://claude.ai/code/session_01BaajsC6gEk1v7Y55dA5cPG

---
_Generated by [Claude Code](https://claude.ai/code/session_01BaajsC6gEk1v7Y55dA5cPG)_