### PR TITLE
release: tag-version verification, publish dry-run, docs/version sync, 0.3.0 break policy

### DIFF
--- a/.github/workflows/tags.yml
+++ b/.github/workflows/tags.yml
@@ -1,5 +1,10 @@
 name: tags
 
+# Triggered by pushing a tag of the form vX.Y.Z (issue #204).
+# The repo uses manual version bumps: update Cargo.toml and Cargo.lock,
+# commit, then push the matching tag.  This workflow enforces the contract
+# by failing loudly when the tag and the manifest version disagree.
+
 on:
   push:
     tags: [ "v*" ]
@@ -17,12 +22,25 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - name: Set version
-        run: echo "VERSION=${GITHUB_REF##*\/v}" >> $GITHUB_ENV
       - uses: actions/checkout@v4
-      - name: Set Cargo.toml version
-        run: sed "s/0\\.0\\.0-git/$VERSION/" -i Cargo.toml Cargo.lock
+      - name: Verify tag matches Cargo.toml version
+        # Extract the version from the tag (strips the leading "v") and compare
+        # it against the version declared in Cargo.toml.  Fail loudly on any
+        # mismatch so a stale or wrong-version tag never silently republishes
+        # the wrong crate version.
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          CRATE_VERSION=$(cargo metadata --no-deps --format-version 1 | \
+            python3 -c "import sys,json; print(json.load(sys.stdin)['packages'][0]['version'])")
+          echo "Tag version:   $TAG_VERSION"
+          echo "Crate version: $CRATE_VERSION"
+          if [ "$TAG_VERSION" != "$CRATE_VERSION" ]; then
+            echo "ERROR: tag 'v${TAG_VERSION}' does not match Cargo.toml version '${CRATE_VERSION}'."
+            echo "Bump the version in Cargo.toml (and Cargo.lock) and commit before pushing the tag."
+            exit 1
+          fi
+          echo "VERSION=$CRATE_VERSION" >> "$GITHUB_ENV"
       - name: Login on crates repository
         run: echo ${{ secrets.CARGO_REGISTRY_TOKEN }} | cargo login
       - name: Publish crate
-        run: cargo publish --allow-dirty
+        run: cargo publish

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -8,8 +8,9 @@ instances. This document describes the **current architecture** and the **target
 [`PROGRESS.md`](./PROGRESS.md) and are assumed here as the baseline; the state-of-the-art
 positioning is in [`SOTA.md`](./SOTA.md).
 
-The crate is unpublished (`0.0.0-git`); the public API and the on-wire / on-disk formats are not yet
-stable and may change. Code locations are given as `file:line` against the current tree.
+The crate is published on crates.io as `reconcile` **0.2.1**. The public API and the on-wire /
+on-disk formats are not yet stable — breaking changes ride a minor-version bump (next: 0.3.0,
+see `CHANGELOG.md`). Code locations are given as `file:line` against the current tree.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,113 @@
+# Changelog
+
+All notable changes to `reconcile` are documented here.
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
+versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+**MSRV policy:** an MSRV bump is a *minor* version increment (e.g. 0.2 → 0.3).
+Patch releases never raise the MSRV.
+
+---
+
+## [Unreleased] — 0.3.0
+
+**This release contains multiple breaking changes that require coordinated
+upgrades across the cluster.  Nodes running 0.2.x and 0.3.0 simultaneously
+will not interoperate correctly.**
+
+### Breaking — wire format (authenticated mode, anti-replay)
+
+The authenticated-mode wire format now includes a per-datagram anti-replay
+header (issue #199).  All nodes in a cluster **must** be upgraded to 0.3.0 in
+lockstep; a 0.2.x node will reject 0.3.0 datagrams (and vice versa) because the
+MAC covers the new header field.  Rolling upgrades are not safe — quiesce the
+cluster, upgrade all nodes, then restart.
+
+### Breaking — `with_persistence` now returns `Result`
+
+`ReconcileStore::with_persistence` (previously infallible) now returns
+`Result<ReconcileStore<K, V>, LoadError>`.  Call sites must handle the error;
+`LoadError::Corrupt` **must not** be silently ignored (doing so drops tombstones
+and re-enables the resurrection hazard of issue #109).  See the updated
+`README.md` Persistence section for the recommended error-handling pattern.
+
+### Breaking — public API removals (fingerprint-unsafe mutable iterators)
+
+The mutable iterator types that allowed in-place value mutation without
+updating the range fingerprint have been removed from the public API
+(issue #197): `IterMut`, `ValuesMut`, `HRTree::iter_mut()`, `HRTree::values_mut()`.
+Any mutation through them silently desynced the fingerprints replicas compare.
+Replace call sites with the hash-safe mutation path —
+`ReconcileStore::get_mut` (or `HRTree::with_mut`) — which recomputes the
+fingerprint on every edit.
+
+### Breaking (planned, not yet landed) — wire and on-disk format (`Entry` / `State` migration, issue #143)
+
+The `Entry<Timestamp, V>` / `State<V>` domain-type migration (architecture step 4,
+`ARCHITECTURE.md` §6) will replace the internal `(Timestamp, Option<V>)` tuple,
+changing both the gossip wire format and the `FileSnapshot` on-disk format.
+If it lands in time it rides this release (one coordinated break beats two);
+**existing snapshots will not be forward-compatible** — pre-break snapshots must
+be rejected cleanly via `LoadError::Corrupt` with a descriptive message rather
+than silently misinterpreted.  Tracked in issue #143; this entry is the policy
+record, not a landed change.
+
+### Changed — MSRV raised to 1.85
+
+The minimum supported Rust version is **1.85** (declared in `Cargo.toml`
+`rust-version`; enforced by the `msrv` CI job).  Per policy this is a minor bump.
+
+---
+
+## [0.2.1] — 2026-05
+
+### Added
+- Per-datagram payload confidentiality via XChaCha20-Poly1305 AEAD
+  (`encryption` Cargo feature, issue #96 / PR #131).
+- Lightweight dateless read-only mirror `ReconcileMirror` — converges with a
+  dated cluster over the same UDP port without keeping per-value timestamps
+  (issue #128 / PR #133).
+- Runtime observability: `tracing` spans across the engine, network, and
+  reconciliation paths; `metrics` facade (opt-in) with optional Prometheus
+  endpoint (`metrics-prometheus` feature, issue #94 / PR #130).
+- DNS-based peer discovery (`DnsDiscovery`) for Kubernetes headless Services:
+  no RBAC, no API access, correct tombstone-GC semantics (issue #147).
+- Multi-location (multi-CIDR) geography-aware gossip with bounded WAN fan-out
+  and decentralised topology; live reconfiguration via `set_nets` / `add_net` /
+  `remove_net` / `set_remote_interval` / `set_remote_fanout` / … (issue #53).
+- Pluggable `Persistence` trait with `InMemory` and `FileSnapshot` backends;
+  chunked fuzzy snapshots, directory fsync, tmp-file hygiene, configurable
+  cadence and change threshold (issue #122 / PR #202-area).
+- Fallible constructors (`ReconcileStore::new` returns `io::Result`; `LoadError`
+  distinguishes corrupt snapshots from transient I/O — issue #148).
+- Per-peer bounded state with configurable `max_peers` cap.
+- Wall-time floor guard: decommissions peers whose tombstone acks are pending
+  but the peer has been absent past the tombstone timeout (discovery grace
+  period, issue #201-area).
+- HLC restart monotonicity: the clock is seeded from the persisted snapshot on
+  startup so the HLC total order is never violated across restarts (issue #195).
+- `TimeoutWheel` same-millisecond expiry correctness fix (issue #196).
+- HLC far-future stamp and counter-wrap hardening (issue #198).
+- Anti-replay per-peer sequence tracking (foundation, issue #199-area).
+- Feature-matrix CI: dedicated `mac-hmac`, `encryption`, and `macos` jobs;
+  scalable poll budget via `RECONCILE_TEST_TIME_MULTIPLIER` (issue #203).
+- MSRV declared as `rust-version = "1.85"` in `Cargo.toml`; MSRV CI job
+  (`dtolnay/rust-toolchain@1.85`, issue #189).
+- `cargo publish --dry-run` in the `lint-and-test` CI job (issue #204).
+
+### Fixed
+- Fingerprint-desyncing mutable iterators removed from public API (issue #197).
+- `pre_insert` hook now runs outside the write lock on both the local and
+  network paths, with a regression test (issue #149 / commit `f4b5028`).
+- Removed debug `println!` from the hot reconciliation path (issue #113).
+- `DefaultHasher` replaced on the wire: fingerprints are now 256-bit additive
+  BLAKE3 (issue #111).
+- Malformed-packet panics hardened: crafted `HashSegment` / inverted ranges /
+  missing bounds are rejected before deserialisation (issues #107, #112).
+- Tombstone resurrection closed: GC is now gated on causal stability — a
+  tombstone is only collected once every monotonic cluster member has
+  acknowledged its exact version hash (issue #109).
+- HLC conflict resolution replaces unsafe physical-clock LWW (issue #110).
+
+[Unreleased]: https://github.com/Akvize/reconcile-rs/compare/v0.2.1...HEAD
+[0.2.1]: https://github.com/Akvize/reconcile-rs/releases/tag/v0.2.1

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -15,8 +15,9 @@
   lanes; scalable test time budget; MSRV declaration — see issues
   [#203](https://github.com/Akvize/reconcile-rs/issues/203) and
   [#189](https://github.com/Akvize/reconcile-rs/issues/189))
-- **Manifest:** `0.2.1` (unpublished; semver and publish policy tracked in
-  [#204](https://github.com/Akvize/reconcile-rs/issues/204))
+- **Manifest:** `0.2.1` (published on crates.io; release pipeline and semver policy fixed by
+  [#204](https://github.com/Akvize/reconcile-rs/issues/204); breaking changes ride 0.3.0 — see
+  `CHANGELOG.md`)
 
 ---
 
@@ -80,8 +81,9 @@ all but one High resolved or mitigated.
 - [x] Malformed-packet fuzz harness (`fuzz_packets.rs`)
 - [x] Security model documented (README "Security model")
 - [x] Pluggable persistence documented (README "Persistence")
-- [ ] Semver and publish policy — `0.2.1` exists but policy is not yet settled ([#204](https://github.com/Akvize/reconcile-rs/issues/204))
-- [ ] `CHANGELOG.md`
+- [x] Semver and publish policy — release pipeline restored (tag-version verification); 0.3.0 break
+  policy documented in `CHANGELOG.md` ([#204](https://github.com/Akvize/reconcile-rs/issues/204))
+- [x] `CHANGELOG.md` — seeded with 0.2.1 baseline and Unreleased (0.3.0) section
 - [x] CI code coverage + doc-tests ([#97](https://github.com/Akvize/reconcile-rs/issues/97)) — Codecov (`cargo llvm-cov`) + `cargo test --doc` in CI
 - [x] Feature-matrix CI — dedicated `mac-hmac`, `encryption`, and `macos` jobs; scalable poll budget via `RECONCILE_TEST_TIME_MULTIPLIER` ([#203](https://github.com/Akvize/reconcile-rs/issues/203))
 - [ ] `cargo audit` / `cargo deny` in CI ([#151](https://github.com/Akvize/reconcile-rs/issues/151))


### PR DESCRIPTION
**Problem (#204).** The tag-driven release pipeline was silently dead: `tags.yml` rewrote the version with `sed "s/0.0.0-git/$VERSION/"`, but that placeholder no longer exists since the manual bump to 0.2.1 — pushing a tag would publish whatever the manifest says regardless of the tag, with no error. Meanwhile ARCHITECTURE.md/PROGRESS.md still described an unpublished `0.0.0-git` crate, and the pending format breaks had no documented version policy.

**Changes:**
- **Tag-version contract enforced**: the dead sed is gone; `tags.yml` now extracts the crate version via `cargo metadata` and **fails loudly** unless the pushed tag is exactly `v$VERSION` (both paths simulation-tested; convention `vX.Y.Z` matches the existing trigger). `--allow-dirty` removed from the publish step — it only existed to paper over the rewrite.
- **Packaging drift insurance**: `cargo publish --dry-run` passes locally; the lint-and-test lane already runs it on every push (from the CI batch), so a packaging break surfaces long before a release.
- **Docs/manifest sync**: ARCHITECTURE.md and PROGRESS.md now state the real publication state (crates.io, 0.2.1) and point at the new CHANGELOG for the stability story. No `0.0.0-git`/"unpublished" strings remain anywhere.
- **`CHANGELOG.md` (new)**, seeded with 0.2.1 and an **Unreleased — 0.3.0** section that makes the break policy a deliberate version event: the authenticated-mode wire break (anti-replay, lockstep upgrade required), `with_persistence → Result` (with the don't-silently-ignore-`Corrupt` warning), the mutable-iterator removals (with the hash-safe `get_mut`/`with_mut` replacement guidance), the MSRV 1.85 note, and the planned Entry/State migration explicitly marked **planned, not yet landed** (policy record, not a landed change).

Self-reviewed line-by-line rather than agent-reviewed — the change is workflows + markdown with zero runtime code; the two factual imprecisions found in review (wrong replacement guidance for the removed iterators; the unlanded #143 break written as landed) are fixed in this commit.

Closes #204.

**Stack** — base: `claude/p1-5-ci-matrix` (#219). Merge after #219.

https://claude.ai/code/session_01BaajsC6gEk1v7Y55dA5cPG

---
_Generated by [Claude Code](https://claude.ai/code/session_01BaajsC6gEk1v7Y55dA5cPG)_