### PR TITLE
ci: finish master -> main migration

### DIFF
--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -86,7 +86,7 @@ jobs:
 
       # The point of this job is to verify the devcontainer image itself builds and
       # works, not to re-run the full suite — fmt, clippy and the complete test matrix
-      # already run (faster) in the `master` workflow's lint-and-test job. So we only
+      # already run (faster) in the `main` workflow's lint-and-test job. So we only
       # smoke the dev image: compile every target and run the fast lib unit tests.
       - name: Smoke-build inside devcontainer
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: master
+name: main
 
 on:
   push:

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -11,7 +11,7 @@
 >   architecture migration (one sub-issue per phase).
 
 - **Last updated:** 2026-06-09
-- **Baseline:** `master` @ `6462970` (steps 1+3, `Hlc`→`Timestamp` + `hlc`→`clock` renames); step 2 on
+- **Baseline:** `main` @ `6462970` (steps 1+3, `Hlc`→`Timestamp` + `hlc`→`clock` renames); step 2 on
   `claude/repo-cleanup-status-bcyjez`
 - **Manifest:** `0.0.0-git` (unpublished; API and wire/on-disk formats may still change)
 

--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@
 [crates-badge]: https://img.shields.io/crates/v/reconcile.svg
 [crates-url]: https://crates.io/crates/reconcile
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
-[mit-url]: https://github.com/Akvize/reconcile-rs/blob/master/LICENSE-MIT
+[mit-url]: https://github.com/Akvize/reconcile-rs/blob/main/LICENSE-MIT
 [apache-badge]: https://img.shields.io/badge/license-APACHE-blue.svg
-[apache-url]: https://github.com/Akvize/reconcile-rs/blob/master/LICENSE-APACHE
-[actions-badge]: https://github.com/Akvize/reconcile-rs/actions/workflows/master.yml/badge.svg
-[actions-url]: https://github.com/Akvize/reconcile-rs/actions/workflows/master.yml
-[codecov-badge]: https://codecov.io/gh/Akvize/reconcile-rs/branch/master/graph/badge.svg
+[apache-url]: https://github.com/Akvize/reconcile-rs/blob/main/LICENSE-APACHE
+[actions-badge]: https://github.com/Akvize/reconcile-rs/actions/workflows/main.yml/badge.svg
+[actions-url]: https://github.com/Akvize/reconcile-rs/actions/workflows/main.yml
+[codecov-badge]: https://codecov.io/gh/Akvize/reconcile-rs/branch/main/graph/badge.svg
 [codecov-url]: https://codecov.io/gh/Akvize/reconcile-rs
 [docs-badge]: https://docs.rs/reconcile/badge.svg
 [docs-url]: https://docs.rs/reconcile/latest/reconcile/


### PR DESCRIPTION
## What

Finishes the `master` -> `main` migration. The CI workflow already triggers on pushes to `main`, but the workflow file, its display name, and several docs/badge URLs still pointed at `master`. This addresses the **"Rename?"** review comment on #208 in a dedicated PR rather than folding it into the HLC clamp change.

## Changes

- **`.github/workflows/master.yml` -> `.github/workflows/main.yml`** (git rename), and `name: master` -> `name: main`.
- **`README.md`** badge/link URLs: `actions/workflows/master.yml` -> `main.yml`, `blob/master/...` -> `blob/main/...`, `branch/master/...` -> `branch/main/...`. (These fix the broken Build Status badge — it pointed at the non-`main`-triggered `master.yml` URL.)
- **`.github/workflows/devcontainer.yml`** comment referencing the `master` workflow.
- **`PROGRESS.md`** baseline branch reference.

## Left intentionally untouched

The `masterless` / `multi-master` occurrences in `src/lib.rs` and `SOTA.md` are domain terminology (IMDG architecture), not branch references.

https://claude.ai/code/session_01FBiXunQUTc3gA7R2tauVdF

---
_Generated by [Claude Code](https://claude.ai/code/session_01FBiXunQUTc3gA7R2tauVdF)_