### PR TITLE
Update range-cmp dependency and use new RangeOrd trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1235,9 +1235,9 @@ dependencies = [
 
 [[package]]
 name = "range-cmp"
-version = "0.1.3"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94e0ac859e82d28e911b4d49359b981e05b37f6984fd37e524f29af7e7c0824c"
+checksum = "0fd4f752ea26d122ef8639262e5efb0428eff64ae2caf34a8e3a4d578f2f911a"
 
 [[package]]
 name = "rapidhash"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,7 @@ metrics-exporter-prometheus = { version = "0.16", optional = true, default-featu
 once_cell = "1.21.3"
 parking_lot = "0.12.1"
 rand = "0.8.5"
-range-cmp = "0.1.1"
+range-cmp = "1"
 serde = { version = "1.0.192", features = ["derive"] }
 sha2 = { version = "0.10", optional = true }
 # Sizes the gossip UDP socket's SO_RCVBUF / SO_SNDBUF (issue #169). Already in the tree as a

--- a/src/hrtree.rs
+++ b/src/hrtree.rs
@@ -31,7 +31,7 @@ use std::hash::Hash;
 use std::ops::{Bound, RangeBounds};
 
 use arrayvec::ArrayVec;
-use range_cmp::{RangeComparable, RangeOrdering};
+use range_cmp::{RangeOrd, RangeOrdering};
 use tracing::trace;
 
 use crate::fingerprint::{hash, Fingerprint};
@@ -632,10 +632,10 @@ impl<K: Hash + Ord, V: Hash> HRTree<K, V> {
 
             let mut cum_hash = Fingerprint::ZERO;
             let mut i = 0;
-            while i < node.keys.len() && node.keys[i].range_cmp(range) == RangeOrdering::Below {
+            while i < node.keys.len() && node.keys[i].rcmp(range) == RangeOrdering::Below {
                 i += 1;
             }
-            while i < node.keys.len() && node.keys[i].range_cmp(range) == RangeOrdering::Inside {
+            while i < node.keys.len() && node.keys[i].rcmp(range) == RangeOrdering::Inside {
                 let cur_bound = Some(&node.keys[i]);
                 if let Some(children) = node.children.as_ref() {
                     cum_hash += aux(&children[i], range, lower_bound, cur_bound);
@@ -765,7 +765,7 @@ impl<K: Ord, V> HRTree<K, V> {
         // traverse interior nodes
         'main_loop: while let Some(children) = node.children.as_ref() {
             for i in 0..node.keys.len() {
-                match node.keys[i].range_cmp(range) {
+                match node.keys[i].rcmp(range) {
                     RangeOrdering::Below => (),
                     RangeOrdering::Above => {
                         node = &children[i];
@@ -776,15 +776,16 @@ impl<K: Ord, V> HRTree<K, V> {
                         node = &children[i];
                         continue 'main_loop;
                     }
+                    RangeOrdering::Empty => break,
                 }
             }
             node = children.last().as_ref().unwrap();
         }
         // traverse leaf node
         for i in 0..node.keys.len() {
-            match node.keys[i].range_cmp(range) {
+            match node.keys[i].rcmp(range) {
                 RangeOrdering::Below => (),
-                RangeOrdering::Above => {
+                RangeOrdering::Above | RangeOrdering::Empty => {
                     break;
                 }
                 RangeOrdering::Inside => {


### PR DESCRIPTION
## Summary
This PR updates the `range-cmp` dependency to version 1 and refactors the code to use the new `RangeOrd` trait with its `rcmp()` method instead of the deprecated `RangeComparable` trait's `range_cmp()` method.

## Key Changes
- Updated `range-cmp` dependency from `0.1.1` to `1` in `Cargo.toml`
- Replaced import of `RangeComparable` with `RangeOrd` in `src/hrtree.rs`
- Renamed all method calls from `range_cmp()` to `rcmp()` throughout the codebase
- Added explicit handling for `RangeOrdering::Empty` variant in the range traversal logic:
  - Added `RangeOrdering::Empty => break` case in the interior node matching block
  - Combined `RangeOrdering::Above | RangeOrdering::Empty => break` in the leaf node matching block

## Implementation Details
The changes maintain the same logic flow while adapting to the new API. The addition of `RangeOrdering::Empty` handling ensures proper termination when encountering empty ranges during tree traversal, improving robustness of the range query implementation.

https://claude.ai/code/session_01B5eZfYBAzL5ZftVfKSxMPQ