### PR TITLE
ci: make CI workflows merge-queue compatible

### DIFF
--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: ["main"]
   pull_request:
+  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [ "main" ]
   pull_request:
+  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
## What

Adds the `merge_group` trigger to the CI workflows so they run on GitHub **merge-queue** events. A merge queue validates each PR against a temporary `merge_group` ref; if the required status checks don't trigger on `merge_group`, they never report there and enqueued PRs stall indefinitely.

## Changes

- **`main.yml`** (`lint-and-test`, `coverage`) — add `merge_group:`.
- **`devcontainer.yml`** (changes detector + gated build) — add `merge_group:` so its required check also reports on the queue. The existing "skip the heavy job when nothing devcontainer-related changed" path keeps queue runs cheap (a skipped job still counts as a passing required check).

## Left unchanged

- **`tags.yml`** — tag-push release only, not part of the merge queue.
- **Concurrency keys** — both already fall back to `github.ref`, which on a merge-queue run is the unique per-`merge_group` ref, so queued entries don't cancel each other.

## Notes

This is a one-sided addition to the `on:` block. The open stack PRs (incl. the CI-matrix PR #219) don't modify that block, so landing them won't regress merge-queue compatibility. After merge, enable the merge queue in branch-protection / rulesets for `main` and add `lint-and-test` (and `coverage` / the devcontainer checks, as desired) as required checks.

https://claude.ai/code/session_01FBiXunQUTc3gA7R2tauVdF

---
_Generated by [Claude Code](https://claude.ai/code/session_01FBiXunQUTc3gA7R2tauVdF)_