### PR TITLE
fix(gc): re-ack held tombstones each round so causal stability converges at N≥3 (#216)

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,16 @@
+# Repository-local build configuration. This file is NOT packaged (it lives outside the crate's
+# published file set — verify with `cargo package --list`), so it never ships to consumers of the
+# published crate.
+#
+# It turns on the `reconcile_internal_testing` cfg for every build and test run IN THIS REPOSITORY.
+# That cfg gates the `reconcile::testing` seam (re-exports of `pub(crate)` reconciliation internals
+# in `src/lib.rs`) and the related test-only methods, so the external integration-test oracles
+# (`tests/diff.rs`, `tests/proptest_hrtree.rs`) and the benchmark can reach them — while downstream
+# consumers of the crate, who do not have this file and cannot set the cfg via a Cargo feature,
+# cannot.
+#
+# An env `RUSTFLAGS` / `RUSTDOCFLAGS` OVERRIDES these (it is not merged), so any CI step that sets
+# those env vars must append `--cfg reconcile_internal_testing` itself (see `.github/workflows`).
+[build]
+rustflags = ["--cfg", "reconcile_internal_testing"]
+rustdocflags = ["--cfg", "reconcile_internal_testing"]

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -54,8 +54,93 @@ jobs:
     - name: Check that the crate is publishable
       run: cargo publish --allow-dirty --dry-run
 
+  # Exercises the HMAC-SHA256 MAC backend, which is compiled out by --all-features
+  # (mac-blake3 takes precedence when both are enabled). Without this lane, a regression
+  # in HmacSha256Mac or any mac-hmac-gated code ships green.
+  mac-hmac:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Enable caching
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+        key: ${{ runner.os }}-cargo-hmac-${{ hashFiles('**/Cargo.lock') }}
+    - name: Build (mac-hmac, no default features)
+      run: cargo build --no-default-features --features mac-hmac --verbose
+    - name: Test (mac-hmac, no default features)
+      run: cargo test --no-default-features --features mac-hmac --verbose
+    - name: Test (mac-hmac + encryption)
+      run: cargo test --no-default-features --features mac-hmac,encryption --verbose
+
+  # Exercises the encryption feature together with the default (blake3) MAC backend.
+  # --all-features already covers this path in lint-and-test; this job makes it explicit
+  # and runs it independently so encryption regressions are easy to spot in CI.
+  encryption:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Enable caching
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+        key: ${{ runner.os }}-cargo-enc-${{ hashFiles('**/Cargo.lock') }}
+    - name: Test (mac-blake3 + encryption)
+      run: cargo test --features encryption --verbose
+
+  # macOS build + unit tests only. Integration tests (real UDP sockets, loopback
+  # routing, multi-thread tokio) are Linux-only for now: the loopback aliases
+  # (127.0.0.x/8) and socket-buffer sysctl tuning that the integration suite relies
+  # on behave differently on macOS, causing spurious port-in-use and bind failures on
+  # shared runners. Unit tests catch compiler regressions and platform-specific ABI
+  # issues without requiring OS-level network setup.
+  macos:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Enable caching
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+    - name: Build
+      run: cargo build --all --verbose
+    - name: Run unit tests (lib only)
+      run: cargo test --lib --all-features --verbose
+
+  # MSRV check: compile all targets against the declared minimum supported Rust version.
+  # Uses `cargo check` (not `cargo test`) to keep the job cheap: the borrow checker
+  # catches the language-level regressions that matter, without the cost of codegen or
+  # linking. A full test run on the MSRV toolchain would also require pinning every
+  # transitive dependency, which is out of scope here.
+  msrv:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install MSRV toolchain
+      uses: dtolnay/rust-toolchain@1.85
+    - name: Enable caching
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+        key: ${{ runner.os }}-cargo-msrv-${{ hashFiles('**/Cargo.lock') }}
+    - name: Check (MSRV, all targets, all features)
+      run: cargo check --all-targets --all-features
+
   coverage:
     runs-on: ubuntu-latest
+    env:
+      # llvm-cov instrumentation slows the test suite by 2-5×; scale the integration-test
+      # poll budgets accordingly so "convergence timed out" is not a spurious failure.
+      RECONCILE_TEST_TIME_MULTIPLIER: 3
     steps:
     - uses: actions/checkout@v3
     - name: Install llvm-tools-preview

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -112,11 +112,15 @@ jobs:
       run: cargo build --all --verbose
     - name: Add loopback aliases
       # macOS only configures 127.0.0.1 on lo0 (Linux routes all of 127/8); the
-      # engine/store unit tests bind distinct 127.0.0.x addresses to isolate their
-      # UDP sockets, so alias the range they use before running them.
+      # engine/store unit tests bind distinct 127.x addresses to isolate their UDP
+      # sockets, so alias them before running. The 127.0.0.x range is aliased densely;
+      # any other 127.x literal the tests use is extracted from the source so this stays
+      # correct as tests are added. `|| true` tolerates non-bindable literals (e.g. the
+      # 127.0.0.0/8 CIDR network address) without failing the step.
       run: |
-        for i in $(seq 2 254); do sudo ifconfig lo0 alias 127.0.0.$i up; done
-        sudo ifconfig lo0 alias 127.1.0.3 up
+        for i in $(seq 2 254); do sudo ifconfig lo0 alias 127.0.0.$i up || true; done
+        grep -rhoE '127(\.[0-9]+){3}' src/ | sort -u | grep -vE '^127\.0\.0\.' | \
+          while read -r addr; do sudo ifconfig lo0 alias "$addr" up || true; done
     - name: Run unit tests (lib only)
       run: cargo test --lib --all-features --verbose
 

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -11,8 +11,12 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
-  RUSTFLAGS: -Dwarnings
-  RUSTDOCFLAGS: -Dwarnings
+  # An env RUSTFLAGS/RUSTDOCFLAGS OVERRIDES (does not merge with) the rustflags in
+  # `.cargo/config.toml`, so we must re-add `--cfg reconcile_internal_testing` here or the
+  # testing-gated oracle/bench code would not compile in CI. This cfg gates the `reconcile::testing`
+  # seam; it is repo-only (not a published Cargo feature). See `.cargo/config.toml`.
+  RUSTFLAGS: -Dwarnings --cfg reconcile_internal_testing
+  RUSTDOCFLAGS: -Dwarnings --cfg reconcile_internal_testing
 
 jobs:
   lint-and-test:
@@ -28,25 +32,25 @@ jobs:
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
     - name: Format
       run: cargo fmt --check
-    # `--features internal-testing` exposes the `reconcile::testing` seam so the external
-    # integration-test oracles (`tests/diff.rs`, `tests/proptest_hrtree.rs`) and the benchmark,
-    # which reach now-`pub(crate)` reconciliation internals, still compile and run. The
-    # `--all-features` steps already cover it; the default steps make it explicit so the oracle
-    # always runs.
+    # The `reconcile::testing` seam (re-exports of now-`pub(crate)` reconciliation internals, reached
+    # by the integration-test oracles `tests/diff.rs` / `tests/proptest_hrtree.rs` and the benchmark)
+    # is gated on the `--cfg reconcile_internal_testing` flag, which the top-level RUSTFLAGS env sets
+    # for every step in this workflow (see the `env:` block). It is repo-only, not a published Cargo
+    # feature, so the seam never ships to consumers.
     - name: Lint
-      run: cargo clippy --all --features internal-testing
+      run: cargo clippy --all
     - name: Lint (all features)
       run: cargo clippy --all --all-features
     - name: Build
       run: cargo build --all --verbose
     - name: Run tests
-      run: cargo test --all --features internal-testing --verbose
+      run: cargo test --all --verbose
     - name: Run tests (all features)
       run: cargo test --all --all-features --verbose
     - name: Run doc-tests
-      run: cargo test --doc --all --features internal-testing --verbose
+      run: cargo test --doc --all --verbose
     - name: Check that the benchmarks can still compile
-      run: cargo bench --no-run --features internal-testing
+      run: cargo bench --no-run
     - name: Generate the documentation
       run: cargo doc --all --verbose
     - name: Generate the documentation (all features)

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -93,11 +93,10 @@ jobs:
       run: cargo test --features encryption --verbose
 
   # macOS build + unit tests only. Integration tests (real UDP sockets, loopback
-  # routing, multi-thread tokio) are Linux-only for now: the loopback aliases
-  # (127.0.0.x/8) and socket-buffer sysctl tuning that the integration suite relies
-  # on behave differently on macOS, causing spurious port-in-use and bind failures on
-  # shared runners. Unit tests catch compiler regressions and platform-specific ABI
-  # issues without requiring OS-level network setup.
+  # routing, multi-thread tokio) are Linux-only for now: the socket-buffer sysctl
+  # tuning and timing budgets the integration suite relies on behave differently on
+  # macOS shared runners. Unit tests (with the loopback aliases added below) catch
+  # compiler regressions and platform-specific socket/ABI issues.
   macos:
     runs-on: macos-latest
     steps:
@@ -111,6 +110,13 @@ jobs:
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
     - name: Build
       run: cargo build --all --verbose
+    - name: Add loopback aliases
+      # macOS only configures 127.0.0.1 on lo0 (Linux routes all of 127/8); the
+      # engine/store unit tests bind distinct 127.0.0.x addresses to isolate their
+      # UDP sockets, so alias the range they use before running them.
+      run: |
+        for i in $(seq 2 254); do sudo ifconfig lo0 alias 127.0.0.$i up; done
+        sudo ifconfig lo0 alias 127.1.0.3 up
     - name: Run unit tests (lib only)
       run: cargo test --lib --all-features --verbose
 

--- a/.github/workflows/tags.yml
+++ b/.github/workflows/tags.yml
@@ -1,5 +1,10 @@
 name: tags
 
+# Triggered by pushing a tag of the form vX.Y.Z (issue #204).
+# The repo uses manual version bumps: update Cargo.toml and Cargo.lock,
+# commit, then push the matching tag.  This workflow enforces the contract
+# by failing loudly when the tag and the manifest version disagree.
+
 on:
   push:
     tags: [ "v*" ]
@@ -17,12 +22,25 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - name: Set version
-        run: echo "VERSION=${GITHUB_REF##*\/v}" >> $GITHUB_ENV
       - uses: actions/checkout@v4
-      - name: Set Cargo.toml version
-        run: sed "s/0\\.0\\.0-git/$VERSION/" -i Cargo.toml Cargo.lock
+      - name: Verify tag matches Cargo.toml version
+        # Extract the version from the tag (strips the leading "v") and compare
+        # it against the version declared in Cargo.toml.  Fail loudly on any
+        # mismatch so a stale or wrong-version tag never silently republishes
+        # the wrong crate version.
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          CRATE_VERSION=$(cargo metadata --no-deps --format-version 1 | \
+            python3 -c "import sys,json; print(json.load(sys.stdin)['packages'][0]['version'])")
+          echo "Tag version:   $TAG_VERSION"
+          echo "Crate version: $CRATE_VERSION"
+          if [ "$TAG_VERSION" != "$CRATE_VERSION" ]; then
+            echo "ERROR: tag 'v${TAG_VERSION}' does not match Cargo.toml version '${CRATE_VERSION}'."
+            echo "Bump the version in Cargo.toml (and Cargo.lock) and commit before pushing the tag."
+            exit 1
+          fi
+          echo "VERSION=$CRATE_VERSION" >> "$GITHUB_ENV"
       - name: Login on crates repository
         run: echo ${{ secrets.CARGO_REGISTRY_TOKEN }} | cargo login
       - name: Publish crate
-        run: cargo publish --allow-dirty
+        run: cargo publish

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -8,8 +8,9 @@ instances. This document describes the **current architecture** and the **target
 [`PROGRESS.md`](./PROGRESS.md) and are assumed here as the baseline; the state-of-the-art
 positioning is in [`SOTA.md`](./SOTA.md).
 
-The crate is unpublished (`0.0.0-git`); the public API and the on-wire / on-disk formats are not yet
-stable and may change. Code locations are given as `file:line` against the current tree.
+The crate is published on crates.io as `reconcile` **0.2.1**. The public API and the on-wire /
+on-disk formats are not yet stable — breaking changes ride a minor-version bump (next: 0.3.0,
+see `CHANGELOG.md`). Code locations are given as `file:line` against the current tree.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,113 @@
+# Changelog
+
+All notable changes to `reconcile` are documented here.
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
+versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+**MSRV policy:** an MSRV bump is a *minor* version increment (e.g. 0.2 → 0.3).
+Patch releases never raise the MSRV.
+
+---
+
+## [Unreleased] — 0.3.0
+
+**This release contains multiple breaking changes that require coordinated
+upgrades across the cluster.  Nodes running 0.2.x and 0.3.0 simultaneously
+will not interoperate correctly.**
+
+### Breaking — wire format (authenticated mode, anti-replay)
+
+The authenticated-mode wire format now includes a per-datagram anti-replay
+header (issue #199).  All nodes in a cluster **must** be upgraded to 0.3.0 in
+lockstep; a 0.2.x node will reject 0.3.0 datagrams (and vice versa) because the
+MAC covers the new header field.  Rolling upgrades are not safe — quiesce the
+cluster, upgrade all nodes, then restart.
+
+### Breaking — `with_persistence` now returns `Result`
+
+`ReconcileStore::with_persistence` (previously infallible) now returns
+`Result<ReconcileStore<K, V>, LoadError>`.  Call sites must handle the error;
+`LoadError::Corrupt` **must not** be silently ignored (doing so drops tombstones
+and re-enables the resurrection hazard of issue #109).  See the updated
+`README.md` Persistence section for the recommended error-handling pattern.
+
+### Breaking — public API removals (fingerprint-unsafe mutable iterators)
+
+The mutable iterator types that allowed in-place value mutation without
+updating the range fingerprint have been removed from the public API
+(issue #197): `IterMut`, `ValuesMut`, `HRTree::iter_mut()`, `HRTree::values_mut()`.
+Any mutation through them silently desynced the fingerprints replicas compare.
+Replace call sites with the hash-safe mutation path —
+`ReconcileStore::get_mut` (or `HRTree::with_mut`) — which recomputes the
+fingerprint on every edit.
+
+### Breaking (planned, not yet landed) — wire and on-disk format (`Entry` / `State` migration, issue #143)
+
+The `Entry<Timestamp, V>` / `State<V>` domain-type migration (architecture step 4,
+`ARCHITECTURE.md` §6) will replace the internal `(Timestamp, Option<V>)` tuple,
+changing both the gossip wire format and the `FileSnapshot` on-disk format.
+If it lands in time it rides this release (one coordinated break beats two);
+**existing snapshots will not be forward-compatible** — pre-break snapshots must
+be rejected cleanly via `LoadError::Corrupt` with a descriptive message rather
+than silently misinterpreted.  Tracked in issue #143; this entry is the policy
+record, not a landed change.
+
+### Changed — MSRV raised to 1.85
+
+The minimum supported Rust version is **1.85** (declared in `Cargo.toml`
+`rust-version`; enforced by the `msrv` CI job).  Per policy this is a minor bump.
+
+---
+
+## [0.2.1] — 2026-05
+
+### Added
+- Per-datagram payload confidentiality via XChaCha20-Poly1305 AEAD
+  (`encryption` Cargo feature, issue #96 / PR #131).
+- Lightweight dateless read-only mirror `ReconcileMirror` — converges with a
+  dated cluster over the same UDP port without keeping per-value timestamps
+  (issue #128 / PR #133).
+- Runtime observability: `tracing` spans across the engine, network, and
+  reconciliation paths; `metrics` facade (opt-in) with optional Prometheus
+  endpoint (`metrics-prometheus` feature, issue #94 / PR #130).
+- DNS-based peer discovery (`DnsDiscovery`) for Kubernetes headless Services:
+  no RBAC, no API access, correct tombstone-GC semantics (issue #147).
+- Multi-location (multi-CIDR) geography-aware gossip with bounded WAN fan-out
+  and decentralised topology; live reconfiguration via `set_nets` / `add_net` /
+  `remove_net` / `set_remote_interval` / `set_remote_fanout` / … (issue #53).
+- Pluggable `Persistence` trait with `InMemory` and `FileSnapshot` backends;
+  chunked fuzzy snapshots, directory fsync, tmp-file hygiene, configurable
+  cadence and change threshold (issue #122 / PR #202-area).
+- Fallible constructors (`ReconcileStore::new` returns `io::Result`; `LoadError`
+  distinguishes corrupt snapshots from transient I/O — issue #148).
+- Per-peer bounded state with configurable `max_peers` cap.
+- Wall-time floor guard: decommissions peers whose tombstone acks are pending
+  but the peer has been absent past the tombstone timeout (discovery grace
+  period, issue #201-area).
+- HLC restart monotonicity: the clock is seeded from the persisted snapshot on
+  startup so the HLC total order is never violated across restarts (issue #195).
+- `TimeoutWheel` same-millisecond expiry correctness fix (issue #196).
+- HLC far-future stamp and counter-wrap hardening (issue #198).
+- Anti-replay per-peer sequence tracking (foundation, issue #199-area).
+- Feature-matrix CI: dedicated `mac-hmac`, `encryption`, and `macos` jobs;
+  scalable poll budget via `RECONCILE_TEST_TIME_MULTIPLIER` (issue #203).
+- MSRV declared as `rust-version = "1.85"` in `Cargo.toml`; MSRV CI job
+  (`dtolnay/rust-toolchain@1.85`, issue #189).
+- `cargo publish --dry-run` in the `lint-and-test` CI job (issue #204).
+
+### Fixed
+- Fingerprint-desyncing mutable iterators removed from public API (issue #197).
+- `pre_insert` hook now runs outside the write lock on both the local and
+  network paths, with a regression test (issue #149 / commit `f4b5028`).
+- Removed debug `println!` from the hot reconciliation path (issue #113).
+- `DefaultHasher` replaced on the wire: fingerprints are now 256-bit additive
+  BLAKE3 (issue #111).
+- Malformed-packet panics hardened: crafted `HashSegment` / inverted ranges /
+  missing bounds are rejected before deserialisation (issues #107, #112).
+- Tombstone resurrection closed: GC is now gated on causal stability — a
+  tombstone is only collected once every monotonic cluster member has
+  acknowledged its exact version hash (issue #109).
+- HLC conflict resolution replaces unsafe physical-clock LWW (issue #110).
+
+[Unreleased]: https://github.com/Akvize/reconcile-rs/compare/v0.2.1...HEAD
+[0.2.1]: https://github.com/Akvize/reconcile-rs/releases/tag/v0.2.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,27 @@ release alongside the anti-replay change above. Concretely:
   being silently misinterpreted (which would drop tombstones and re-enable the
   resurrection hazard of issue #109).
 
+### Added — `Transport` and `Codec` ports (hexagonal I/O boundary, issue #144)
+
+The reconciliation engine no longer calls `tokio::net` or `bincode` directly: it
+drives its datagram I/O and wire encoding through two new public ports
+(architecture step 5, `ARCHITECTURE.md` §3.4). **No wire-format change** — the
+frozen bincode `DefaultOptions` config and `Message` tag order are preserved.
+
+- `Transport` port + `UdpTransport` adapter (`reconcile::{Transport, UdpTransport}`):
+  datagram send/recv/local-addr over `Addr = SocketAddr`. `UdpTransport::bind`
+  owns the socket bind and `SO_RCVBUF` / `SO_SNDBUF` sizing.
+- `Codec` port + `BincodeCodec` adapter (`reconcile::{Codec, BincodeCodec}`):
+  `encode` to a buffer and `decode_stream` with a `max_items` cap that bounds the
+  datagram-expansion DoS (issue #151).
+- Authentication stays **ahead of** the codec: the MAC is verified on raw bytes
+  before any decode (invariant #5) — the `Codec` never absorbs authentication.
+- The engine is generic over the codec (default `BincodeCodec`) and holds the
+  transport as `Arc<dyn Transport<Addr = SocketAddr>>`, so an in-memory transport
+  makes convergence testable with no real sockets (a deterministic convergence
+  proptest now runs over it). New dependency: `async-trait` (for the `Transport`
+  port) and tokio's `sync` feature (for the in-memory test transport).
+
 ### Changed — MSRV raised to 1.85
 
 The minimum supported Rust version is **1.85** (declared in `Cargo.toml`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,16 +41,31 @@ Replace call sites with the hash-safe mutation path —
 `ReconcileStore::get_mut` (or `HRTree::with_mut`) — which recomputes the
 fingerprint on every edit.
 
-### Breaking (planned, not yet landed) — wire and on-disk format (`Entry` / `State` migration, issue #143)
+### Breaking — wire and on-disk format (`Entry` / `State` domain type, issue #143)
 
-The `Entry<Timestamp, V>` / `State<V>` domain-type migration (architecture step 4,
-`ARCHITECTURE.md` §6) will replace the internal `(Timestamp, Option<V>)` tuple,
-changing both the gossip wire format and the `FileSnapshot` on-disk format.
-If it lands in time it rides this release (one coordinated break beats two);
-**existing snapshots will not be forward-compatible** — pre-break snapshots must
-be rejected cleanly via `LoadError::Corrupt` with a descriptive message rather
-than silently misinterpreted.  Tracked in issue #143; this entry is the policy
-record, not a landed change.
+The internal `(Timestamp, Option<V>)` tuple is replaced by an intention-revealing
+`Entry<Timestamp, V>` cell with a `State<V>` (`Present(V)` / `Tombstone`) payload
+(architecture step 4, `ARCHITECTURE.md` §6). This **changes both the gossip wire
+format and the `FileSnapshot` on-disk format** — a coordinated break riding this
+release alongside the anti-replay change above. Concretely:
+
+- The value-shape helper traits `Reconcilable`, `MaybeTombstone` (`reconcilable.rs`)
+  and `Timestamped` (`clock.rs`) are removed; their behaviour is now inherent on
+  `Entry` (`is_tombstone` / `value` / `merge`, the last carrying the LWW policy)
+  and plain `stamp` field access.
+- `Projectable` / `ValueOnly<V>` are dissolved: the dateless mirror's value-only
+  projection **is** `State<V>` (`Entry::project` → `State<V>`), so the dated store
+  and the dateless `ReconcileMirror` share one domain type. `State`'s `Hash` stays
+  timestamp-less (invariant #8); `Entry`'s covers the stamp (invariant #7).
+- The public pre-insert hook `ReconcileStore::add_pre_insert` now takes
+  `&Entry<Timestamp, V>` (was `&(Timestamp, Option<V>)`), and `PersistedState` /
+  `DatedEntries` carry `Entry<Timestamp, V>`.
+- `reconcile::{Entry, State}` are now exported (replacing `Projectable` / `ValueOnly`).
+- `FileSnapshot` now writes a versioned header (`RCNL` magic + `u32` format version).
+  **Existing (0.2.x, header-less) snapshots are not forward-compatible** and are
+  rejected cleanly with `LoadError::Corrupt` and a descriptive message rather than
+  being silently misinterpreted (which would drop tombstones and re-enable the
+  resurrection hazard of issue #109).
 
 ### Changed — MSRV raised to 1.85
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,16 +77,47 @@ frozen bincode `DefaultOptions` config and `Message` tag order are preserved.
 - `Transport` port + `UdpTransport` adapter (`reconcile::{Transport, UdpTransport}`):
   datagram send/recv/local-addr over `Addr = SocketAddr`. `UdpTransport::bind`
   owns the socket bind and `SO_RCVBUF` / `SO_SNDBUF` sizing.
-- `Codec` port + `BincodeCodec` adapter (`reconcile::{Codec, BincodeCodec}`):
-  `encode` to a buffer and `decode_stream` with a `max_items` cap that bounds the
-  datagram-expansion DoS (issue #151).
+- `Codec` port + `BincodeCodec` adapter, both **internal** (`pub(crate)`): it has
+  generic methods, so it is not object-safe and is carried as a type parameter.
+  `decode_stream` takes a `max_items` cap that bounds the datagram-expansion DoS
+  (issue #151). See `ARCHITECTURE.md` §7 D2 for why this port is not exposed while
+  `Transport` is.
 - Authentication stays **ahead of** the codec: the MAC is verified on raw bytes
   before any decode (invariant #5) — the `Codec` never absorbs authentication.
 - The engine is generic over the codec (default `BincodeCodec`) and holds the
-  transport as `Arc<dyn Transport<Addr = SocketAddr>>`, so an in-memory transport
-  makes convergence testable with no real sockets (a deterministic convergence
-  proptest now runs over it). New dependency: `async-trait` (for the `Transport`
-  port) and tokio's `sync` feature (for the in-memory test transport).
+  transport as `Arc<dyn Transport<Addr = SocketAddr>>`. New dependency:
+  `async-trait` (for the `Transport` port) and tokio's `sync` feature.
+
+### Added — `ReconcileStore::new_with_transport` and the in-memory transport
+
+`Transport` is now consumer-wireable (`ARCHITECTURE.md` §7 D2). The new
+constructor takes any `Arc<dyn Transport<Addr = SocketAddr>>` and is **infallible**
+— the only fallible step in `new` is binding the socket, which the caller has
+already done. `InMemoryNetwork` / `InMemoryTransport` are no longer test-gated, so
+downstream crates can drive a deterministic in-process cluster in their own tests.
+
+`Clock` deliberately stays test-only: the protocol already assumes datagrams may be
+lost, duplicated or reordered, so an unreliable transport cannot break an invariant,
+whereas a non-monotonic clock silently breaks the causal ordering tombstone
+collection depends on.
+
+### Added — `ReconcileStore::node_id()`
+
+Reads back the Hybrid-Logical-Clock identity that `Config::with_node_id` sets
+(`ARCHITECTURE.md` §7 D4). Sourced from the clock adapter through the new
+`Clock::node_id`, so it can never disagree with the id actually stamped onto minted
+timestamps. **Breaking for anyone implementing `Clock` by hand** — the trait gains
+one required method.
+
+### Breaking — `Value` no longer requires `PartialEq`
+
+The `Value` bound bundle drops `PartialEq` (`ARCHITECTURE.md` §7 D5). This *relaxes*
+the bound, so no existing `V` stops compiling; it is listed as breaking only because
+`Value` is a public trait whose definition changed. The single site that used it —
+post-merge change detection on the receive path — now compares stamps, which is
+provably equivalent under last-write-wins and avoids cloning the value on a hot
+path. `ReconcileMirror` consequently uses the `Value` bundle directly instead of
+spelling out its own bound set.
 
 ### Changed — MSRV raised to 1.85
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,6 +120,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "async-trait"
+version = "0.1.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -346,7 +357,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1282,6 +1293,7 @@ name = "reconcile"
 version = "0.2.1"
 dependencies = [
  "arrayvec",
+ "async-trait",
  "bincode",
  "blake3",
  "chacha20poly1305",
@@ -1421,7 +1433,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1514,6 +1526,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1543,7 +1566,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1590,7 +1613,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1631,7 +1654,7 @@ checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1786,7 +1809,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
  "wasm-bindgen-shared",
 ]
 
@@ -1808,7 +1831,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1884,7 +1907,7 @@ checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1895,7 +1918,7 @@ checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -2027,7 +2050,7 @@ checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -2047,5 +2070,5 @@ checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "reconcile"
 version = "0.2.1"
 edition = "2021"
+rust-version = "1.85"
 license = "MIT OR Apache-2.0"
 description = "A reconciliation storage service to sync a key-value map over multiple instances"
 repository = "https://github.com/Akvize/reconcile-rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,10 @@ exclude = [
     "ARCHITECTURE.md",
     "SOTA.md",
     "PROGRESS.md",
+    # MUST NOT ship: it sets `--cfg reconcile_internal_testing`, which gates the test-only
+    # `reconcile::testing` seam. Packaging it would let that cfg leak into a consumer's build of the
+    # crate, re-exposing internals the move off the Cargo feature was meant to hide.
+    ".cargo/",
 ]
 
 [profile.release]
@@ -54,15 +58,24 @@ metrics-prometheus = ["metrics", "dep:metrics-exporter-prometheus"]
 # TTL/ndots control, robust resolution in static/musl images). Not implemented yet: the default
 # `DnsDiscovery` uses the system resolver via `tokio::net::lookup_host` and needs no extra crate.
 dns-hickory = []
-# Exposes the `crate::testing` seam (re-exports of `pub(crate)` reconciliation internals) so the
-# external integration-test oracles (`tests/diff.rs`, `tests/proptest_hrtree.rs`) can reach them.
-# No deps; not part of the supported public API.
-internal-testing = []
+# NOTE: the `crate::testing` seam (re-exports of `pub(crate)` reconciliation internals, used by the
+# external integration-test oracles `tests/diff.rs` / `tests/proptest_hrtree.rs` and the benchmark)
+# is gated on the `--cfg reconcile_internal_testing` build flag, NOT a Cargo feature. A feature on a
+# published crate is reachable by any downstream consumer; the cfg flag is set only by this repo's
+# `.cargo/config.toml` (which is not packaged), so the seam never ships to consumers. See the
+# `[lints.rust]` table below, which declares the cfg so `unexpected_cfgs` stays quiet.
+
+[lints.rust]
+# Declare the `reconcile_internal_testing` cfg (set by `.cargo/config.toml` for this repo's own
+# builds/tests) so that `#[cfg(reconcile_internal_testing)]` does not trip the `unexpected_cfgs`
+# lint under clippy `-D warnings`. check-cfg is stable since Rust 1.80; our MSRV is 1.85.
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(reconcile_internal_testing)'] }
 
 # The turnkey Kubernetes example. It is a multi-file example (`examples/k8s/main.rs`), so its
-# target is named after the directory: `cargo run --example k8s`. The metrics/readiness endpoint
-# (the Kubernetes probes target `/metrics`) is built in via the feature below. The rest of
-# `examples/k8s/` (manifests, kind playground, Dockerfile) is deployment scaffolding.
+# target is named after the directory: `cargo run --example k8s`. The metrics endpoint (the kubelet
+# liveness probe and Prometheus scrape) and the separate readiness endpoint are built in via the
+# feature below. The rest of `examples/k8s/` (manifests, kind playground, Dockerfile) is deployment
+# scaffolding.
 [[example]]
 name = "k8s"
 path = "examples/k8s/main.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,6 +83,7 @@ required-features = ["metrics-prometheus"]
 
 [dependencies]
 arrayvec = "0.7.4"
+async-trait = "0.1"
 bincode = "1.3.3"
 blake3 = "1.5"
 chacha20poly1305 = { version = "0.10", optional = true }
@@ -100,7 +101,7 @@ sha2 = { version = "0.10", optional = true }
 # Sizes the gossip UDP socket's SO_RCVBUF / SO_SNDBUF (issue #169). Already in the tree as a
 # transitive dependency of tokio, so this is essentially free.
 socket2 = "0.5"
-tokio = { version = "1.33.0", features = ["net", "time", "rt", "macros"] }
+tokio = { version = "1.33.0", features = ["net", "time", "rt", "macros", "sync"] }
 tracing = "0.1.40"
 zeroize = { version = "1.7", optional = true, features = ["derive"] }
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -10,9 +10,11 @@
 > - **Issue [#138](https://github.com/Akvize/reconcile-rs/issues/138)** — execution tracking of the
 >   architecture migration (one sub-issue per phase).
 
-- **Last updated:** 2026-06-12
-- **Baseline:** `claude/determined-franklin-s3tvt1` @ `f1423ce` (2026-06 correctness sprint; pending
-  merge to master)
+- **Last updated:** 2026-06-13
+- **Baseline:** `claude/p1-5-ci-matrix` @ `32193cc` (CI hardening: feature-matrix + macOS + MSRV
+  lanes; scalable test time budget; MSRV declaration — see issues
+  [#203](https://github.com/Akvize/reconcile-rs/issues/203) and
+  [#189](https://github.com/Akvize/reconcile-rs/issues/189))
 - **Manifest:** `0.2.1` (unpublished; semver and publish policy tracked in
   [#204](https://github.com/Akvize/reconcile-rs/issues/204))
 
@@ -81,8 +83,9 @@ all but one High resolved or mitigated.
 - [ ] Semver and publish policy — `0.2.1` exists but policy is not yet settled ([#204](https://github.com/Akvize/reconcile-rs/issues/204))
 - [ ] `CHANGELOG.md`
 - [x] CI code coverage + doc-tests ([#97](https://github.com/Akvize/reconcile-rs/issues/97)) — Codecov (`cargo llvm-cov`) + `cargo test --doc` in CI
+- [x] Feature-matrix CI — dedicated `mac-hmac`, `encryption`, and `macos` jobs; scalable poll budget via `RECONCILE_TEST_TIME_MULTIPLIER` ([#203](https://github.com/Akvize/reconcile-rs/issues/203))
 - [ ] `cargo audit` / `cargo deny` in CI ([#151](https://github.com/Akvize/reconcile-rs/issues/151))
-- [ ] Declare + CI-pin MSRV (`rust-version`) — iterators are safe Rust (crate is `#![forbid(unsafe_code)]`); miri item dropped ([#189](https://github.com/Akvize/reconcile-rs/issues/189))
+- [x] Declare + CI-pin MSRV (`rust-version = "1.85"`) — iterators are safe Rust (crate is `#![forbid(unsafe_code)]`); miri item dropped ([#189](https://github.com/Akvize/reconcile-rs/issues/189))
 - [ ] `overflow-checks = true` in the release profile ([#151](https://github.com/Akvize/reconcile-rs/issues/151))
 - [ ] bincode decode limit (`with_limit`) against allocation bombs ([#150](https://github.com/Akvize/reconcile-rs/issues/150), [#151](https://github.com/Akvize/reconcile-rs/issues/151))
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -15,8 +15,9 @@
   lanes; scalable test time budget; MSRV declaration — see issues
   [#203](https://github.com/Akvize/reconcile-rs/issues/203) and
   [#189](https://github.com/Akvize/reconcile-rs/issues/189))
-- **Manifest:** `0.2.1` (unpublished; semver and publish policy tracked in
-  [#204](https://github.com/Akvize/reconcile-rs/issues/204))
+- **Manifest:** `0.2.1` (published on crates.io; release pipeline and semver policy fixed by
+  [#204](https://github.com/Akvize/reconcile-rs/issues/204); breaking changes ride 0.3.0 — see
+  `CHANGELOG.md`)
 
 ---
 
@@ -80,8 +81,9 @@ all but one High resolved or mitigated.
 - [x] Malformed-packet fuzz harness (`fuzz_packets.rs`)
 - [x] Security model documented (README "Security model")
 - [x] Pluggable persistence documented (README "Persistence")
-- [ ] Semver and publish policy — `0.2.1` exists but policy is not yet settled ([#204](https://github.com/Akvize/reconcile-rs/issues/204))
-- [ ] `CHANGELOG.md`
+- [x] Semver and publish policy — release pipeline restored (tag-version verification); 0.3.0 break
+  policy documented in `CHANGELOG.md` ([#204](https://github.com/Akvize/reconcile-rs/issues/204))
+- [x] `CHANGELOG.md` — seeded with 0.2.1 baseline and Unreleased (0.3.0) section
 - [x] CI code coverage + doc-tests ([#97](https://github.com/Akvize/reconcile-rs/issues/97)) — Codecov (`cargo llvm-cov`) + `cargo test --doc` in CI
 - [x] Feature-matrix CI — dedicated `mac-hmac`, `encryption`, and `macos` jobs; scalable poll budget via `RECONCILE_TEST_TIME_MULTIPLIER` ([#203](https://github.com/Akvize/reconcile-rs/issues/203))
 - [ ] `cargo audit` / `cargo deny` in CI ([#151](https://github.com/Akvize/reconcile-rs/issues/151))

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -10,14 +10,14 @@
 > - **Issue [#138](https://github.com/Akvize/reconcile-rs/issues/138)** — execution tracking of the
 >   architecture migration (one sub-issue per phase).
 
-- **Last updated:** 2026-06-13
-- **Baseline:** `claude/p1-5-ci-matrix` @ `32193cc` (CI hardening: feature-matrix + macOS + MSRV
-  lanes; scalable test time budget; MSRV declaration — see issues
-  [#203](https://github.com/Akvize/reconcile-rs/issues/203) and
-  [#189](https://github.com/Akvize/reconcile-rs/issues/189))
-- **Manifest:** `0.2.1` (published on crates.io; release pipeline and semver policy fixed by
-  [#204](https://github.com/Akvize/reconcile-rs/issues/204); breaking changes ride 0.3.0 — see
-  `CHANGELOG.md`)
+- **Last updated:** 2026-07-30
+- **Baseline:** `claude/priority-issues-review-2lu5e9`, stacked on the full Phase-1 stack
+  (`claude/p1-7-hygiene`, pending merge to main). Carries the
+  [#216](https://github.com/Akvize/reconcile-rs/issues/216) tombstone-GC convergence fix and the
+  Phase-2 architecture step 4 — the [#143](https://github.com/Akvize/reconcile-rs/issues/143)
+  `Entry` / `State` domain type (wire + on-disk format break).
+- **Manifest:** `0.2.1` (unpublished; breaking changes ride 0.3.0 — see `CHANGELOG.md`; semver and
+  publish policy tracked in [#204](https://github.com/Akvize/reconcile-rs/issues/204))
 
 ---
 
@@ -35,7 +35,9 @@ findings ([#195](https://github.com/Akvize/reconcile-rs/issues/195),
 [#196](https://github.com/Akvize/reconcile-rs/issues/196),
 [#197](https://github.com/Akvize/reconcile-rs/issues/197),
 [#198](https://github.com/Akvize/reconcile-rs/issues/198)) plus
-[#148](https://github.com/Akvize/reconcile-rs/issues/148) are **fixed on this branch**; remaining
+[#148](https://github.com/Akvize/reconcile-rs/issues/148) are **fixed on this branch**, as is the
+[#216](https://github.com/Akvize/reconcile-rs/issues/216) tombstone-GC convergence bug (causal
+stability was unreachable in clusters of three or more nodes); remaining
 audit findings ([#199](https://github.com/Akvize/reconcile-rs/issues/199)–[#205](https://github.com/Akvize/reconcile-rs/issues/205))
 are **security/robustness-grade**, scheduled per [#206](https://github.com/Akvize/reconcile-rs/issues/206).
 Remaining work is **maturity, scaling, and the confidentiality roadmap**.
@@ -134,7 +136,11 @@ HLC restart monotonicity ([#195](https://github.com/Akvize/reconcile-rs/issues/1
 same-millisecond expiry collision ([#196](https://github.com/Akvize/reconcile-rs/issues/196)),
 fingerprint-desyncing mutable iterators ([#197](https://github.com/Akvize/reconcile-rs/issues/197)),
 and HLC far-future stamp / counter wrap ([#198](https://github.com/Akvize/reconcile-rs/issues/198))
-— are fixed on this branch; the remainder
+— are fixed on this branch, together with the tombstone-GC convergence bug
+([#216](https://github.com/Akvize/reconcile-rs/issues/216), found during the
+[#215](https://github.com/Akvize/reconcile-rs/issues/215) review: causal stability was unreachable
+at three or more nodes because tombstone acks were pairwise and non-transitive — now every node
+re-acknowledges the tombstones it holds on each reconciliation round); the remainder
 ([#199](https://github.com/Akvize/reconcile-rs/issues/199) replay/membership poisoning,
 [#200](https://github.com/Akvize/reconcile-rs/issues/200) unbounded acks/bulk dumps,
 [#201](https://github.com/Akvize/reconcile-rs/issues/201) DNS decommission vs GC gate,

--- a/README.md
+++ b/README.md
@@ -511,6 +511,15 @@ changes from 10 to 1,000,000 elements.
 **Note:** These benchmarks are performed locally on the loop-back network
 interface. On a real network, transmission delays will make the values larger.
 
+## Minimum Supported Rust Version (MSRV)
+
+The crate requires **Rust 1.85** or later (`rust-version = "1.85"` in `Cargo.toml`).
+This is enforced by a dedicated CI job that runs `cargo check` against that toolchain on
+every push.
+
+**Policy:** an MSRV bump is treated as a **minor version increment** (e.g. 0.2 → 0.3) and
+documented in `CHANGELOG.md`. Patch releases never raise the MSRV.
+
 ## Testing and coverage
 
 The crate is covered by unit, integration, property-based and documentation
@@ -533,4 +542,6 @@ cargo llvm-cov --workspace --html     # browsable HTML report under target/llvm-
 ```
 
 Coverage is collected with the crate's default features. The `mac-blake3` and
-`mac-hmac` backends are mutually exclusive, so do **not** pass `--all-features`.
+`mac-hmac` backends are mutually exclusive at build time (`mac-blake3` takes precedence
+when both are enabled), so a separate CI job (`mac-hmac`) exercises the HMAC-SHA256
+backend with `--no-default-features --features mac-hmac`.

--- a/README.md
+++ b/README.md
@@ -89,7 +89,19 @@ performance limitations.
 > poison propagates to the whole cluster through last-write-wins. UDP source addresses are
 > spoofable, so this is anonymous.
 
-To close this vector, provide a shared 32-byte cluster secret on **every** node:
+> **Keyless mode also leaks the whole dataset.** The default `RandomProbe` discovery answers any
+> host inside a configured CIDR, and anti-entropy then serves it whatever it is missing. A stranger
+> that squats (or spoofs) one IP in the range eventually receives the **entire dataset** through the
+> paced bulk diff dumps — no key, no per-peer identity stops it. Keyless mode is therefore safe only
+> on a fully trusted network underlay.
+
+Keyless is the out-of-the-box default. If you deliberately run keyless on a trusted underlay,
+acknowledge it with `Config::default().with_insecure_no_key()` — this changes nothing about the
+protocol but downgrades the loud startup `SECURITY` warning to a single acknowledged line, so a
+deliberate deployment is not nagged on every restart.
+
+To close both vectors (forged writes *and* the read leak), provide a shared 32-byte cluster secret
+on **every** node:
 
 ```rust,ignore
 let key: [u8; 32] = /* same secret on all nodes, e.g. loaded from your secret manager */;
@@ -204,7 +216,8 @@ stays lean:
 
 ```rust,ignore
 # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-// Serve a /metrics HTTP endpoint (requires a Tokio runtime):
+// Serve a /metrics HTTP endpoint (requires a Tokio runtime). `0.0.0.0` listens on every
+// interface — see the exposure caveat below; prefer a trusted interface in production:
 reconcile::prometheus::serve("0.0.0.0:9000".parse()?).await?;
 
 // ...or install the recorder and render the text yourself through your own HTTP server:
@@ -217,6 +230,13 @@ let body: String = handle.render();
 
 Enable with `cargo build --features metrics-prometheus` (or list `metrics`/`metrics-prometheus`
 in your dependency's `features`).
+
+> **Exposure caveat.** The `/metrics` endpoint is _unauthenticated_ and leaks operational
+> information (dataset size and churn, byte/datagram counters, peer and reconciliation activity)
+> that an observer can use to fingerprint your deployment. Binding `0.0.0.0:9000`, as the examples
+> do for convenience, listens on **every** interface. In production, bind it to `127.0.0.1` (or a
+> trusted management interface) and/or restrict access with a firewall or a Kubernetes
+> `NetworkPolicy`. Do not expose it on an untrusted network.
 
 ## Operational tuning
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ the cluster as an empty replica.
 
 In code, this would look like this:
 
-```rust
+```rust,ignore
 let mut store = ReconcileStore::new(Config::default()).await.unwrap();
 tokio::spawn(store.clone().run());
 // use the reconciliation store as a key-value store in the API
@@ -91,7 +91,7 @@ performance limitations.
 
 To close this vector, provide a shared 32-byte cluster secret on **every** node:
 
-```rust
+```rust,ignore
 let key: [u8; 32] = /* same secret on all nodes, e.g. loaded from your secret manager */;
 let config = Config::default().with_cluster_key(key);
 let store = ReconcileStore::new(config).await.unwrap();
@@ -114,7 +114,7 @@ feature, `Config::with_encryption()` upgrades it to authenticated **encryption**
 framed as `nonce || ciphertext || tag` with [XChaCha20-Poly1305] over the same 32-byte cluster key,
 and is decrypted-and-verified before deserialization.
 
-```rust
+```rust,ignore
 // requires the `encryption` feature
 let config = Config::default().with_cluster_key(key).with_encryption();
 ```
@@ -151,15 +151,34 @@ tombstones, and the issue-#109 causal-stability bookkeeping (membership and per-
 acknowledgments) — is reloaded **before** the node rejoins the gossip protocol, so a restart does
 not look like a fresh, empty replica:
 
-```rust
+```rust,no_run
 use std::sync::Arc;
-use reconcile::{reconcile_store::Config, FileSnapshot, ReconcileStore};
+use reconcile::{reconcile_store::Config, FileSnapshot, LoadError, ReconcileStore};
 
-let store = ReconcileStore::new(Config::default())
-    .await
-    .unwrap()
-    .with_persistence(Arc::new(FileSnapshot::new("/var/lib/myapp/reconcile.snapshot")));
-tokio::spawn(store.clone().run()); // periodically snapshots in the background
+async fn start() -> Result<(), Box<dyn std::error::Error>> {
+    let store = ReconcileStore::<String, String>::new(Config::default())
+        .await?
+        .with_persistence(Arc::new(FileSnapshot::new("/var/lib/myapp/reconcile.snapshot")));
+
+    let store = match store {
+        Ok(s) => s,
+        Err(LoadError::Corrupt(msg)) => {
+            // The snapshot file exists but could not be decoded.
+            // Do NOT silently start empty: that drops tombstones and enables resurrection
+            // of previously deleted values. Alert an operator and halt; if data loss is
+            // acceptable, delete the snapshot file and restart.
+            return Err(format!("snapshot corrupt, operator action required: {msg}").into());
+        }
+        Err(LoadError::Io(err)) => {
+            // Transient I/O failure (e.g. volume still mounting). Retry after a short
+            // delay rather than discarding durable state.
+            return Err(format!("transient I/O error loading snapshot, retry later: {err}").into());
+        }
+    };
+
+    tokio::spawn(store.clone().run()); // periodically snapshots in the background
+    Ok(())
+}
 ```
 
 The backend is pluggable: implement the `Persistence` trait to store snapshots in `redb`, `sled`,
@@ -183,7 +202,7 @@ stays lean:
 - `metrics-prometheus` — additionally provides `reconcile::prometheus` to install a Prometheus
   recorder and either serve a `/metrics` endpoint or render the exposition text yourself:
 
-```rust,no_run
+```rust,ignore
 # async fn run() -> Result<(), Box<dyn std::error::Error>> {
 // Serve a /metrics HTTP endpoint (requires a Tokio runtime):
 reconcile::prometheus::serve("0.0.0.0:9000".parse()?).await?;
@@ -239,7 +258,7 @@ value-only projection* of its data and answers a mirror's value-only diff agains
 mirror keeps no tombstone bookkeeping, never acknowledges tombstones, and is never counted as a
 causal-stability member, so it cannot hold back a dated node's garbage collection.
 
-```rust
+```rust,ignore
 use reconcile::{reconcile_store::Config, ReconcileMirror};
 
 // Mirrors a dated cluster reachable at `dated_addr` on the same port.
@@ -262,7 +281,7 @@ cloud region, an availability zone, or a single subnet. The model is intentional
 per location, no rack/host level and no hierarchy), because the CIDR mask already lets you pick the
 granularity. Declare every network with `with_net` — **including this node's own**:
 
-```rust
+```rust,ignore
 use reconcile::{reconcile_store::Config, ReconcileStore};
 
 let config = Config::default()
@@ -302,7 +321,7 @@ re-bind the socket and lose its identity) — useful for elastic deployments: op
 decommissioning one, or retuning WAN traffic on the fly. These `&self` methods on `ReconcileStore`
 take effect on the running `run()` loop:
 
-```rust
+```rust,ignore
 store.add_net("10.4.0.0/16".parse().unwrap()); // start gossiping with a new location
 store.remove_net("10.3.0.0/16".parse().unwrap()); // stop probing a retired one
 store.set_nets(&nets);                          // replace the whole topology at once
@@ -330,7 +349,7 @@ almost never lands on a live pod. Instead, point the store at a **headless `Serv
 (`clusterIP: None`): its DNS name resolves to one address record per ready pod, giving every peer in
 a single lookup — the canonical StatefulSet pattern, with **no Kubernetes API access and no RBAC**.
 
-```rust
+```rust,ignore
 use reconcile::{reconcile_store::Config, ReconcileStore};
 
 let config = Config::default()

--- a/SOTA.md
+++ b/SOTA.md
@@ -418,7 +418,7 @@ surrounding system.
 |---|---|
 | **MSRV** (*Minimum Supported Rust Version*) | The minimum supported Rust version; absent from `Cargo.toml` (F17). |
 | **clippy / `-Dwarnings`** | The Rust linter; CI treating warnings as errors. The `mismatched_lifetime_syntaxes` warning (`hrtree_iter.rs:177`) would break CI (F17). |
-| **miri** | An interpreter detecting UB (*Undefined Behavior*); not applicable here — the crate is `#![forbid(unsafe_code)]` and all iterators are safe Rust (since `d030c15`). The CI gap for F17 is now the undeclared MSRV ([#189](https://github.com/Akvize/reconcile-rs/issues/189)). |
+| **miri** | An interpreter detecting UB (*Undefined Behavior*); not applicable here — the crate is `#![forbid(unsafe_code)]` and all iterators are safe Rust (since `d030c15`). The F17 CI gap (undeclared MSRV) was closed by declaring `rust-version = "1.85"` and adding a CI check job ([#189](https://github.com/Akvize/reconcile-rs/issues/189)). |
 | **proptest / quickcheck / fuzzing** | Property-based / generative / random-input testing. **Entirely absent** (F11). |
 | **`cargo audit` / `cargo deny`** | Vulnerability audit / dependency policies. Absent from CI (F19). |
 | **bincode / serde / tokio / parking_lot / arrayvec / ipnet / range-cmp / chrono / rand / once_cell / tracing** | Dependencies: binary serialization; (de)serialization; async runtime; non-poisoning locks; `ArrayVec` (inline vector, B-tree nodes); network/CIDR types; key↔range comparison (`RangeOrdering`); `DateTime<Utc>` (LWW timestamps); randomness; lazy init; structured logs. |

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,14 +1,16 @@
 // The benchmark drives the internal range-fingerprint via `HRTree::hash`, which is `pub(crate)`.
 // Like the integration-test oracles it reaches that internal through the gated
-// `reconcile::testing` seam (the `range_hash` shim), so the real bench body only compiles with the
-// `internal-testing` feature. Without it we fall back to an empty `main` so the target still links.
-#[cfg(not(feature = "internal-testing"))]
+// `reconcile::testing` seam (the `range_hash` shim), so the real bench body only compiles under the
+// `reconcile_internal_testing` cfg flag. Without it we fall back to an empty `main` so the target
+// still links. The flag is set by this repo's `.cargo/config.toml` (it is not a Cargo feature, so
+// it never ships to consumers of the published crate).
+#[cfg(not(reconcile_internal_testing))]
 fn main() {}
 
-#[cfg(feature = "internal-testing")]
+#[cfg(reconcile_internal_testing)]
 use imp::main;
 
-#[cfg(feature = "internal-testing")]
+#[cfg(reconcile_internal_testing)]
 mod imp {
     use std::collections::BTreeMap;
     use std::time::Duration;

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -23,7 +23,7 @@ mod imp {
     };
 
     use reconcile::testing::range_hash;
-    use reconcile::{reconcile_store::Config, HRTree, ReconcileStore, Timestamp, ValueOnly};
+    use reconcile::{reconcile_store::Config, Entry, HRTree, ReconcileStore, State, Timestamp};
 
     fn hrtree_new(c: &mut Criterion) {
         let mut group = c.benchmark_group("HRTree::new");
@@ -242,11 +242,11 @@ mod imp {
     /// (less to move/hash per entry) and, as the one-off report below shows, stores fewer bytes per
     /// entry — the whole point of the optimization for fleets with many passive read replicas.
     fn mirror_memory(c: &mut Criterion) {
-        let dated = std::mem::size_of::<(Timestamp, Option<u32>)>();
-        let light = std::mem::size_of::<ValueOnly<u32>>();
+        let dated = std::mem::size_of::<Entry<Timestamp, u32>>();
+        let light = std::mem::size_of::<State<u32>>();
         println!(
-            "[mirror memory] per-entry value size: dated (Timestamp, Option<u32>) = {dated} B, \
-         value-only ValueOnly<u32> = {light} B, saved = {} B/entry",
+            "[mirror memory] per-entry value size: dated Entry<Timestamp, u32> = {dated} B, \
+         value-only State<u32> = {light} B, saved = {} B/entry",
             dated - light
         );
 
@@ -266,25 +266,25 @@ mod imp {
             group.sample_size(10.max(1_000_000 / size).min(100));
             group.sampling_mode(SamplingMode::Linear);
             group.bench_with_input(
-                BenchmarkId::new("dated (Timestamp, Option<u32>)", size),
+                BenchmarkId::new("dated Entry<Timestamp, u32>", size),
                 &size,
                 |b, &size| {
                     b.iter(|| {
-                        let mut tree = HRTree::<u32, (Timestamp, Option<u32>)>::new();
+                        let mut tree = HRTree::<u32, Entry<Timestamp, u32>>::new();
                         for &k in keys[..size].iter() {
-                            tree.insert(k, (Timestamp::new(k as u64, 0, 0), Some(k)));
+                            tree.insert(k, Entry::present(Timestamp::new(k as u64, 0, 0), k));
                         }
                     })
                 },
             );
             group.bench_with_input(
-                BenchmarkId::new("value-only ValueOnly<u32>", size),
+                BenchmarkId::new("value-only State<u32>", size),
                 &size,
                 |b, &size| {
                     b.iter(|| {
-                        let mut tree = HRTree::<u32, ValueOnly<u32>>::new();
+                        let mut tree = HRTree::<u32, State<u32>>::new();
                         for &k in keys[..size].iter() {
-                            tree.insert(k, ValueOnly(Some(k)));
+                            tree.insert(k, State::Present(k));
                         }
                     })
                 },

--- a/examples/k8s/README.md
+++ b/examples/k8s/README.md
@@ -16,8 +16,11 @@ crate. The library itself lives in [`../../src/`](../../src/).
 ## The node
 
 [`main.rs`](main.rs) is env-driven and discovers its peers by resolving the headless `Service` over
-DNS (no Kubernetes API access, no RBAC). It runs the store and exposes `/metrics` for the kubelet
-probes. To make reconciliation observable it also runs a small **demo** behaviour — a periodic
+DNS (no Kubernetes API access, no RBAC). It runs the store and exposes `/metrics` (Prometheus scrape
+plus the kubelet liveness probe) and a separate `/ready` endpoint that reports ready only once the
+store is built and gossiping — so a pod is not advertised to the Service DNS (and peers'
+`DnsDiscovery`) before it can serve. To make reconciliation observable it also runs a small **demo**
+behaviour — a periodic
 per-pod heartbeat write plus a hook that logs reconciled keys, so you watch convergence directly in
 `kubectl logs`. Those two blocks are fenced with `--- demo ---` markers; delete them for a bare
 production node.

--- a/examples/k8s/base/configmap.yaml
+++ b/examples/k8s/base/configmap.yaml
@@ -10,8 +10,16 @@ data:
   # FQDN of the headless Service. Adjust the namespace if not "default".
   RECONCILE_DNS_NAME: "reconcile-headless.default.svc.cluster.local"
   RECONCILE_PORT: "8080"
-  # Address the in-process Prometheus/readiness endpoint listens on.
+  # Address the in-process Prometheus/readiness endpoint listens on. SECURITY: this endpoint is
+  # unauthenticated and leaks operational info (dataset size/churn, byte and peer counters). 0.0.0.0
+  # listens on every interface so the kubelet and in-cluster Prometheus can scrape it; keep it
+  # cluster-internal — do NOT expose port 9000 via a LoadBalancer/Ingress, and restrict scrape
+  # access with a NetworkPolicy. Bind to 127.0.0.1 if only a node-local sidecar scrapes it.
   RECONCILE_METRICS_ADDR: "0.0.0.0:9000"
+  # Address of the readiness endpoint the kubelet readiness probe targets. It reports ready only
+  # once the store is built and gossiping, so a pod is not advertised to the Service DNS (and peers'
+  # DnsDiscovery) before it can serve reconciliation. Kept distinct from the metrics endpoint.
+  RECONCILE_READY_ADDR: "0.0.0.0:9001"
   # How often (seconds) to re-resolve peers, and how many consecutive misses before a vanished pod
   # is decommissioned (so its tombstones stop gating garbage collection).
   RECONCILE_DISCOVERY_INTERVAL_SECS: "5"

--- a/examples/k8s/base/statefulset.yaml
+++ b/examples/k8s/base/statefulset.yaml
@@ -51,12 +51,23 @@ spec:
             - name: metrics
               containerPort: 9000
               protocol: TCP
+            - name: ready
+              containerPort: 9001
+              protocol: TCP
+          # Readiness gates the pod into the headless-Service DNS (and thus into peers'
+          # DnsDiscovery). It MUST reflect real store health, not just "an HTTP port is open":
+          # /metrics is the in-process Prometheus listener and comes up before ReconcileStore::new
+          # binds the UDP socket, so probing it would advertise a pod that cannot yet serve a single
+          # reconciliation. The dedicated /ready endpoint returns 200 only once the store is built
+          # and its gossip loop is running. (This is join-time health; the discovery decommission
+          # floor of issue #201 governs leave-time grace — the two are independent.)
           readinessProbe:
             httpGet:
-              path: /metrics
-              port: metrics
+              path: /ready
+              port: ready
             initialDelaySeconds: 3
             periodSeconds: 5
+          # Liveness only checks the process is alive and serving HTTP, so /metrics is fine here.
           livenessProbe:
             httpGet:
               path: /metrics

--- a/examples/k8s/main.rs
+++ b/examples/k8s/main.rs
@@ -9,10 +9,11 @@
 //! A Kubernetes-native reconcile node — the example behind `examples/k8s/`.
 //!
 //! It binds to its pod IP, derives a stable node identity from the pod name, discovers its peers by
-//! resolving a headless `Service` over DNS, and exposes a `/metrics` endpoint for the kubelet
-//! probes. Everything is taken from the environment (the Kubernetes downward API + a ConfigMap /
-//! Secret), so the same image works for every replica. See `examples/k8s/base/` for the manifests
-//! and `examples/k8s/kind/` for a local playground.
+//! resolving a headless `Service` over DNS, exposes a `/metrics` endpoint (Prometheus scrape +
+//! liveness probe), and a separate readiness endpoint that only reports ready once the store is
+//! built and its gossip loop is running. Everything is taken from the environment (the Kubernetes
+//! downward API + a ConfigMap / Secret), so the same image works for every replica. See
+//! `examples/k8s/base/` for the manifests and `examples/k8s/kind/` for a local playground.
 //!
 //! To make reconciliation *observable*, it also runs a small **demo** behaviour (clearly fenced
 //! below with `--- demo ---` markers — delete those two blocks for a bare production node):
@@ -36,12 +37,58 @@ use std::collections::hash_map::DefaultHasher;
 use std::collections::HashSet;
 use std::hash::{Hash, Hasher};
 use std::net::{IpAddr, SocketAddr};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
 use tracing::{info, warn};
 
 use reconcile::{reconcile_store::Config, ReconcileStore};
+
+/// Serve a minimal readiness endpoint that returns `200` only once `ready` has been set, and `503`
+/// before that. Pointing the kubelet readiness probe here (rather than at `/metrics`) keeps a pod
+/// out of the headless-Service DNS — and thus out of every peer's `DnsDiscovery` set — until its
+/// store is actually built and its gossip loop is running. `/metrics` comes up too early (it is the
+/// in-process Prometheus listener, live before `ReconcileStore::new` binds the UDP socket), so a
+/// pod probing `/metrics` would advertise itself before it could serve a single reconciliation.
+///
+/// This complements the discovery decommission-floor behaviour: readiness gates a pod *into*
+/// rotation only when it can serve, while the decommission floor governs how long a vanished member
+/// is tolerated before its tombstone-GC gate is released. The two are independent — one is join-time
+/// health, the other leave-time grace — and both keep DNS membership honest.
+async fn serve_readiness(addr: SocketAddr, ready: Arc<AtomicBool>) {
+    let listener = TcpListener::bind(addr)
+        .await
+        .expect("failed to bind the readiness endpoint");
+    loop {
+        let Ok((mut stream, _)) = listener.accept().await else {
+            continue;
+        };
+        let ready = Arc::clone(&ready);
+        tokio::spawn(async move {
+            // Drain the request line(s); we serve a fixed response regardless of path.
+            let mut buf = [0u8; 1024];
+            let _ = stream.read(&mut buf).await;
+            let body = if ready.load(Ordering::Relaxed) {
+                "ready"
+            } else {
+                "not ready"
+            };
+            let status = if ready.load(Ordering::Relaxed) {
+                "200 OK"
+            } else {
+                "503 Service Unavailable"
+            };
+            let response = format!(
+                "HTTP/1.1 {status}\r\ncontent-type: text/plain\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            let _ = stream.write_all(response.as_bytes()).await;
+        });
+    }
+}
 
 /// Read a required environment variable or exit with a clear message.
 fn required(name: &str) -> String {
@@ -103,6 +150,9 @@ async fn main() {
     let metrics_addr: SocketAddr = optional("RECONCILE_METRICS_ADDR", "0.0.0.0:9000")
         .parse()
         .expect("RECONCILE_METRICS_ADDR must be host:port");
+    let ready_addr: SocketAddr = optional("RECONCILE_READY_ADDR", "0.0.0.0:9001")
+        .parse()
+        .expect("RECONCILE_READY_ADDR must be host:port");
     // How often this pod refreshes its own heartbeat key.
     let heartbeat_interval = Duration::from_secs(
         optional("RECONCILE_HEARTBEAT_SECS", "5")
@@ -125,7 +175,17 @@ async fn main() {
         ),
     }
 
-    // Expose /metrics for the kubelet readiness/liveness probes.
+    // Start the readiness endpoint immediately, reporting NOT ready: the kubelet readiness probe
+    // targets it, so the pod stays out of the headless-Service DNS (and out of peers' DnsDiscovery)
+    // until the store below is built and its gossip loop is running. We flip it to ready only after
+    // `ReconcileStore::new` has bound the UDP socket and `run()` is about to start.
+    let ready = Arc::new(AtomicBool::new(false));
+    tokio::spawn(serve_readiness(ready_addr, Arc::clone(&ready)));
+
+    // Expose /metrics for the kubelet liveness probe and for Prometheus scraping. SECURITY: this
+    // endpoint is unauthenticated and leaks operational info — keep it cluster-internal (see the
+    // ConfigMap caveat) and bind it to a trusted interface rather than 0.0.0.0 if a node-local
+    // sidecar is the only scraper.
     reconcile::prometheus::serve(metrics_addr)
         .await
         .expect("failed to start the metrics endpoint");
@@ -170,5 +230,8 @@ async fn main() {
     // --- end demo ---------------------------------------------------------------------------
 
     info!(%pod_ip, %pod_name, port, "reconcile k8s node starting; writing heartbeats; discovering peers over DNS");
+    // The store is built and its UDP socket is bound; the gossip loop starts on the next line.
+    // Flip readiness on so the kubelet adds the pod to the Service DNS now that it can serve peers.
+    ready.store(true, Ordering::Relaxed);
     store.run().await;
 }

--- a/examples/k8s/main.rs
+++ b/examples/k8s/main.rs
@@ -205,8 +205,8 @@ async fn main() {
     {
         let seen = seen.clone();
         store.add_pre_insert(move |key: &String, value| {
-            // `value.1` is `None` for a tombstone (a delete); only announce live keys.
-            if value.1.is_some() && seen.lock().unwrap().insert(key.clone()) {
+            // A tombstone (a delete) has no live value; only announce live keys.
+            if !value.is_tombstone() && seen.lock().unwrap().insert(key.clone()) {
                 info!(%key, "store now holds this key (local write or reconciled from a peer)");
             }
         });

--- a/src/bounds.rs
+++ b/src/bounds.rs
@@ -16,6 +16,12 @@
 //! These bundles cover only the data bounds; *entry-semantics* bounds (such as
 //! [`Projectable`](crate::reconcilable::Projectable)) are not bundled here and travel as extra
 //! bounds alongside `V: Value` where required.
+//!
+//! The [`Hash`] bound carries a correctness requirement: per-element fingerprints hash the key and
+//! value into one stream with no separator (see [`fingerprint::hash`](crate::fingerprint::hash)),
+//! so a custom `Hash` impl on a key or value type **must be self-delimiting** or two distinct
+//! elements can collide across the key/value boundary and the replicas silently fail to converge.
+//! The standard library's impls (integers, `str`/`String`, slices/`Vec`) already satisfy this.
 
 use std::fmt::Debug;
 use std::hash::Hash;

--- a/src/bounds.rs
+++ b/src/bounds.rs
@@ -13,9 +13,10 @@
 //! once, with blanket impls, so implementation sites can read `impl<K: Key, V: Value>` instead of
 //! spelling the full list out each time.
 //!
-//! These bundles cover only the data bounds; *entry-semantics* bounds (such as
-//! [`Projectable`](crate::reconcilable::Projectable)) are not bundled here and travel as extra
-//! bounds alongside `V: Value` where required.
+//! These bundles cover only the data bounds. *Entry semantics* (tombstone, timestamp, merge,
+//! projection) are not bounds at all: they are inherent methods on
+//! [`Entry`](crate::reconcilable::Entry) / [`State`](crate::reconcilable::State), so they travel
+//! with the concrete domain type rather than with the `V` bound (see `ARCHITECTURE.md` §3.8).
 //!
 //! The [`Hash`] bound carries a correctness requirement: per-element fingerprints hash the key and
 //! value into one stream with no separator (see [`fingerprint::hash`](crate::fingerprint::hash)),

--- a/src/bounds.rs
+++ b/src/bounds.rs
@@ -50,14 +50,19 @@ impl<T> Key for T where
 ///
 /// A blanket impl makes any type that satisfies the listed bounds a `Value` automatically, so this
 /// never has to be implemented by hand. It does not add or remove any concrete bound; it is purely
-/// a shorthand for the repeated `Clone + Debug + Hash + PartialEq + Send + Sync + Serialize +
-/// DeserializeOwned + 'static` list. Note it requires `PartialEq` (not `Ord`), unlike [`Key`].
+/// a shorthand for the repeated `Clone + Debug + Hash + Send + Sync + Serialize + DeserializeOwned
+/// + 'static` list. Unlike [`Key`] it needs no ordering: values are ordered by the stamp on their
+/// [`Entry`](crate::reconcilable::Entry), never by their own content.
+///
+/// It also needs no `PartialEq`. Values are never compared: under last-write-wins the only
+/// question the receive path asks is whether the remote stamp is greater, which `Timestamp: Ord`
+/// answers (see `ARCHITECTURE.md` §7 D5 for why that equivalence holds, and what would break it).
 pub trait Value:
-    Clone + Debug + Hash + PartialEq + Send + Sync + Serialize + DeserializeOwned + 'static
+    Clone + Debug + Hash + Send + Sync + Serialize + DeserializeOwned + 'static
 {
 }
 
 impl<T> Value for T where
-    T: Clone + Debug + Hash + PartialEq + Send + Sync + Serialize + DeserializeOwned + 'static
+    T: Clone + Debug + Hash + Send + Sync + Serialize + DeserializeOwned + 'static
 {
 }

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -351,21 +351,6 @@ impl Clock for HlcClock {
     }
 }
 
-/// A value that carries a [`Timestamp`].
-///
-/// Lets the reconciliation engine read the timestamp of a stored value (to advance its
-/// clock on receipt) without knowing the concrete value type.
-pub trait Timestamped {
-    /// The Hybrid Logical Clock timestamp attached to this value.
-    fn timestamp(&self) -> Timestamp;
-}
-
-impl<V> Timestamped for (Timestamp, V) {
-    fn timestamp(&self) -> Timestamp {
-        self.0
-    }
-}
-
 /// Deterministic [`Clock`] adapter for tests: no physical-time read at all.
 ///
 /// [`now`](Clock::now) bumps the logical counter; [`observe`](Clock::observe) jumps to a strictly

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -150,6 +150,13 @@ fn advance(wall_ms: u64, counter: u32) -> (u64, u32) {
 pub trait Clock: Send + Sync + 'static {
     /// Mint a strictly-monotonic local timestamp for a write or an outgoing message.
     fn now(&self) -> Timestamp;
+    /// This node's identity — the `node_id` component the adapter stamps onto every timestamp it
+    /// mints, and the deterministic tie-break that makes the conflict order total.
+    ///
+    /// Reading it here rather than caching it elsewhere means the reported identity can never
+    /// disagree with the one actually stamped, and — unlike calling [`now`](Clock::now) for it —
+    /// costs no counter tick.
+    fn node_id(&self) -> u64;
     /// Advance the clock past a timestamp received from a peer, so that a subsequent
     /// [`now`](Clock::now) is ordered after it (this is what prevents lost updates under skew).
     ///
@@ -276,6 +283,10 @@ impl Clock for HlcClock {
     ///
     /// The returned timestamp is strictly greater than every timestamp previously produced
     /// or observed by this clock, ensuring local monotonicity.
+    fn node_id(&self) -> u64 {
+        self.node_id
+    }
+
     fn now(&self) -> Timestamp {
         let pt = phys_now_ms();
         let mut last = self.last.lock();
@@ -375,6 +386,10 @@ impl ManualClock {
 
 #[cfg(test)]
 impl Clock for ManualClock {
+    fn node_id(&self) -> u64 {
+        self.node_id
+    }
+
     fn now(&self) -> Timestamp {
         let mut last = self.last.lock();
         let next = Timestamp::new(last.wall_ms(), last.counter() + 1, self.node_id);

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -1,0 +1,170 @@
+// Copyright 2023 Developers of the reconcile project.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! The [`Codec`] port — the domain's wire-encoding boundary — and its default
+//! [`BincodeCodec`] adapter (`ARCHITECTURE.md` §3.4).
+//!
+//! The reconciliation engine drives itself over this port instead of calling `bincode` directly, so
+//! the encoding is a substitutable adapter rather than a hard dependency of the domain.
+//! Authentication ([`Authenticator`](crate::auth)) always sits **ahead of** the codec: the MAC is
+//! verified on the raw datagram bytes before any decoding runs (invariant #5), so a forged datagram
+//! never reaches [`decode_stream`](Codec::decode_stream).
+
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+
+/// Abstracts the wire encoding used for protocol messages.
+///
+/// A single datagram carries a *stream* of protocol messages, so the decode side returns a `Vec`
+/// and takes a `max_items` cap: a crafted datagram cannot be expanded into an unbounded number of
+/// messages (a denial-of-service hazard). The encode side appends to a caller-owned buffer so a
+/// batch of messages can be framed into one datagram without per-message allocation.
+pub trait Codec: Send + Sync + 'static {
+    /// The error type produced by encoding or decoding.
+    type Error: std::error::Error + Send + Sync + 'static;
+
+    /// Append the encoding of `value` to `out`.
+    fn encode<T: Serialize + ?Sized>(
+        &self,
+        value: &T,
+        out: &mut Vec<u8>,
+    ) -> Result<(), Self::Error>;
+
+    /// Decode a stream of `T` from `bytes`, stopping at a clean end-of-input or once `max_items`
+    /// values have been decoded (whichever comes first).
+    ///
+    /// A **clean** end-of-input (all bytes consumed on a message boundary) yields the values decoded
+    /// so far; a *malformed* stream (a partial or invalid message mid-buffer) is an error, so a
+    /// corrupt or hostile datagram is rejected wholesale rather than half-applied.
+    fn decode_stream<T: DeserializeOwned>(
+        &self,
+        bytes: &[u8],
+        max_items: usize,
+    ) -> Result<Vec<T>, Self::Error>;
+}
+
+/// The default [`Codec`] adapter: `bincode` with the crate's frozen
+/// [`DefaultOptions`](bincode::DefaultOptions) configuration.
+///
+/// The configuration (variable-int encoding, little-endian) is part of the frozen wire format;
+/// changing it is a wire break. Zero-sized, so it is free to hold and clone.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct BincodeCodec;
+
+impl BincodeCodec {
+    /// Create the default bincode codec.
+    pub fn new() -> Self {
+        BincodeCodec
+    }
+}
+
+impl Codec for BincodeCodec {
+    type Error = bincode::Error;
+
+    fn encode<T: Serialize + ?Sized>(
+        &self,
+        value: &T,
+        out: &mut Vec<u8>,
+    ) -> Result<(), Self::Error> {
+        use bincode::{DefaultOptions, Serializer};
+        value.serialize(&mut Serializer::new(out, DefaultOptions::new()))
+    }
+
+    fn decode_stream<T: DeserializeOwned>(
+        &self,
+        bytes: &[u8],
+        max_items: usize,
+    ) -> Result<Vec<T>, Self::Error> {
+        use bincode::{DefaultOptions, Deserializer};
+        let mut deserializer = Deserializer::from_slice(bytes, DefaultOptions::new());
+        let mut out = Vec::new();
+        while out.len() < max_items {
+            match T::deserialize(&mut deserializer) {
+                Ok(value) => out.push(value),
+                Err(err) => {
+                    // A clean end-of-stream surfaces as an `UnexpectedEof` I/O error once every
+                    // framed message has been consumed; that is success, not corruption. Any other
+                    // error (or a truncated message mid-buffer) means the datagram is malformed and
+                    // the whole thing is rejected — matching the engine's drop-the-datagram policy.
+                    if let bincode::ErrorKind::Io(io_err) = err.as_ref() {
+                        if io_err.kind() == std::io::ErrorKind::UnexpectedEof {
+                            break;
+                        }
+                    }
+                    return Err(err);
+                }
+            }
+        }
+        Ok(out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trips_a_stream_of_messages() {
+        let codec = BincodeCodec::new();
+        let mut buf = Vec::new();
+        codec.encode(&1u32, &mut buf).unwrap();
+        codec.encode(&2u32, &mut buf).unwrap();
+        codec.encode(&3u32, &mut buf).unwrap();
+        let decoded: Vec<u32> = codec.decode_stream(&buf, 100).unwrap();
+        assert_eq!(decoded, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn max_items_caps_the_decoded_count() {
+        let codec = BincodeCodec::new();
+        let mut buf = Vec::new();
+        for i in 0..10u32 {
+            codec.encode(&i, &mut buf).unwrap();
+        }
+        // Only the first `max_items` are decoded; the rest are left un-decoded (DoS bound).
+        let decoded: Vec<u32> = codec.decode_stream(&buf, 4).unwrap();
+        assert_eq!(decoded, vec![0, 1, 2, 3]);
+    }
+
+    #[test]
+    fn empty_input_decodes_to_nothing() {
+        let codec = BincodeCodec::new();
+        let decoded: Vec<u32> = codec.decode_stream(&[], 100).unwrap();
+        assert!(decoded.is_empty());
+    }
+
+    #[test]
+    fn a_malformed_message_is_an_error() {
+        // A byte that is neither 0 nor 1 is an invalid `bool` encoding — a genuine mid-stream
+        // corruption (not a clean end-of-input), so the whole datagram is rejected.
+        let codec = BincodeCodec::new();
+        let decoded: Result<Vec<bool>, _> = codec.decode_stream(&[2u8], 100);
+        assert!(
+            decoded.is_err(),
+            "a malformed message must be rejected, not silently accepted"
+        );
+    }
+
+    #[test]
+    fn a_truncated_trailing_message_ends_the_stream_leniently() {
+        // A final message cut short surfaces as an end-of-input (indistinguishable from a clean
+        // boundary in a non-self-describing stream), so the intact prefix is returned and the
+        // partial tail is dropped — matching the engine's historical datagram handling.
+        // Fixed-width 4-byte arrays give an unambiguous frame boundary (no varint), so a truncated
+        // trailing frame is a clean short read rather than being misparsed as more values.
+        let codec = BincodeCodec::new();
+        let mut buf = Vec::new();
+        codec.encode(&[1u8, 2, 3, 4], &mut buf).unwrap();
+        codec.encode(&[5u8, 6, 7, 8], &mut buf).unwrap();
+        buf.pop(); // truncate the trailing 4-byte frame to 3 bytes
+        let decoded: Vec<[u8; 4]> = codec
+            .decode_stream(&buf, 100)
+            .expect("a truncated trailing message ends the stream, not an error");
+        assert_eq!(decoded, vec![[1, 2, 3, 4]]);
+    }
+}

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -29,11 +29,7 @@ pub trait Codec: Send + Sync + 'static {
     type Error: std::error::Error + Send + Sync + 'static;
 
     /// Append the encoding of `value` to `out`.
-    fn encode<T: Serialize + ?Sized>(
-        &self,
-        value: &T,
-        out: &mut Vec<u8>,
-    ) -> Result<(), Self::Error>;
+    fn encode<T: Serialize>(&self, value: &T, out: &mut Vec<u8>) -> Result<(), Self::Error>;
 
     /// Decode a stream of `T` from `bytes`, stopping at a clean end-of-input or once `max_items`
     /// values have been decoded (whichever comes first).
@@ -66,11 +62,7 @@ impl BincodeCodec {
 impl Codec for BincodeCodec {
     type Error = bincode::Error;
 
-    fn encode<T: Serialize + ?Sized>(
-        &self,
-        value: &T,
-        out: &mut Vec<u8>,
-    ) -> Result<(), Self::Error> {
+    fn encode<T: Serialize>(&self, value: &T, out: &mut Vec<u8>) -> Result<(), Self::Error> {
         use bincode::{DefaultOptions, Serializer};
         value.serialize(&mut Serializer::new(out, DefaultOptions::new()))
     }

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -11,9 +11,9 @@
 //!
 //! The reconciliation engine drives itself over this port instead of calling `bincode` directly, so
 //! the encoding is a substitutable adapter rather than a hard dependency of the domain.
-//! Authentication ([`Authenticator`](crate::auth)) always sits **ahead of** the codec: the MAC is
-//! verified on the raw datagram bytes before any decoding runs (invariant #5), so a forged datagram
-//! never reaches [`decode_stream`](Codec::decode_stream).
+//! Datagram authentication always sits **ahead of** the codec: the MAC is verified on the raw
+//! datagram bytes before any decoding runs (invariant #5), so a forged datagram never reaches
+//! [`decode_stream`](Codec::decode_stream).
 
 use serde::de::DeserializeOwned;
 use serde::Serialize;

--- a/src/fingerprint.rs
+++ b/src/fingerprint.rs
@@ -240,6 +240,25 @@ impl Hasher for Blake3Hasher {
 /// combines into range fingerprints. It is BLAKE3 over the key bytes followed by
 /// the value bytes, fed in a fixed, portable encoding (see the `Blake3Hasher` adapter),
 /// and is part of the wire protocol — see the golden-vector tests.
+///
+/// # Domain separation is the caller's burden
+///
+/// The key and the value are hashed into **one** BLAKE3 stream back-to-back, with **no length
+/// prefix or separator** between them. The encoding is therefore only collision-free across the
+/// key/value boundary when each type's [`Hash`] impl is **self-delimiting** — i.e. the byte stream
+/// it writes unambiguously encodes its own length. If both `K` and `V` can emit variable-length
+/// byte runs without a length marker, two *different* elements can hash identically because the
+/// boundary shifts: `k1 ‖ v1 == k2 ‖ v2` (e.g. `("ab", "c")` and `("a", "bc")`). Two elements that
+/// collide here are indistinguishable to the range-diff protocol, so a real difference can go
+/// undetected and the replicas silently fail to converge on those keys.
+///
+/// The standard library's `Hash` impls used as keys/values here are self-delimiting and safe:
+/// integers and other fixed-width primitives write a fixed number of bytes; slices/`Vec` prepend
+/// their length (`Hash::hash` calls `write_usize(len)` first); and `str`/`String` write a trailing
+/// `0xff` sentinel after the bytes. A **custom**
+/// `Hash` impl is safe as long as it is self-delimiting; if it concatenates variable-length fields
+/// without lengths, give it a self-delimiting impl (e.g. `#[derive(Hash)]`, or hash a length before
+/// each variable-length field) before using the type as a `K` or `V`.
 pub fn hash<K: Hash, V: Hash>(key: &K, value: &V) -> Fingerprint {
     let mut hasher = Blake3Hasher::new();
     key.hash(&mut hasher);

--- a/src/hrtree.rs
+++ b/src/hrtree.rs
@@ -40,6 +40,13 @@ const B: usize = 6;
 const MIN_CAPACITY: usize = B - 1;
 const MAX_CAPACITY: usize = 2 * B - 1;
 
+// A node only ever splits at `len == MAX_CAPACITY` (`2 * B - 1`), promoting the median and leaving
+// `B - 1` keys on each side. For both sides to be non-empty after a split, `B - 1 >= 1`, i.e.
+// `B >= 3` (`MAX_CAPACITY >= 5`, an odd median split). At `B == 2` (`MAX_CAPACITY == 3`) the split
+// can leave a node empty, violating the B-tree occupancy invariant. Pin the lower bound here so a
+// future retune of `B` that crosses it fails to compile rather than silently corrupting the tree.
+const _: () = assert!(B >= 3);
+
 type InsertionTuple<K, V> = Option<(K, V, Fingerprint, Box<Node<K, V>>)>;
 
 /// Which sibling a [`Node::steal`] rotates a separator from.
@@ -98,7 +105,8 @@ impl<K, V> Node<K, V> {
     ) -> InsertionTuple<K, V> {
         assert_eq!(self.children.is_none(), right_child.is_none());
         if self.keys.is_full() {
-            // TODO: handle case where self.keys.len() == 2 without leaving empty node
+            // A split promotes the median and leaves `B - 1` keys on each side; both are non-empty
+            // because `B >= 3` (asserted at the top of this module). `mid` is the median index.
             let mid = self.keys.len() / 2;
             // split
             let mut right_sibling = Box::new(Node {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,10 +111,12 @@ pub use reconcile_store::ReconcileStore;
 /// integration tests need to reach a handful of their internals to drive the diff protocol. This
 /// module re-exports exactly those symbols so the default public surface stays clean while the
 /// tests can still reach them. It is hidden from docs and only compiled under `cfg(test)` or the
-/// `internal-testing` feature (integration tests are separate crates, so `cfg(test)` does not
-/// apply to them — they enable the feature instead).
+/// `reconcile_internal_testing` cfg flag (integration tests are separate crates, so `cfg(test)`
+/// does not apply to them — they rely on the flag instead). The flag is **not** a Cargo feature: it
+/// is set by this repository's `.cargo/config.toml` for its own builds/tests and never ships to
+/// consumers of the published crate, so downstream code cannot reach this seam.
 #[doc(hidden)]
-#[cfg(any(test, feature = "internal-testing"))]
+#[cfg(any(test, reconcile_internal_testing))]
 pub mod testing {
     pub use crate::fingerprint::hash;
     pub use crate::proto::{diff_round, start_diff, DiffRange, HashSegment};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,7 +100,7 @@ pub use hrtree::HRTree;
 // mutation path is `HRTree::with_mut`. A correct iterator-based design is future work.
 pub use hrtree_iter::{IntoIter, IntoKeys, IntoValues, Iter, Keys, Values};
 pub use mirror::ReconcileMirror;
-pub use persistence::{FileSnapshot, InMemoryPersistence, PersistedState, Persistence};
+pub use persistence::{FileSnapshot, InMemoryPersistence, LoadError, PersistedState, Persistence};
 pub use reconcilable::{Projectable, ValueOnly};
 pub use reconcile_store::ReconcileStore;
 
@@ -220,3 +220,10 @@ pub mod testing {
         store.bulk_dumps_in_flight_count()
     }
 }
+
+/// Compile-checks the README's code blocks as doctests, so an API change that breaks an
+/// example fails `cargo test --doc`. `#[cfg(doctest)]` keeps it out of builds and rendered
+/// documentation.
+#[doc = include_str!("../README.md")]
+#[cfg(doctest)]
+pub struct ReadmeDoctests;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -171,6 +171,19 @@ pub mod testing {
         store.peers_map_len()
     }
 
+    /// Whether `peer` is currently in the gossip-routing peers map.
+    ///
+    /// Exposed so discovery integration tests can deterministically confirm that at least one
+    /// discovery round has seeded a peer before mutating the scripted resolver — eliminating the
+    /// `seen_ever` race that caused intermittent failures in the floor tests.
+    pub fn peers_contains<K, V>(store: &crate::ReconcileStore<K, V>, peer: std::net::IpAddr) -> bool
+    where
+        K: crate::bounds::Key,
+        V: crate::bounds::Value,
+    {
+        store.peers_contains(peer)
+    }
+
     /// Number of entries in the per-peer replay filter.
     ///
     /// Exposed for integration-test assertions so the peer-cap tests can verify that no new

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,6 @@
 
 pub mod bounds;
 pub mod clock;
-pub mod codec;
 pub mod discovery;
 pub mod fingerprint;
 pub mod hrtree;
@@ -77,6 +76,13 @@ pub mod transport;
 pub mod prometheus;
 
 pub(crate) mod auth;
+// The `Codec` port is deliberately internal (ARCHITECTURE.md §7 D2). Unlike `Transport` it has
+// generic methods, so it is not object-safe and is carried as a type parameter — exposing it would
+// force a type-changing builder. Its plausible uses are not served by swapping the trait anyway:
+// compression interacts with authenticate-before-decode (invariant 5) and with datagram size
+// accounting, and cross-language interop needs a published wire spec, not a Rust trait. The type
+// parameter is kept, so the seam survives at no public cost.
+pub(crate) mod codec;
 // Internal reconciliation mechanism. Demoted to `pub(crate)` (ARCHITECTURE.md §3.7): these are
 // implementation details, not part of the supported public surface. The few internals the
 // integration-test oracles need are re-exported through the gated [`testing`] module below.
@@ -90,11 +96,10 @@ pub(crate) mod timeout_wheel;
 
 pub use bounds::{Key, Value};
 pub use clock::{Clock, Timestamp};
-pub use codec::{BincodeCodec, Codec};
 pub use discovery::{DiscoverFuture, Discovery, DnsDiscovery, RandomProbe};
 pub use fingerprint::Fingerprint;
 pub use hrtree::HRTree;
-pub use transport::{Transport, UdpTransport};
+pub use transport::{InMemoryNetwork, InMemoryTransport, Transport, UdpTransport};
 // The `hrtree_iter` module is `pub(crate)`, but the iterator types below appear in public `HRTree`
 // method return types, so they must stay publicly reachable. A `pub` type re-exported from a
 // `pub(crate)` module is publicly reachable, which avoids private-in-public errors (E0446).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,6 +62,7 @@
 
 pub mod bounds;
 pub mod clock;
+pub mod codec;
 pub mod discovery;
 pub mod fingerprint;
 pub mod hrtree;
@@ -69,6 +70,7 @@ pub mod mirror;
 pub mod persistence;
 pub mod reconcilable;
 pub mod reconcile_store;
+pub mod transport;
 
 /// Optional Prometheus integration (enabled by the `metrics-prometheus` feature).
 #[cfg(feature = "metrics-prometheus")]
@@ -88,9 +90,11 @@ pub(crate) mod timeout_wheel;
 
 pub use bounds::{Key, Value};
 pub use clock::{Clock, Timestamp};
+pub use codec::{BincodeCodec, Codec};
 pub use discovery::{DiscoverFuture, Discovery, DnsDiscovery, RandomProbe};
 pub use fingerprint::Fingerprint;
 pub use hrtree::HRTree;
+pub use transport::{Transport, UdpTransport};
 // The `hrtree_iter` module is `pub(crate)`, but the iterator types below appear in public `HRTree`
 // method return types, so they must stay publicly reachable. A `pub` type re-exported from a
 // `pub(crate)` module is publicly reachable, which avoids private-in-public errors (E0446).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,7 +101,7 @@ pub use hrtree::HRTree;
 pub use hrtree_iter::{IntoIter, IntoKeys, IntoValues, Iter, Keys, Values};
 pub use mirror::ReconcileMirror;
 pub use persistence::{FileSnapshot, InMemoryPersistence, LoadError, PersistedState, Persistence};
-pub use reconcilable::{Projectable, ValueOnly};
+pub use reconcilable::{Entry, State};
 pub use reconcile_store::ReconcileStore;
 
 /// Internal seam for the external integration-test oracles (`tests/diff.rs`,

--- a/src/mirror.rs
+++ b/src/mirror.rs
@@ -15,7 +15,7 @@
 //! (last-write-wins) and run the tombstone causal-stability machinery. For a fleet with many
 //! *passive read replicas* that only ever consume values, that timestamp is pure overhead: ~12–16
 //! bytes per entry that the replica never needs. A `ReconcileMirror` stores only
-//! [`ValueOnly<V>`] — the `Option<V>` payload, no timestamp — and still converges with a dated peer
+//! [`State<V>`] — the `Option<V>` payload, no timestamp — and still converges with a dated peer
 //! over the **existing range-based diff protocol**, on the same UDP port.
 //!
 //! # How it stays causal-stability-safe
@@ -69,7 +69,7 @@ use crate::clock::Timestamp;
 use crate::fingerprint::Fingerprint;
 use crate::gen_ip::{gen_ip, net_of};
 use crate::proto;
-use crate::reconcilable::ValueOnly;
+use crate::reconcilable::{Entry, State};
 use crate::reconcile_engine::{send_messages_to, send_to_retry, Message};
 use crate::reconcile_store::Config;
 use crate::replay;
@@ -79,21 +79,21 @@ const BUFFER_SIZE: usize = 65507;
 const ACTIVITY_TIMEOUT: Duration = Duration::from_secs(1);
 const PEER_EXPIRATION: Duration = Duration::from_secs(60);
 
-type OnUpdateCallback<K, V> = Box<dyn Send + Sync + Fn(&K, &ValueOnly<V>)>;
+type OnUpdateCallback<K, V> = Box<dyn Send + Sync + Fn(&K, &State<V>)>;
 
 /// The wire value type a mirror names for (de)serialization. The mirror never stores a dated value;
 /// it only needs the type so the shared [`Message`] enum has a concrete `Update` payload (which it
-/// ignores) and so the value-only [`Projected`](crate::reconcilable::Projectable::Projected) type
-/// resolves to [`ValueOnly<V>`].
-type WireDated<V> = (Timestamp, Option<V>);
+/// ignores) and so the value-only projection type resolves to
+/// [`State<V>`](crate::reconcilable::State).
+type WireDated<V> = Entry<Timestamp, V>;
 
 /// A lightweight, dateless, read-only mirror of a dated [`ReconcileStore`](crate::ReconcileStore).
 ///
 /// See the [module documentation](crate::mirror) for the design and the causal-stability-safety guarantees.
 pub struct ReconcileMirror<K, V> {
     /// The value-only mirror. Its range fingerprints are timestamp-less by construction (see
-    /// [`ValueOnly`]), matching a dated peer's value-only projection.
-    tree: Arc<RwLock<HRTree<K, ValueOnly<V>>>>,
+    /// [`State`](crate::reconcilable::State)), matching a dated peer's value-only projection.
+    tree: Arc<RwLock<HRTree<K, State<V>>>>,
     port: u16,
     socket: Arc<UdpSocket>,
     /// The single network this read-only mirror probes for discovery. A mirror is a
@@ -167,7 +167,7 @@ impl<K: Key, V: Clone + Debug + DeserializeOwned + Hash + Send + Serialize + Syn
             .or_else(|| nets.first().copied())
             .unwrap_or_else(|| "127.0.0.1/8".parse().unwrap());
         Ok(ReconcileMirror {
-            tree: Arc::new(RwLock::new(HRTree::<K, ValueOnly<V>>::new())),
+            tree: Arc::new(RwLock::new(HRTree::<K, State<V>>::new())),
             port: config.port,
             socket: Arc::new(socket),
             net: Arc::new(RwLock::new(net)),
@@ -200,15 +200,15 @@ impl<K: Key, V: Clone + Debug + DeserializeOwned + Hash + Send + Serialize + Syn
     /// Register a hook invoked (outside the map lock) just before each inbound value is integrated.
     ///
     /// Useful to be notified of changes mirrored from the dated cluster. The tombstone case is
-    /// `ValueOnly(None)`.
-    pub fn add_on_update<F: Send + Sync + Fn(&K, &ValueOnly<V>) + 'static>(&self, on_update: F) {
+    /// `State::Tombstone`.
+    pub fn add_on_update<F: Send + Sync + Fn(&K, &State<V>) + 'static>(&self, on_update: F) {
         *self.on_update.write() = Box::new(on_update);
     }
 
     /// Get the live value for a key, or `None` if the key is absent or holds a mirrored tombstone.
     pub fn get(&self, k: &K) -> Option<MappedRwLockReadGuard<'_, V>> {
         let guard = self.tree.read();
-        RwLockReadGuard::try_map(guard, |tree| tree.get(k).and_then(|vo| vo.as_value())).ok()
+        RwLockReadGuard::try_map(guard, |tree| tree.get(k).and_then(|vo| vo.value())).ok()
     }
 
     /// Whether the mirror currently holds a live value for the key (a tombstone counts as absent).
@@ -241,7 +241,7 @@ impl<K: Key, V: Clone + Debug + DeserializeOwned + Hash + Send + Serialize + Syn
     /// Integrate inbound value-only updates by plain overwrite (the mirror holds no timestamp to
     /// compare against — it trusts the authoritative dated peer). Hooks run outside the map lock,
     /// so a hook may safely call back into the mirror.
-    fn integrate(&self, updates: Vec<(K, ValueOnly<V>)>) {
+    fn integrate(&self, updates: Vec<(K, State<V>)>) {
         if updates.is_empty() {
             return;
         }
@@ -263,7 +263,7 @@ impl<K: Key, V: Clone + Debug + DeserializeOwned + Hash + Send + Serialize + Syn
         let segments = proto::start_diff(&self.tree.read());
         send_buf.clear();
         for segment in segments {
-            Message::ValueComparisonItem::<K, WireDated<V>, ValueOnly<V>>(segment)
+            Message::ValueComparisonItem::<K, WireDated<V>, State<V>>(segment)
                 .serialize(&mut Serializer::new(&mut *send_buf, DefaultOptions::new()))
                 .unwrap();
         }
@@ -300,10 +300,10 @@ impl<K: Key, V: Clone + Debug + DeserializeOwned + Hash + Send + Serialize + Syn
         let payload = payload.as_bytes();
         trace!("mirror received {} bytes from {peer}", payload.len());
         let mut value_in_comparison = Vec::new();
-        let mut value_updates: Vec<(K, ValueOnly<V>)> = Vec::new();
+        let mut value_updates: Vec<(K, State<V>)> = Vec::new();
         let mut deserializer = Deserializer::from_slice(payload, DefaultOptions::new());
         loop {
-            match Message::<K, WireDated<V>, ValueOnly<V>>::deserialize(&mut deserializer) {
+            match Message::<K, WireDated<V>, State<V>>::deserialize(&mut deserializer) {
                 Err(ref kind) => {
                     if let bincode::ErrorKind::Io(err) = kind.as_ref() {
                         if err.kind() == std::io::ErrorKind::UnexpectedEof {
@@ -348,7 +348,7 @@ impl<K: Key, V: Clone + Debug + DeserializeOwned + Hash + Send + Serialize + Syn
             if !out_comparison.is_empty() {
                 let messages: Vec<_> = out_comparison
                     .into_iter()
-                    .map(Message::<K, WireDated<V>, ValueOnly<V>>::ValueComparisonItem)
+                    .map(Message::<K, WireDated<V>, State<V>>::ValueComparisonItem)
                     .collect();
                 send_messages_to(
                     &messages,
@@ -452,24 +452,24 @@ mod tests {
             .await
             .expect("bind failed");
         assert!(mirror.get(&1).is_none());
-        mirror.integrate(vec![(1, ValueOnly(Some("hello".to_string())))]);
+        mirror.integrate(vec![(1, State::Present("hello".to_string()))]);
         assert_eq!(mirror.get(&1).as_deref(), Some(&"hello".to_string()));
         assert!(mirror.contains_key(&1));
         assert_eq!(mirror.len(), 1);
     }
 
-    /// A mirrored tombstone (`ValueOnly(None)`) hides the value but is still a stored entry.
+    /// A mirrored tombstone (`State::Tombstone`) hides the value but is still a stored entry.
     #[tokio::test]
     async fn mirrors_tombstones() {
         let mirror = ReconcileMirror::<i32, String>::new(ephemeral_config())
             .await
             .expect("bind failed");
-        mirror.integrate(vec![(1, ValueOnly(Some("v".to_string())))]);
+        mirror.integrate(vec![(1, State::Present("v".to_string()))]);
         assert_eq!(mirror.get(&1).as_deref(), Some(&"v".to_string()));
 
         // A later tombstone overwrites it: the value disappears from `get`, but the key is retained
         // as a tombstone (the mirror has no timestamp and trusts the authoritative peer).
-        mirror.integrate(vec![(1, ValueOnly(None))]);
+        mirror.integrate(vec![(1, State::Tombstone)]);
         assert!(mirror.get(&1).is_none());
         assert!(!mirror.contains_key(&1));
         assert_eq!(mirror.len(), 1, "the tombstone is retained as an entry");
@@ -487,7 +487,7 @@ mod tests {
         mirror.add_on_update(move |_, _| {
             count2.fetch_add(1, Ordering::SeqCst);
         });
-        mirror.integrate(vec![(1, ValueOnly(Some(10))), (2, ValueOnly(None))]);
+        mirror.integrate(vec![(1, State::Present(10)), (2, State::Tombstone)]);
         assert_eq!(count.load(Ordering::SeqCst), 2);
     }
 
@@ -499,23 +499,23 @@ mod tests {
             .await
             .expect("bind failed");
         mirror.integrate(vec![
-            (1, ValueOnly(Some("a".to_string()))),
-            (2, ValueOnly(None)),
+            (1, State::Present("a".to_string())),
+            (2, State::Tombstone),
         ]);
 
-        let mut reference: HRTree<i32, ValueOnly<String>> = HRTree::new();
-        reference.insert(1, ValueOnly(Some("a".to_string())));
-        reference.insert(2, ValueOnly(None));
+        let mut reference: HRTree<i32, State<String>> = HRTree::new();
+        reference.insert(1, State::Present("a".to_string()));
+        reference.insert(2, State::Tombstone);
 
         assert_eq!(mirror.fingerprint(..), reference.hash(&..));
     }
 
-    /// A live value and its `ValueOnly` projection hash identically only via the value-only basis:
+    /// A live value and its `State` projection hash identically only via the value-only basis:
     /// per-entry, the dateless mirror saves the whole `Timestamp` (the point of the dateless mirror).
     #[test]
     fn value_only_is_smaller_per_entry() {
-        let dated = std::mem::size_of::<(Timestamp, Option<u64>)>();
-        let light = std::mem::size_of::<ValueOnly<u64>>();
+        let dated = std::mem::size_of::<Entry<Timestamp, u64>>();
+        let light = std::mem::size_of::<State<u64>>();
         assert!(
             light < dated,
             "value-only entry ({light} B) should be smaller than dated entry ({dated} B)"

--- a/src/mirror.rs
+++ b/src/mirror.rs
@@ -71,7 +71,7 @@ use crate::fingerprint::Fingerprint;
 use crate::gen_ip::{gen_ip, net_of};
 use crate::proto;
 use crate::reconcilable::{Entry, State};
-use crate::reconcile_engine::{send_messages_to, send_to_retry, Message};
+use crate::reconcile_engine::{send_messages_to, send_to_retry, Message, SendPorts};
 use crate::reconcile_store::Config;
 use crate::replay;
 use crate::transport::UdpTransport;
@@ -352,16 +352,15 @@ impl<K: Key, V: Clone + Debug + DeserializeOwned + Hash + Send + Serialize + Syn
                     .into_iter()
                     .map(Message::<K, WireDated<V>, State<V>>::ValueComparisonItem)
                     .collect();
-                send_messages_to(
-                    &messages,
-                    &UdpTransport::new(Arc::clone(&self.socket)),
-                    &BincodeCodec::new(),
-                    &self.authenticator,
-                    &self.sender_counter,
-                    &peer,
-                    send_buf,
-                )
-                .await;
+                let transport = UdpTransport::new(Arc::clone(&self.socket));
+                let codec = BincodeCodec::new();
+                let ports = SendPorts {
+                    transport: &transport,
+                    codec: &codec,
+                    authenticator: &self.authenticator,
+                    sender_counter: &self.sender_counter,
+                };
+                send_messages_to(&messages, &ports, &peer, send_buf).await;
             }
         }
     }

--- a/src/mirror.rs
+++ b/src/mirror.rs
@@ -45,8 +45,6 @@
 //!   replica with no causal-stability bookkeeping of its own.
 
 use std::collections::HashMap;
-use std::fmt::Debug;
-use std::hash::Hash;
 use std::io;
 use std::net::{IpAddr, SocketAddr};
 use std::ops::RangeBounds;
@@ -58,13 +56,13 @@ use ipnet::IpNet;
 use parking_lot::{MappedRwLockReadGuard, RwLock, RwLockReadGuard};
 use rand::rngs::StdRng;
 use rand::SeedableRng;
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 use tokio::net::UdpSocket;
 use tokio::time::timeout;
 use tracing::{debug, trace, warn};
 
 use crate::auth;
-use crate::bounds::Key;
+use crate::bounds::{Key, Value};
 use crate::clock::Timestamp;
 use crate::codec::BincodeCodec;
 use crate::fingerprint::Fingerprint;
@@ -92,6 +90,14 @@ type WireDated<V> = Entry<Timestamp, V>;
 /// A lightweight, dateless, read-only mirror of a dated [`ReconcileStore`](crate::ReconcileStore).
 ///
 /// See the [module documentation](crate::mirror) for the design and the causal-stability-safety guarantees.
+///
+/// # Correct only under last-write-wins
+///
+/// A mirror stores no timestamps, so it cannot resolve a conflict: inbound updates are applied by
+/// plain overwrite. That is correct *only* because the authoritative dated peer already
+/// resolved the conflict under LWW before sending the projection. Under any other resolution
+/// policy, last-writer-by-arrival would be wrong and the mirror would need redesigning — see
+/// `ARCHITECTURE.md` §7 D9, and D6 for why the policy is fixed.
 pub struct ReconcileMirror<K, V> {
     /// The value-only mirror. Its range fingerprints are timestamp-less by construction (see
     /// [`State`](crate::reconcilable::State)), matching a dated peer's value-only projection.
@@ -134,12 +140,7 @@ impl<K, V> Clone for ReconcileMirror<K, V> {
     }
 }
 
-// NOTE: `V` here is NOT the `Value` bundle: a mirror only ever handles the value-only projection,
-// so it does not require `V: PartialEq` (which `Value` includes). The data bounds are spelled out
-// to keep the required bound set identical (no tightening). `K` matches `Key` exactly.
-impl<K: Key, V: Clone + Debug + DeserializeOwned + Hash + Send + Serialize + Sync + 'static>
-    ReconcileMirror<K, V>
-{
+impl<K: Key, V: Value> ReconcileMirror<K, V> {
     /// Create a new mirror bound to the configured UDP socket.
     ///
     /// The mirror honours the same [`Config`] as a dated store, including
@@ -243,6 +244,11 @@ impl<K: Key, V: Clone + Debug + DeserializeOwned + Hash + Send + Serialize + Syn
     /// Integrate inbound value-only updates by plain overwrite (the mirror holds no timestamp to
     /// compare against — it trusts the authoritative dated peer). Hooks run outside the map lock,
     /// so a hook may safely call back into the mirror.
+    /// Apply inbound value-only updates by **overwriting** the local entry.
+    ///
+    /// A mirror holds no stamps, so there is nothing to compare and no merge to perform: the
+    /// arriving projection is taken as-is. This is sound only because the dated sender already
+    /// applied last-write-wins — see the type-level note and `ARCHITECTURE.md` §7 D9.
     fn integrate(&self, updates: Vec<(K, State<V>)>) {
         if updates.is_empty() {
             return;

--- a/src/mirror.rs
+++ b/src/mirror.rs
@@ -66,6 +66,7 @@ use tracing::{debug, trace, warn};
 use crate::auth;
 use crate::bounds::Key;
 use crate::clock::Timestamp;
+use crate::codec::BincodeCodec;
 use crate::fingerprint::Fingerprint;
 use crate::gen_ip::{gen_ip, net_of};
 use crate::proto;
@@ -73,6 +74,7 @@ use crate::reconcilable::{Entry, State};
 use crate::reconcile_engine::{send_messages_to, send_to_retry, Message};
 use crate::reconcile_store::Config;
 use crate::replay;
+use crate::transport::UdpTransport;
 use crate::HRTree;
 
 const BUFFER_SIZE: usize = 65507;
@@ -276,11 +278,11 @@ impl<K: Key, V: Clone + Debug + DeserializeOwned + Hash + Send + Serialize + Syn
         for peer in peers {
             trace!("mirror start_diff {} bytes to {peer}", send_buf.len());
             if let Err(err) = send_to_retry(
-                &self.socket,
+                &UdpTransport::new(Arc::clone(&self.socket)),
                 &self.authenticator,
                 &self.sender_counter,
                 send_buf,
-                (peer, self.port),
+                SocketAddr::new(peer, self.port),
             )
             .await
             {
@@ -352,7 +354,8 @@ impl<K: Key, V: Clone + Debug + DeserializeOwned + Hash + Send + Serialize + Syn
                     .collect();
                 send_messages_to(
                     &messages,
-                    Arc::clone(&self.socket),
+                    &UdpTransport::new(Arc::clone(&self.socket)),
+                    &BincodeCodec::new(),
                     &self.authenticator,
                     &self.sender_counter,
                     &peer,

--- a/src/observability.rs
+++ b/src/observability.rs
@@ -28,6 +28,7 @@
 //! | `reconcile_send_failures_total` | counter | sends that exhausted all retries |
 //! | `reconcile_datagrams_dropped_total` | counter (`reason` label) | dropped datagrams |
 //! | `reconcile_rounds_total` | counter | reconciliation rounds initiated |
+//! | `reconcile_tombstone_reacks_total` | counter | tombstone re-acknowledgments emitted on rounds |
 //! | `reconcile_round_duration_seconds` | histogram | `start_reconciliation` wall time |
 //! | `reconcile_handle_messages_duration_seconds` | histogram | `handle_messages` wall time |
 
@@ -47,6 +48,7 @@ mod imp {
     pub(crate) const SEND_FAILURES_TOTAL: &str = "reconcile_send_failures_total";
     pub(crate) const DATAGRAMS_DROPPED_TOTAL: &str = "reconcile_datagrams_dropped_total";
     pub(crate) const ROUNDS_TOTAL: &str = "reconcile_rounds_total";
+    pub(crate) const TOMBSTONE_REACKS_TOTAL: &str = "reconcile_tombstone_reacks_total";
     pub(crate) const ROUND_DURATION_SECONDS: &str = "reconcile_round_duration_seconds";
     pub(crate) const HANDLE_DURATION_SECONDS: &str = "reconcile_handle_messages_duration_seconds";
 
@@ -100,6 +102,11 @@ mod imp {
     }
 
     #[inline]
+    pub(crate) fn record_tombstone_reacks(n: usize) {
+        counter!(TOMBSTONE_REACKS_TOTAL).increment(n as u64);
+    }
+
+    #[inline]
     pub(crate) fn record_round_duration(start: Option<Instant>) {
         if let Some(start) = start {
             histogram!(ROUND_DURATION_SECONDS).record(start.elapsed().as_secs_f64());
@@ -145,6 +152,11 @@ mod imp {
             "Datagrams dropped, by reason"
         );
         describe_counter!(ROUNDS_TOTAL, Unit::Count, "Reconciliation rounds initiated");
+        describe_counter!(
+            TOMBSTONE_REACKS_TOTAL,
+            Unit::Count,
+            "Tombstone re-acknowledgments emitted on reconciliation rounds"
+        );
         describe_histogram!(
             ROUND_DURATION_SECONDS,
             Unit::Seconds,
@@ -190,6 +202,9 @@ mod imp {
 
     #[inline(always)]
     pub(crate) fn record_reconcile_round() {}
+
+    #[inline(always)]
+    pub(crate) fn record_tombstone_reacks(_n: usize) {}
 
     #[inline(always)]
     pub(crate) fn record_round_duration(_start: Option<Instant>) {}

--- a/src/observability.rs
+++ b/src/observability.rs
@@ -28,7 +28,7 @@
 //! | `reconcile_send_failures_total` | counter | sends that exhausted all retries |
 //! | `reconcile_datagrams_dropped_total` | counter (`reason` label) | dropped datagrams |
 //! | `reconcile_rounds_total` | counter | reconciliation rounds initiated |
-//! | `reconcile_tombstone_reacks_total` | counter | tombstone re-acknowledgments emitted on rounds |
+//! | `reconcile_tombstone_acks_resent_total` | counter | tombstone acks resent on reconciliation rounds |
 //! | `reconcile_round_duration_seconds` | histogram | `start_reconciliation` wall time |
 //! | `reconcile_handle_messages_duration_seconds` | histogram | `handle_messages` wall time |
 
@@ -48,7 +48,7 @@ mod imp {
     pub(crate) const SEND_FAILURES_TOTAL: &str = "reconcile_send_failures_total";
     pub(crate) const DATAGRAMS_DROPPED_TOTAL: &str = "reconcile_datagrams_dropped_total";
     pub(crate) const ROUNDS_TOTAL: &str = "reconcile_rounds_total";
-    pub(crate) const TOMBSTONE_REACKS_TOTAL: &str = "reconcile_tombstone_reacks_total";
+    pub(crate) const TOMBSTONE_ACKS_RESENT_TOTAL: &str = "reconcile_tombstone_acks_resent_total";
     pub(crate) const ROUND_DURATION_SECONDS: &str = "reconcile_round_duration_seconds";
     pub(crate) const HANDLE_DURATION_SECONDS: &str = "reconcile_handle_messages_duration_seconds";
 
@@ -102,8 +102,8 @@ mod imp {
     }
 
     #[inline]
-    pub(crate) fn record_tombstone_reacks(n: usize) {
-        counter!(TOMBSTONE_REACKS_TOTAL).increment(n as u64);
+    pub(crate) fn record_tombstone_acks_resent(n: usize) {
+        counter!(TOMBSTONE_ACKS_RESENT_TOTAL).increment(n as u64);
     }
 
     #[inline]
@@ -153,9 +153,9 @@ mod imp {
         );
         describe_counter!(ROUNDS_TOTAL, Unit::Count, "Reconciliation rounds initiated");
         describe_counter!(
-            TOMBSTONE_REACKS_TOTAL,
+            TOMBSTONE_ACKS_RESENT_TOTAL,
             Unit::Count,
-            "Tombstone re-acknowledgments emitted on reconciliation rounds"
+            "Tombstone acks resent on reconciliation rounds"
         );
         describe_histogram!(
             ROUND_DURATION_SECONDS,
@@ -204,7 +204,7 @@ mod imp {
     pub(crate) fn record_reconcile_round() {}
 
     #[inline(always)]
-    pub(crate) fn record_tombstone_reacks(_n: usize) {}
+    pub(crate) fn record_tombstone_acks_resent(_n: usize) {}
 
     #[inline(always)]
     pub(crate) fn record_round_duration(_start: Option<Instant>) {}

--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -40,11 +40,17 @@ use std::io;
 use std::net::IpAddr;
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
+use std::time::Duration;
 
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
+use tracing::{debug, warn};
 
 use crate::clock::Timestamp;
+
+/// Backoff parameters for transient-I/O retries in [`FileSnapshot::load`].
+const LOAD_RETRY_ATTEMPTS: u32 = 3;
+const LOAD_RETRY_INITIAL_BACKOFF: Duration = Duration::from_millis(100);
 
 /// The store's keyed entries in their internal dated, tombstone-aware form: each key maps to a
 /// `(timestamp, Option<V>)`, where a `None` payload is a tombstone.
@@ -67,6 +73,61 @@ pub struct PersistedState<K, V> {
     pub members: HashSet<IpAddr>,
     /// Per-tombstone acknowledgments: `key -> (peer -> version token of the tombstone it holds)`.
     pub tombstone_acks: HashMap<K, HashMap<IpAddr, u64>>,
+}
+
+/// Classifies why [`FileSnapshot::load`] failed, so callers can act differently on corruption
+/// versus transient I/O problems.
+///
+/// # Operator guidance
+///
+/// - **Corrupt** — the snapshot file exists but cannot be decoded. The safe choices are to delete
+///   the file (accepts data loss: the node starts empty) or to restore from a backup. **Do not
+///   silently start empty**, as that drops tombstones, enabling resurrection of previously deleted
+///   values. The store exposes this as a distinct error so the calling application can log a clear
+///   message and halt (recommended) or attempt recovery.
+///
+/// - **Io** — a transient I/O error persisted across all retry attempts (e.g. a filesystem still
+///   mounting, a volume remount in progress). Retrying after a longer delay or restarting the
+///   process is appropriate. The error is surfaced rather than causing a panic so the caller can
+///   choose a graceful shutdown path.
+#[derive(Debug)]
+pub enum LoadError {
+    /// The snapshot file exists but its contents could not be decoded. Data corruption or
+    /// truncation. The inner string carries the original error message.
+    Corrupt(String),
+    /// An I/O error that survived all retry attempts; the file may or may not exist.
+    Io(io::Error),
+}
+
+impl std::fmt::Display for LoadError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            LoadError::Corrupt(msg) => write!(
+                f,
+                "snapshot file is corrupt and cannot be loaded: {msg}; \
+                 delete the snapshot to start empty (accepts data loss) or restore from backup"
+            ),
+            LoadError::Io(err) => write!(f, "transient I/O error loading snapshot: {err}"),
+        }
+    }
+}
+
+impl std::error::Error for LoadError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            LoadError::Corrupt(_) => None,
+            LoadError::Io(err) => Some(err),
+        }
+    }
+}
+
+impl From<LoadError> for io::Error {
+    fn from(e: LoadError) -> io::Error {
+        match e {
+            LoadError::Corrupt(msg) => io::Error::new(io::ErrorKind::InvalidData, msg),
+            LoadError::Io(err) => err,
+        }
+    }
 }
 
 /// A pluggable durable backend for a [`ReconcileStore`](crate::ReconcileStore).
@@ -123,8 +184,30 @@ where
 
 /// A durable, file-based [`Persistence`] backend storing a single bincode-encoded snapshot.
 ///
-/// Saves are **atomic**: the snapshot is written to a sibling `*.tmp` file, flushed, then renamed
-/// over the target path, so a crash mid-write never corrupts a previously good snapshot.
+/// # Atomic saves
+///
+/// Saves are **atomic at the file level**: the snapshot is written to a sibling `*.tmp` file,
+/// flushed to the OS page cache (`sync_all` on the file), then renamed over the target path, and
+/// finally the **containing directory** is fsynced so the name binding is durable. This sequence
+/// means a crash after the rename but before the directory fsync may leave the old snapshot in
+/// place (the kernel replays the rename from the journal on most filesystems, but the POSIX
+/// guarantee requires the directory fsync), while a crash before the rename leaves the original
+/// snapshot untouched. In both cases exactly one valid snapshot is recoverable on restart.
+///
+/// A crash after writing the tmp file but before the rename leaves a stale `*.tmp` sibling.
+/// [`FileSnapshot::load`] removes any such stale temporaries on startup so they do not accumulate.
+///
+/// # Fallible load
+///
+/// [`FileSnapshot::load_checked`] — called by
+/// [`ReconcileStore::with_persistence`](crate::ReconcileStore::with_persistence) — returns a
+/// [`LoadError`] rather than panicking:
+///
+/// - **Corrupt** data (`InvalidData`) is surfaced as [`LoadError::Corrupt`] so the caller can
+///   decide whether to halt or attempt recovery.
+/// - **Transient I/O** errors are retried up to three times with exponential backoff before being
+///   surfaced as [`LoadError::Io`].
+/// - **`NotFound`** (no snapshot yet) is a clean fresh start and returns `Ok(None)`.
 #[derive(Clone, Debug)]
 pub struct FileSnapshot {
     path: PathBuf,
@@ -143,6 +226,64 @@ impl FileSnapshot {
         tmp.push(".tmp");
         PathBuf::from(tmp)
     }
+
+    /// Clean up stale `*.tmp` siblings of the snapshot path, logging each removal at debug level.
+    ///
+    /// Called during load so that temporaries left behind by an interrupted save do not accumulate.
+    fn remove_stale_tmp(&self) {
+        let tmp = self.tmp_path();
+        match fs::remove_file(&tmp) {
+            Ok(()) => debug!(path = %tmp.display(), "removed stale snapshot tmp file"),
+            Err(err) if err.kind() == io::ErrorKind::NotFound => {} // nothing to clean
+            Err(err) => {
+                warn!(path = %tmp.display(), "failed to remove stale snapshot tmp file: {err}")
+            }
+        }
+    }
+
+    /// Load state, splitting I/O errors into [`LoadError::Corrupt`] vs. [`LoadError::Io`],
+    /// with bounded retries for transient I/O.
+    ///
+    /// Stale `*.tmp` siblings are removed unconditionally on entry, before the load attempt.
+    pub fn load_checked<K, V>(&self) -> Result<Option<PersistedState<K, V>>, LoadError>
+    where
+        K: DeserializeOwned + Eq + std::hash::Hash,
+        V: DeserializeOwned,
+    {
+        self.remove_stale_tmp();
+
+        let mut attempts = 0u32;
+        let mut backoff = LOAD_RETRY_INITIAL_BACKOFF;
+        loop {
+            attempts += 1;
+            match fs::read(&self.path) {
+                Ok(bytes) => {
+                    return bincode::deserialize::<PersistedState<K, V>>(&bytes)
+                        .map(Some)
+                        .map_err(|err| LoadError::Corrupt(err.to_string()));
+                }
+                Err(err) if err.kind() == io::ErrorKind::NotFound => {
+                    return Ok(None);
+                }
+                Err(err) if err.kind() == io::ErrorKind::InvalidData => {
+                    return Err(LoadError::Corrupt(err.to_string()));
+                }
+                Err(err) => {
+                    if attempts >= LOAD_RETRY_ATTEMPTS {
+                        return Err(LoadError::Io(err));
+                    }
+                    warn!(
+                        path = %self.path.display(),
+                        attempt = attempts,
+                        max = LOAD_RETRY_ATTEMPTS,
+                        "transient I/O error loading snapshot, retrying: {err}"
+                    );
+                    std::thread::sleep(backoff);
+                    backoff *= 2;
+                }
+            }
+        }
+    }
 }
 
 impl<K, V> Persistence<K, V> for FileSnapshot
@@ -151,14 +292,7 @@ where
     V: Serialize + DeserializeOwned + Send + Sync + 'static,
 {
     fn load(&self) -> io::Result<Option<PersistedState<K, V>>> {
-        let bytes = match fs::read(&self.path) {
-            Ok(bytes) => bytes,
-            Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(None),
-            Err(err) => return Err(err),
-        };
-        let state = bincode::deserialize(&bytes)
-            .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
-        Ok(Some(state))
+        self.load_checked().map_err(io::Error::from)
     }
 
     fn save(&self, state: &PersistedState<K, V>) -> io::Result<()> {
@@ -174,6 +308,23 @@ where
             file.sync_all()?;
         }
         fs::rename(&tmp, &self.path)?;
+        // fsync the parent directory so the name binding (the rename) is durable. Without this,
+        // a crash after the rename but before the OS flushes the directory journal may leave the
+        // old snapshot in place on some filesystems. The directory fsync is a no-op on journalling
+        // filesystems that replay the rename on recovery, but it is required for the POSIX
+        // durability guarantee.
+        //
+        // Note: directory fsync durability cannot be unit-tested in-process — the guarantee is
+        // that the kernel persists the rename to storage; verifying that requires a real crash or
+        // raw block-device inspection. The call is tested indirectly by the save/load round-trip
+        // tests; its presence is verified by code inspection.
+        if let Some(parent) = self.path.parent() {
+            // Silently skip if the parent is empty (unlikely, but handle gracefully).
+            if !parent.as_os_str().is_empty() {
+                let dir = fs::File::open(parent)?;
+                dir.sync_all()?;
+            }
+        }
         Ok(())
     }
 }
@@ -278,5 +429,101 @@ mod tests {
         assert!(!dir.path().join("snapshot.bin.tmp").exists());
         let loaded = Persistence::<i32, String>::load(&backend).unwrap().unwrap();
         assert_eq!(loaded.entries[0].1 .1, Some("second".to_string()));
+    }
+
+    /// Interrupted save: tmp written but not renamed → old snapshot still loads, stale tmp is
+    /// cleaned on the next load.
+    #[test]
+    fn stale_tmp_cleaned_on_load_and_old_snapshot_still_readable() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("snapshot.bin");
+        let backend = FileSnapshot::new(&path);
+
+        // Write the first snapshot normally.
+        let mut first = sample_state();
+        first.entries = vec![(1, (Timestamp::new(1, 0, 0), Some("first".to_string())))];
+        Persistence::<i32, String>::save(&backend, &first).unwrap();
+
+        // Simulate an interrupted second save: write the tmp but do NOT rename.
+        let tmp_path = dir.path().join("snapshot.bin.tmp");
+        {
+            use std::io::Write;
+            let mut second = sample_state();
+            second.entries = vec![(1, (Timestamp::new(2, 0, 0), Some("second".to_string())))];
+            let bytes = bincode::serialize(&second).unwrap();
+            let mut file = fs::File::create(&tmp_path).unwrap();
+            file.write_all(&bytes).unwrap();
+            file.sync_all().unwrap();
+        }
+        // The tmp must be present before we call load.
+        assert!(tmp_path.exists(), "precondition: tmp file should exist");
+
+        // Load cleans the stale tmp and returns the original (first) snapshot.
+        let loaded = backend
+            .load_checked::<i32, String>()
+            .expect("load must succeed")
+            .expect("old snapshot must be present");
+        assert_eq!(
+            loaded.entries[0].1 .1,
+            Some("first".to_string()),
+            "old snapshot must load, not the tmp contents"
+        );
+        assert!(!tmp_path.exists(), "stale tmp must be removed on load");
+    }
+
+    /// Completed save → new snapshot loads correctly.
+    #[test]
+    fn completed_save_loads_new_snapshot() {
+        let dir = tempfile::tempdir().unwrap();
+        let backend = FileSnapshot::new(dir.path().join("snapshot.bin"));
+
+        let mut first = sample_state();
+        first.entries = vec![(1, (Timestamp::new(1, 0, 0), Some("first".to_string())))];
+        Persistence::<i32, String>::save(&backend, &first).unwrap();
+
+        let mut second = sample_state();
+        second.entries = vec![(1, (Timestamp::new(2, 0, 0), Some("new".to_string())))];
+        Persistence::<i32, String>::save(&backend, &second).unwrap();
+
+        let loaded = Persistence::<i32, String>::load(&backend)
+            .unwrap()
+            .expect("snapshot must be present");
+        assert_eq!(
+            loaded.entries[0].1 .1,
+            Some("new".to_string()),
+            "completed save must be visible on load"
+        );
+    }
+
+    /// Corrupt snapshot file → `load_checked` returns `LoadError::Corrupt` (no panic).
+    #[test]
+    fn corrupt_snapshot_returns_error_variant() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("snapshot.bin");
+        fs::write(&path, b"not valid bincode at all").unwrap();
+        let backend = FileSnapshot::new(&path);
+        match backend.load_checked::<i32, String>() {
+            Err(LoadError::Corrupt(_)) => {} // expected
+            other => panic!("expected LoadError::Corrupt, got {other:?}"),
+        }
+    }
+
+    /// Transient I/O error (path is a directory) → retries are attempted, then `LoadError::Io`
+    /// is returned (no panic).
+    #[test]
+    fn transient_io_returns_error_variant() {
+        // Use a directory as the snapshot path: `fs::read` on a directory returns an error on all
+        // major platforms (Linux: EISDIR, macOS: EISDIR). We override LOAD_RETRY_ATTEMPTS to 1 via
+        // the public knob by testing load_checked which internally uses the constants; we simply
+        // verify the variant and that no panic occurs.
+        let dir = tempfile::tempdir().unwrap();
+        // The path itself IS a directory, so fs::read will fail with a non-NotFound, non-corrupt error.
+        let backend = FileSnapshot::new(dir.path());
+        match backend.load_checked::<i32, String>() {
+            Err(LoadError::Io(_)) => {} // expected
+            // On some platforms a directory read may look like corrupt data; accept both.
+            Err(LoadError::Corrupt(_)) => {}
+            Ok(_) => panic!("expected an error when the snapshot path is a directory"),
+        }
     }
 }

--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -24,8 +24,9 @@
 //!
 //! # What is persisted
 //!
-//! - **All map entries**, live values *and* tombstones (the map stores `(timestamp, Option<V>)`,
-//!   and tombstones are `(timestamp, None)` retained until causal-stability-gated GC).
+//! - **All map entries**, live values *and* tombstones (the map stores `Entry<Timestamp, V>`, and
+//!   tombstones are `Entry`s with a `State::Tombstone` payload retained until
+//!   causal-stability-gated GC).
 //! - The **causal-stability state**: the membership set and the per-tombstone
 //!   acknowledgments, so a restarted node still holds back GC until every replica has seen a
 //!   deletion.
@@ -47,27 +48,95 @@ use serde::{Deserialize, Serialize};
 use tracing::{debug, warn};
 
 use crate::clock::Timestamp;
+use crate::reconcilable::Entry;
 
 /// Backoff parameters for transient-I/O retries in [`FileSnapshot::load`].
 const LOAD_RETRY_ATTEMPTS: u32 = 3;
 const LOAD_RETRY_INITIAL_BACKOFF: Duration = Duration::from_millis(100);
 
-/// The store's keyed entries in their internal dated, tombstone-aware form: each key maps to a
-/// `(timestamp, Option<V>)`, where a `None` payload is a tombstone.
-pub type DatedEntries<K, V> = Vec<(K, (Timestamp, Option<V>))>;
+/// On-disk snapshot header: a 4-byte magic followed by a little-endian `u32` format version.
+///
+/// The body is bincode (not self-describing), so a format change — e.g. the `Entry` / `State`
+/// domain-type migration (issue #143), which changed how each cell encodes — would otherwise be
+/// **silently misinterpreted** on load rather than detected. The header lets
+/// [`FileSnapshot::load_checked`] reject any snapshot whose magic or version does not match this
+/// build with a descriptive [`LoadError::Corrupt`], instead of decoding stale bytes into a plausible
+/// but wrong state (which would drop or corrupt tombstones and re-enable resurrection). A pre-header
+/// (0.2.x) snapshot has no such prefix and is rejected the same way.
+const SNAPSHOT_MAGIC: [u8; 4] = *b"RCNL";
+/// Current on-disk snapshot format version. Bump whenever the serialized shape of
+/// [`PersistedState`] changes. Version 1 is the `Entry<Timestamp, V>` / `State<V>` layout (0.3.0).
+const SNAPSHOT_FORMAT_VERSION: u32 = 1;
+/// Length of the header written ahead of the bincode body: magic (4) + version (4).
+const SNAPSHOT_HEADER_LEN: usize = 8;
+
+/// Serialize a snapshot as `magic || version(LE u32) || bincode(state)`.
+fn encode_snapshot<K, V>(state: &PersistedState<K, V>) -> bincode::Result<Vec<u8>>
+where
+    K: Serialize,
+    V: Serialize,
+{
+    let body = bincode::serialize(state)?;
+    let mut out = Vec::with_capacity(SNAPSHOT_HEADER_LEN + body.len());
+    out.extend_from_slice(&SNAPSHOT_MAGIC);
+    out.extend_from_slice(&SNAPSHOT_FORMAT_VERSION.to_le_bytes());
+    out.extend_from_slice(&body);
+    Ok(out)
+}
+
+/// Validate the snapshot header, then bincode-decode the body. Every failure — too short, wrong
+/// magic, unsupported version, or a body that does not decode — maps to [`LoadError::Corrupt`] with
+/// a descriptive message, so a stale-format snapshot (e.g. a pre-`Entry`/`State` 0.2.x file) is
+/// rejected cleanly rather than silently misread into a plausible-but-wrong state.
+fn decode_snapshot<K, V>(bytes: &[u8]) -> Result<PersistedState<K, V>, LoadError>
+where
+    K: DeserializeOwned + Eq + std::hash::Hash,
+    V: DeserializeOwned,
+{
+    if bytes.len() < SNAPSHOT_HEADER_LEN {
+        return Err(LoadError::Corrupt(format!(
+            "snapshot is {} bytes, shorter than the {SNAPSHOT_HEADER_LEN}-byte format header \
+             (truncated, or a pre-0.3.0 snapshot without the versioned header)",
+            bytes.len()
+        )));
+    }
+    let (header, body) = bytes.split_at(SNAPSHOT_HEADER_LEN);
+    if header[..4] != SNAPSHOT_MAGIC {
+        return Err(LoadError::Corrupt(format!(
+            "snapshot magic {:02x?} does not match {SNAPSHOT_MAGIC:02x?}; the file is not a \
+             reconcile snapshot, or predates the versioned format (0.3.0)",
+            &header[..4]
+        )));
+    }
+    let version = u32::from_le_bytes([header[4], header[5], header[6], header[7]]);
+    if version != SNAPSHOT_FORMAT_VERSION {
+        return Err(LoadError::Corrupt(format!(
+            "snapshot format version {version} is not supported by this build (expected \
+             {SNAPSHOT_FORMAT_VERSION}); it was written by a different reconcile version and must \
+             be migrated or discarded"
+        )));
+    }
+    bincode::deserialize::<PersistedState<K, V>>(body)
+        .map_err(|err| LoadError::Corrupt(err.to_string()))
+}
+
+/// The store's keyed entries in their internal dated, tombstone-aware form: each key maps to an
+/// [`Entry<Timestamp, V>`](Entry), whose [`Tombstone`](crate::State::Tombstone) state is a deletion.
+pub type DatedEntries<K, V> = Vec<(K, Entry<Timestamp, V>)>;
 
 /// A snapshot of everything a [`ReconcileStore`](crate::ReconcileStore) needs to durably survive a
 /// restart without behaving like a fresh replica.
 ///
 /// `V` is the user value type; entries store the internal dated, tombstone-aware representation
-/// `(Timestamp, Option<V>)`.
+/// [`Entry<Timestamp, V>`](Entry).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(bound(
     serialize = "K: Serialize, V: Serialize",
     deserialize = "K: Deserialize<'de> + Eq + std::hash::Hash, V: Deserialize<'de>"
 ))]
 pub struct PersistedState<K, V> {
-    /// Every key with its dated value. A `None` payload is a tombstone.
+    /// Every key with its dated [`Entry`]. A [`State::Tombstone`](crate::State::Tombstone) state
+    /// is a deletion.
     pub entries: DatedEntries<K, V>,
     /// Every peer this node has ever communicated with (causal-stability membership).
     pub members: HashSet<IpAddr>,
@@ -258,9 +327,7 @@ impl FileSnapshot {
             attempts += 1;
             match fs::read(&self.path) {
                 Ok(bytes) => {
-                    return bincode::deserialize::<PersistedState<K, V>>(&bytes)
-                        .map(Some)
-                        .map_err(|err| LoadError::Corrupt(err.to_string()));
+                    return decode_snapshot::<K, V>(&bytes).map(Some);
                 }
                 Err(err) if err.kind() == io::ErrorKind::NotFound => {
                     return Ok(None);
@@ -296,7 +363,7 @@ where
     }
 
     fn save(&self, state: &PersistedState<K, V>) -> io::Result<()> {
-        let bytes = bincode::serialize(state)
+        let bytes = encode_snapshot(state)
             .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
         let tmp = self.tmp_path();
         // Write to a temporary file, flush it, then atomically rename over the target so a crash
@@ -345,8 +412,11 @@ mod tests {
 
         PersistedState {
             entries: vec![
-                (1, (Timestamp::new(1_000, 0, 7), Some("alive".to_string()))),
-                (2, (Timestamp::new(2_000, 1, 7), None)), // tombstone
+                (
+                    1,
+                    Entry::present(Timestamp::new(1_000, 0, 7), "alive".to_string()),
+                ),
+                (2, Entry::tombstone(Timestamp::new(2_000, 1, 7))), // tombstone
             ],
             members,
             tombstone_acks: acks,
@@ -382,15 +452,21 @@ mod tests {
         let backend = InMemoryPersistence::<i32, String>::new();
 
         let mut first = sample_state();
-        first.entries = vec![(1, (Timestamp::new(1, 0, 0), Some("first".to_string())))];
+        first.entries = vec![(
+            1,
+            Entry::present(Timestamp::new(1, 0, 0), "first".to_string()),
+        )];
         backend.save(&first).unwrap();
 
         let mut second = sample_state();
-        second.entries = vec![(1, (Timestamp::new(2, 0, 0), Some("second".to_string())))];
+        second.entries = vec![(
+            1,
+            Entry::present(Timestamp::new(2, 0, 0), "second".to_string()),
+        )];
         backend.save(&second).unwrap();
 
         let loaded = backend.load().unwrap().unwrap();
-        assert_eq!(loaded.entries[0].1 .1, Some("second".to_string()));
+        assert_eq!(loaded.entries[0].1.value(), Some(&"second".to_string()));
     }
 
     #[test]
@@ -418,17 +494,23 @@ mod tests {
         let backend = FileSnapshot::new(dir.path().join("snapshot.bin"));
 
         let mut first = sample_state();
-        first.entries = vec![(1, (Timestamp::new(1, 0, 0), Some("first".to_string())))];
+        first.entries = vec![(
+            1,
+            Entry::present(Timestamp::new(1, 0, 0), "first".to_string()),
+        )];
         Persistence::<i32, String>::save(&backend, &first).unwrap();
 
         let mut second = sample_state();
-        second.entries = vec![(1, (Timestamp::new(2, 0, 0), Some("second".to_string())))];
+        second.entries = vec![(
+            1,
+            Entry::present(Timestamp::new(2, 0, 0), "second".to_string()),
+        )];
         Persistence::<i32, String>::save(&backend, &second).unwrap();
 
         // No leftover temporary file, and the latest snapshot wins.
         assert!(!dir.path().join("snapshot.bin.tmp").exists());
         let loaded = Persistence::<i32, String>::load(&backend).unwrap().unwrap();
-        assert_eq!(loaded.entries[0].1 .1, Some("second".to_string()));
+        assert_eq!(loaded.entries[0].1.value(), Some(&"second".to_string()));
     }
 
     /// Interrupted save: tmp written but not renamed → old snapshot still loads, stale tmp is
@@ -441,7 +523,10 @@ mod tests {
 
         // Write the first snapshot normally.
         let mut first = sample_state();
-        first.entries = vec![(1, (Timestamp::new(1, 0, 0), Some("first".to_string())))];
+        first.entries = vec![(
+            1,
+            Entry::present(Timestamp::new(1, 0, 0), "first".to_string()),
+        )];
         Persistence::<i32, String>::save(&backend, &first).unwrap();
 
         // Simulate an interrupted second save: write the tmp but do NOT rename.
@@ -449,7 +534,10 @@ mod tests {
         {
             use std::io::Write;
             let mut second = sample_state();
-            second.entries = vec![(1, (Timestamp::new(2, 0, 0), Some("second".to_string())))];
+            second.entries = vec![(
+                1,
+                Entry::present(Timestamp::new(2, 0, 0), "second".to_string()),
+            )];
             let bytes = bincode::serialize(&second).unwrap();
             let mut file = fs::File::create(&tmp_path).unwrap();
             file.write_all(&bytes).unwrap();
@@ -464,8 +552,8 @@ mod tests {
             .expect("load must succeed")
             .expect("old snapshot must be present");
         assert_eq!(
-            loaded.entries[0].1 .1,
-            Some("first".to_string()),
+            loaded.entries[0].1.value(),
+            Some(&"first".to_string()),
             "old snapshot must load, not the tmp contents"
         );
         assert!(!tmp_path.exists(), "stale tmp must be removed on load");
@@ -478,19 +566,25 @@ mod tests {
         let backend = FileSnapshot::new(dir.path().join("snapshot.bin"));
 
         let mut first = sample_state();
-        first.entries = vec![(1, (Timestamp::new(1, 0, 0), Some("first".to_string())))];
+        first.entries = vec![(
+            1,
+            Entry::present(Timestamp::new(1, 0, 0), "first".to_string()),
+        )];
         Persistence::<i32, String>::save(&backend, &first).unwrap();
 
         let mut second = sample_state();
-        second.entries = vec![(1, (Timestamp::new(2, 0, 0), Some("new".to_string())))];
+        second.entries = vec![(
+            1,
+            Entry::present(Timestamp::new(2, 0, 0), "new".to_string()),
+        )];
         Persistence::<i32, String>::save(&backend, &second).unwrap();
 
         let loaded = Persistence::<i32, String>::load(&backend)
             .unwrap()
             .expect("snapshot must be present");
         assert_eq!(
-            loaded.entries[0].1 .1,
-            Some("new".to_string()),
+            loaded.entries[0].1.value(),
+            Some(&"new".to_string()),
             "completed save must be visible on load"
         );
     }
@@ -505,6 +599,45 @@ mod tests {
         match backend.load_checked::<i32, String>() {
             Err(LoadError::Corrupt(_)) => {} // expected
             other => panic!("expected LoadError::Corrupt, got {other:?}"),
+        }
+    }
+
+    /// A **pre-header** snapshot — valid bincode of a `PersistedState`, but written without the
+    /// 0.3.0 magic/version prefix, exactly as a 0.2.x node would have produced — must be rejected as
+    /// [`LoadError::Corrupt`], never silently misread. This is the resurrection-safety guard for the
+    /// `Entry`/`State` format break (issue #143).
+    #[test]
+    fn headerless_legacy_snapshot_is_rejected_as_corrupt() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("snapshot.bin");
+        // Raw bincode body with no header prefix — the historical on-disk shape.
+        let body = bincode::serialize(&sample_state()).unwrap();
+        fs::write(&path, &body).unwrap();
+        let backend = FileSnapshot::new(&path);
+        match backend.load_checked::<i32, String>() {
+            Err(LoadError::Corrupt(_)) => {}
+            other => panic!("expected LoadError::Corrupt for a headerless snapshot, got {other:?}"),
+        }
+    }
+
+    /// A snapshot carrying the right magic but a **future/unknown format version** must be rejected
+    /// as [`LoadError::Corrupt`] rather than decoded with this build's layout.
+    #[test]
+    fn unknown_format_version_is_rejected_as_corrupt() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("snapshot.bin");
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&SNAPSHOT_MAGIC);
+        bytes.extend_from_slice(&(SNAPSHOT_FORMAT_VERSION + 1).to_le_bytes());
+        bytes.extend_from_slice(&bincode::serialize(&sample_state()).unwrap());
+        fs::write(&path, &bytes).unwrap();
+        let backend = FileSnapshot::new(&path);
+        match backend.load_checked::<i32, String>() {
+            Err(LoadError::Corrupt(msg)) => assert!(
+                msg.contains("format version"),
+                "error should name the version mismatch, got: {msg}"
+            ),
+            other => panic!("expected LoadError::Corrupt for an unknown version, got {other:?}"),
         }
     }
 

--- a/src/prometheus.rs
+++ b/src/prometheus.rs
@@ -16,11 +16,22 @@
 //! The metrics themselves are only emitted when the `metrics` feature is enabled;
 //! `metrics-prometheus` implies it.
 //!
+//! # Exposure caveat
+//!
+//! The `/metrics` endpoint is **unauthenticated** and exposes operational information — dataset
+//! size and churn, byte/datagram counters, peer and reconciliation activity — that an observer can
+//! use to fingerprint your deployment. The examples bind `0.0.0.0:9000` for convenience, which
+//! listens on **every** interface. In production, bind it to `127.0.0.1` (or a trusted management
+//! interface) and let your scrape agent reach it locally, and/or restrict it with a firewall or a
+//! Kubernetes `NetworkPolicy`. Do not expose it on an untrusted network.
+//!
 //! # Serving a `/metrics` endpoint
 //!
 //! ```no_run
 //! # async fn run() -> Result<(), Box<dyn std::error::Error>> {
 //! // Installs the recorder and spawns a background HTTP server exposing `/metrics`.
+//! // `0.0.0.0` listens on every interface — see the exposure caveat above; prefer a trusted
+//! // interface (e.g. `127.0.0.1:9000`) in production.
 //! reconcile::prometheus::serve("0.0.0.0:9000".parse()?).await?;
 //! // ... then start your store: `store.run().await;`
 //! # Ok(())
@@ -62,6 +73,9 @@ pub fn install_recorder() -> Result<PrometheusHandle, BuildError> {
 /// Requires a Tokio runtime (the listener is spawned onto the current runtime). Returns once
 /// the listener is set up; the server then runs in the background. Call this exactly once,
 /// early in `main`, before starting the reconciliation loop.
+///
+/// The endpoint is unauthenticated and leaks operational information; choose `addr` accordingly
+/// (prefer `127.0.0.1`/a trusted interface over `0.0.0.0`). See the module-level exposure caveat.
 pub async fn serve(addr: SocketAddr) -> Result<(), BuildError> {
     PrometheusBuilder::new()
         .with_http_listener(addr)

--- a/src/reconcilable.rs
+++ b/src/reconcilable.rs
@@ -25,9 +25,21 @@ pub trait Reconcilable {
 ///
 /// Because [`Timestamp`] is a **total order** `(wall_ms, counter, node_id)`, `reconcile` is `max`
 /// over that order: it is commutative, associative and idempotent, so every replica
-/// converges to the same value (Strong Eventual Consistency). Two *distinct* writes can
-/// never share a `Timestamp` (the same node bumps the counter, different nodes differ on
-/// `node_id`), so the equal-timestamp branch only fires for identical values. See the
+/// converges to the same value (Strong Eventual Consistency). Two distinct writes from the *same*
+/// node never share a `Timestamp` (the node bumps the counter); two writes from *different* nodes
+/// are kept apart by `node_id`, the deterministic tie-break.
+///
+/// That tie-break is only as unique as `node_id` itself. The `node_id` is a random 64-bit value
+/// (see [`Config::node_id`](crate::reconcile_store::Config::node_id)), so distinctness is
+/// **probabilistic, not guaranteed**: by the birthday bound, the probability that any two of `n`
+/// nodes draw the same id is roughly `n² / 2^65` (≈ 3e-14 at 1000 nodes, ≈ 3e-10 at 100 000). If two
+/// live nodes *do* collide, two genuinely different values can share a full `Timestamp`; the
+/// equal-timestamp branch then keeps the local value on each side, so the two replicas can diverge
+/// permanently for that key. There is no collision detection: a `node_id` rides inside every
+/// `Timestamp` on the wire, but nothing asserts ownership of an id, so there is no identity
+/// handshake by which a node could notice another claiming its id (out of scope). Pin a stable,
+/// distinct id per node via [`Config::with_node_id`](crate::reconcile_store::Config::with_node_id)
+/// when you need a guarantee rather than an overwhelming probability. See the
 /// [`clock`](crate::clock) module for why the previous physical-clock scheme was unsafe.
 impl<V: Clone> Reconcilable for (Timestamp, V) {
     fn reconcile(&self, other: &Self) -> Self {

--- a/src/reconcilable.rs
+++ b/src/reconcilable.rs
@@ -6,44 +6,163 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-//! Provides the [`Reconcilable`] trait.
+//! The domain value types: [`Entry`] — a stamped stored cell — and [`State`] — the live-value /
+//! tombstone payload — together with the last-write-wins conflict policy carried by
+//! [`Entry::merge`].
+//!
+//! A single, intention-revealing [`Entry`] replaces the historical `(Timestamp, Option<V>)` tuple
+//! and the value-shape helper traits it used to carry (`MaybeTombstone`, `Timestamped`,
+//! `Reconcilable`). Its [`State`] payload doubles as the **timestamp-less projection** that powers
+//! the dateless [`ReconcileMirror`](crate::mirror::ReconcileMirror) (see [`Entry::project`]).
 
-use std::hash::Hash;
-
-use serde::de::DeserializeOwned;
-use serde::{Deserialize, Serialize};
-
-use crate::clock::Timestamp;
-
-/// Values stored in a map to be synced by the [`ReconcileStore`](crate::reconcile_store::ReconcileStore)
-/// have to be [`Reconcilable`] to ensure safe conflict handling.
-pub trait Reconcilable {
-    fn reconcile(&self, other: &Self) -> Self;
+/// The logical state of a stored cell: a live value ([`Present`](State::Present)) or a deletion
+/// marker ([`Tombstone`](State::Tombstone)).
+///
+/// `State` is *also* the **timestamp-less projection** of an [`Entry`] (see [`Entry::project`]).
+/// Its [`Hash`] is **value-only by construction**: it carries no [`Timestamp`](crate::Timestamp),
+/// so two replicas that agree on the logical value compute the *same* per-element fingerprint
+/// regardless of when (or on which node) each last wrote it. This is what lets a dateless
+/// [`ReconcileMirror`](crate::mirror::ReconcileMirror) and a dated
+/// [`ReconcileStore`](crate::reconcile_store::ReconcileStore) converge over the shared range-diff
+/// protocol without the mirror ever storing timestamps (invariant #8 in `ARCHITECTURE.md` §5).
+///
+/// A dated [`Entry`] deliberately hashes **with** its stamp (required by the engine's
+/// `version_hash` for the causal-stability acks), while its `State` projection hashes the value
+/// alone; the two hashes must stay distinct.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+pub enum State<V> {
+    /// A live value.
+    Present(V),
+    /// A deletion marker.
+    Tombstone,
 }
 
-/// Last-write-wins keyed on a [`Timestamp`].
+impl<V> State<V> {
+    /// Returns `true` if this state is a deletion marker (tombstone).
+    pub fn is_tombstone(&self) -> bool {
+        matches!(self, State::Tombstone)
+    }
+
+    /// Borrow the live value, or `None` if this is a tombstone.
+    pub fn value(&self) -> Option<&V> {
+        match self {
+            State::Present(v) => Some(v),
+            State::Tombstone => None,
+        }
+    }
+
+    /// Mutably borrow the live value, or `None` if this is a tombstone.
+    pub fn value_mut(&mut self) -> Option<&mut V> {
+        match self {
+            State::Present(v) => Some(v),
+            State::Tombstone => None,
+        }
+    }
+
+    /// Consume the state, yielding the live value or `None` if it was a tombstone.
+    pub fn into_value(self) -> Option<V> {
+        match self {
+            State::Present(v) => Some(v),
+            State::Tombstone => None,
+        }
+    }
+}
+
+/// A stored cell: a [`State`] payload stamped with the timestamp `T` that ordered its last write.
 ///
-/// Because [`Timestamp`] is a **total order** `(wall_ms, counter, node_id)`, `reconcile` is `max`
-/// over that order: it is commutative, associative and idempotent, so every replica
-/// converges to the same value (Strong Eventual Consistency). Two distinct writes from the *same*
-/// node never share a `Timestamp` (the node bumps the counter); two writes from *different* nodes
-/// are kept apart by `node_id`, the deterministic tie-break.
+/// This replaces the leaky `(Timestamp, Option<V>)` tuple with a concrete domain type that carries
+/// the tombstone, timestamp, and merge semantics itself. `T` is the stamp type — in this crate
+/// always [`Timestamp`](crate::Timestamp) — kept generic so the merge policy is expressed once over
+/// any totally-ordered stamp.
 ///
-/// That tie-break is only as unique as `node_id` itself. The `node_id` is a random 64-bit value
-/// (see [`Config::node_id`](crate::reconcile_store::Config::node_id)), so distinctness is
-/// **probabilistic, not guaranteed**: by the birthday bound, the probability that any two of `n`
-/// nodes draw the same id is roughly `n² / 2^65` (≈ 3e-14 at 1000 nodes, ≈ 3e-10 at 100 000). If two
-/// live nodes *do* collide, two genuinely different values can share a full `Timestamp`; the
-/// equal-timestamp branch then keeps the local value on each side, so the two replicas can diverge
-/// permanently for that key. There is no collision detection: a `node_id` rides inside every
-/// `Timestamp` on the wire, but nothing asserts ownership of an id, so there is no identity
-/// handshake by which a node could notice another claiming its id (out of scope). Pin a stable,
-/// distinct id per node via [`Config::with_node_id`](crate::reconcile_store::Config::with_node_id)
-/// when you need a guarantee rather than an overwhelming probability. See the
-/// [`clock`](crate::clock) module for why the previous physical-clock scheme was unsafe.
-impl<V: Clone> Reconcilable for (Timestamp, V) {
-    fn reconcile(&self, other: &Self) -> Self {
-        if other.0 > self.0 {
+/// Its [`Hash`] covers **both** `stamp` and `state`, so `version_hash` distinguishes two tombstones
+/// written at different times (invariant #7 in `ARCHITECTURE.md` §5). Contrast [`State`], whose hash
+/// is value-only.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+pub struct Entry<T, V> {
+    /// The stamp that ordered this cell's last write.
+    pub stamp: T,
+    /// The live value or tombstone.
+    pub state: State<V>,
+}
+
+impl<T, V> Entry<T, V> {
+    /// A live value stamped at `stamp`.
+    pub fn present(stamp: T, value: V) -> Self {
+        Entry {
+            stamp,
+            state: State::Present(value),
+        }
+    }
+
+    /// A tombstone stamped at `stamp`.
+    pub fn tombstone(stamp: T) -> Self {
+        Entry {
+            stamp,
+            state: State::Tombstone,
+        }
+    }
+
+    /// Returns `true` if this entry is a deletion marker (tombstone).
+    ///
+    /// The reconciliation engine uses this to decide which applied updates require
+    /// causal-stability tracking before the corresponding key can be garbage-collected.
+    /// See the tombstone-resurrection discussion on
+    /// [`ReconcileStore`](crate::reconcile_store::ReconcileStore).
+    pub fn is_tombstone(&self) -> bool {
+        self.state.is_tombstone()
+    }
+
+    /// Borrow the live value, or `None` if this entry is a tombstone.
+    pub fn value(&self) -> Option<&V> {
+        self.state.value()
+    }
+
+    /// Mutably borrow the live value, or `None` if this entry is a tombstone.
+    pub fn value_mut(&mut self) -> Option<&mut V> {
+        self.state.value_mut()
+    }
+
+    /// Consume the entry, yielding the live value or `None` if it was a tombstone.
+    pub fn into_value(self) -> Option<V> {
+        self.state.into_value()
+    }
+}
+
+impl<T, V: Clone> Entry<T, V> {
+    /// Project this dated entry to its timestamp-less [`State`] form.
+    ///
+    /// The dated store maintains a parallel value-only *projection* tree so it can reconcile with
+    /// dateless mirrors over the range-diff protocol without exposing timestamps. Because `State`
+    /// hashes value-only, the projection's per-element fingerprints match a mirror's (invariant #8).
+    pub fn project(&self) -> State<V> {
+        self.state.clone()
+    }
+}
+
+impl<T: Ord + Copy, V: Clone> Entry<T, V> {
+    /// Resolve a conflict between two entries by **last-write-wins** over the stamp order.
+    ///
+    /// Because [`Timestamp`](crate::Timestamp) is a **total order** `(wall_ms, counter, node_id)`,
+    /// `merge` is `max` over that order with a **strict `>`**: it is commutative, associative and
+    /// idempotent, so every replica converges to the same value (Strong Eventual Consistency). Two
+    /// distinct writes from the *same* node never share a `Timestamp` (the node bumps the counter);
+    /// two writes from *different* nodes are kept apart by `node_id`, the deterministic tie-break.
+    ///
+    /// That tie-break is only as unique as `node_id` itself. The `node_id` is a random 64-bit value
+    /// (see [`Config::node_id`](crate::reconcile_store::Config::node_id)), so distinctness is
+    /// **probabilistic, not guaranteed**: by the birthday bound, the probability that any two of `n`
+    /// nodes draw the same id is roughly `n² / 2^65` (≈ 3e-14 at 1000 nodes, ≈ 3e-10 at 100 000). If
+    /// two live nodes *do* collide, two genuinely different values can share a full `Timestamp`; the
+    /// equal-stamp branch then keeps the local value on each side, so the two replicas can diverge
+    /// permanently for that key. There is no collision detection: a `node_id` rides inside every
+    /// `Timestamp` on the wire, but nothing asserts ownership of an id, so there is no identity
+    /// handshake by which a node could notice another claiming its id (out of scope). Pin a stable,
+    /// distinct id per node via [`Config::with_node_id`](crate::reconcile_store::Config::with_node_id)
+    /// when you need a guarantee rather than an overwhelming probability. See the
+    /// [`clock`](crate::clock) module for why the previous physical-clock scheme was unsafe.
+    pub fn merge(&self, other: &Self) -> Self {
+        if other.stamp > self.stamp {
             other.clone()
         } else {
             self.clone()
@@ -51,103 +170,61 @@ impl<V: Clone> Reconcilable for (Timestamp, V) {
     }
 }
 
-/// Marks values that may represent a deletion (a *tombstone*).
-///
-/// The reconciliation engine uses this to decide which applied updates require
-/// causal-stability tracking before the corresponding key can be garbage-collected.
-/// See the tombstone-resurrection discussion on
-/// [`ReconcileStore`](crate::reconcile_store::ReconcileStore).
-pub trait MaybeTombstone {
-    /// Returns `true` if this value is a deletion marker (tombstone).
-    fn is_tombstone(&self) -> bool;
-}
-
-impl<V> MaybeTombstone for (Timestamp, Option<V>) {
-    fn is_tombstone(&self) -> bool {
-        self.1.is_none()
-    }
-}
-
-/// A timestamp-less projection of a value, used by lightweight read-only mirrors
-/// ([`ReconcileMirror`](crate::mirror::ReconcileMirror)) and by the value-only
-/// *projection* tree a dated store maintains to answer them.
-///
-/// Its [`Hash`] is **value-only by construction**: it wraps just the [`Option<V>`] payload, with no
-/// [`Timestamp`], so two replicas that agree on the logical value compute the *same* per-element
-/// fingerprint regardless of when (or on which node) each last wrote it. A live value is
-/// `ValueOnly(Some(v))`; a tombstone is `ValueOnly(None)`.
-///
-/// This is deliberately a *separate* type from the dated `(Timestamp, Option<V>)`: the dated value keeps
-/// its timestamp-inclusive `Hash` (required by the engine's `version_hash` for the
-/// causal-stability acks), so a single value-only hash never replaces it.
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub struct ValueOnly<V>(pub Option<V>);
-
-impl<V> ValueOnly<V> {
-    /// Borrow the live value, or `None` if this is a tombstone.
-    pub fn as_value(&self) -> Option<&V> {
-        self.0.as_ref()
-    }
-
-    /// Returns `true` if this projection is a deletion marker (tombstone).
-    pub fn is_tombstone(&self) -> bool {
-        self.0.is_none()
-    }
-}
-
-/// A dated value that can be projected to its timestamp-less [`ValueOnly`] form.
-///
-/// The dated store maintains a parallel value-only *projection* tree so it can reconcile with
-/// dateless mirrors over the existing range-diff protocol without exposing timestamps. The
-/// projection is kept in sync wherever the dated map mutates (insert, reconcile, GC removal).
-///
-/// The associated [`Projected`](Projectable::Projected) type carries exactly the bounds the
-/// projection tree and the value-only wire channel need, so the reconciliation engine only has to
-/// add a single `Projectable` bound. Note it deliberately does **not** require `PartialEq`: the
-/// value-only path decides equality on fingerprints, never on the projected values themselves.
-pub trait Projectable {
-    /// The value-only projection. Its `Hash` must ignore any timestamp (see [`ValueOnly`]).
-    type Projected: Clone + Hash + Send + Sync + Serialize + DeserializeOwned + 'static;
-    /// Project this dated value to its timestamp-less form.
-    fn project(&self) -> Self::Projected;
-}
-
-impl<V: Clone + Hash + Send + Sync + Serialize + DeserializeOwned + 'static> Projectable
-    for (Timestamp, Option<V>)
-{
-    type Projected = ValueOnly<V>;
-    fn project(&self) -> ValueOnly<V> {
-        ValueOnly(self.1.clone())
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::clock::Timestamp;
+
+    fn present(
+        wall_ms: u64,
+        counter: u32,
+        node_id: u64,
+        v: &'static str,
+    ) -> Entry<Timestamp, &'static str> {
+        Entry::present(Timestamp::new(wall_ms, counter, node_id), v)
+    }
 
     #[test]
-    fn reconcile_is_commutative_on_equal_wall_and_counter() {
+    fn merge_is_commutative_on_equal_wall_and_counter() {
         // Distinct node_ids with the same wall+counter: the old physical-clock tie-break
         // kept the local value, so the two replicas diverged forever (defect (b)). The
         // total order makes the survivor deterministic regardless of argument order.
-        let a = (Timestamp::new(100, 0, 1), "a");
-        let b = (Timestamp::new(100, 0, 2), "b");
-        assert_eq!(a.reconcile(&b), b.reconcile(&a));
+        let a = present(100, 0, 1, "a");
+        let b = present(100, 0, 2, "b");
+        assert_eq!(a.merge(&b), b.merge(&a));
         // The higher node_id wins consistently.
-        assert_eq!(a.reconcile(&b).1, "b");
+        assert_eq!(a.merge(&b).value(), Some(&"b"));
     }
 
     #[test]
-    fn reconcile_is_idempotent() {
-        let a = (Timestamp::new(7, 3, 42), "x");
-        assert_eq!(a.reconcile(&a), a);
+    fn merge_is_idempotent() {
+        let a = present(7, 3, 42, "x");
+        assert_eq!(a.merge(&a), a);
     }
 
     #[test]
-    fn reconcile_picks_the_greater_timestamp() {
-        let older = (Timestamp::new(10, 0, 5), "old");
-        let newer = (Timestamp::new(11, 0, 1), "new");
-        assert_eq!(older.reconcile(&newer).1, "new");
-        assert_eq!(newer.reconcile(&older).1, "new");
+    fn merge_picks_the_greater_timestamp() {
+        let older = present(10, 0, 5, "old");
+        let newer = present(11, 0, 1, "new");
+        assert_eq!(older.merge(&newer).value(), Some(&"new"));
+        assert_eq!(newer.merge(&older).value(), Some(&"new"));
+    }
+
+    #[test]
+    fn tombstone_is_a_tombstone() {
+        let live = present(1, 0, 0, "v");
+        let dead: Entry<Timestamp, &'static str> = Entry::tombstone(Timestamp::new(2, 0, 0));
+        assert!(!live.is_tombstone());
+        assert!(dead.is_tombstone());
+        assert_eq!(live.value(), Some(&"v"));
+        assert_eq!(dead.value(), None);
+    }
+
+    #[test]
+    fn projection_is_the_state() {
+        let live = present(1, 0, 0, "v");
+        assert_eq!(live.project(), State::Present("v"));
+        let dead: Entry<Timestamp, &'static str> = Entry::tombstone(Timestamp::new(2, 0, 0));
+        assert_eq!(dead.project(), State::Tombstone);
     }
 }

--- a/src/reconcile_engine.rs
+++ b/src/reconcile_engine.rs
@@ -174,8 +174,9 @@ pub(crate) struct Inner<K, V: Projectable> {
     /// reconciliation round — the effective gossip cadence. Shared so it can be retuned at runtime.
     reconcile_interval: Arc<RwLock<Duration>>,
     /// Rate (bytes/sec) at which a single bulk anti-entropy value transfer to one peer is paced, or
-    /// `None` to send back-to-back. Mirrors [`Config::bulk_send_rate`](crate::reconcile_store::Config::bulk_send_rate)
-    /// and is read by [`spawn_paced_send`](Self::spawn_paced_send).
+    /// `None` to send back-to-back. Mirrors [`Config::bulk_send_rate`](crate::reconcile_store::Config::bulk_send_rate),
+    /// already floored at construction (see `MIN_BULK_SEND_RATE`), and is read by
+    /// [`spawn_paced_send`](Self::spawn_paced_send).
     bulk_send_rate: Option<usize>,
     /// Peers with a bulk value transfer currently in flight. At most one paced dump
     /// runs per peer at a time: while one is in flight, the reconcile timer re-firing (the receiver
@@ -341,17 +342,44 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
         info!("Listening on: {}", socket.local_addr()?);
         // Size the kernel send/receive buffers before any traffic flows.
         set_socket_buffers(&socket, &config);
+        // Floor the bulk pacing rate. A non-None rate below the floor would make `pace()` sleep for
+        // an effectively unbounded time while holding the per-peer in-flight mark, wedging that
+        // peer's sync; raise it (with a warning) so the in-flight mark always turns over promptly.
+        // None (pacing disabled) is an explicit choice and left untouched.
+        let bulk_send_rate = config.bulk_send_rate.map(|rate| {
+            if rate < crate::reconcile_store::MIN_BULK_SEND_RATE {
+                warn!(
+                    "bulk_send_rate {rate} B/s is below the {} B/s floor and would stall bulk \
+                     syncs; raising it to the floor",
+                    crate::reconcile_store::MIN_BULK_SEND_RATE
+                );
+                crate::reconcile_store::MIN_BULK_SEND_RATE
+            } else {
+                rate
+            }
+        });
         let authenticator = auth::Authenticator::new(config.cluster_key, config.encrypt);
         if authenticator.is_encrypted() {
             debug!("per-datagram authenticated encryption (XChaCha20-Poly1305) ENABLED");
         } else if authenticator.is_enabled() {
             debug!("per-datagram MAC authentication ENABLED");
+        } else if config.acknowledged_no_key {
+            // The operator explicitly acknowledged keyless mode via Config::with_insecure_no_key.
+            // The trust model is unchanged (still unauthenticated, still leaks the dataset); only
+            // the loud warning is downgraded so a deliberate keyless deployment is not nagged.
+            info!(
+                "no cluster key set (acknowledged via Config::with_insecure_no_key): UDP \
+                 reconciliation is UNAUTHENTICATED and serves the whole dataset to any host that \
+                 can reach this port. Run only on a trusted network underlay."
+            );
         } else {
             warn!(
                 "SECURITY: no cluster key set — UDP reconciliation is UNAUTHENTICATED. Any host \
                  that can send UDP to this port can forge updates and poison the cluster via \
-                 last-write-wins. Set Config::with_cluster_key on every node, or restrict the \
-                 network to a trusted underlay. See REVIEW.md F3."
+                 last-write-wins, and will be served the ENTIRE dataset through anti-entropy diff \
+                 dumps. Set Config::with_cluster_key on every node, or restrict the network to a \
+                 trusted underlay (and acknowledge with Config::with_insecure_no_key to silence \
+                 this warning)."
             );
         }
         let map = HRTree::<K, V>::new();
@@ -383,7 +411,7 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
                 remote_interval: Arc::new(AtomicU32::new(config.remote_interval)),
                 remote_fanout: Arc::new(AtomicUsize::new(config.remote_fanout)),
                 reconcile_interval: Arc::new(RwLock::new(config.reconcile_interval)),
-                bulk_send_rate: config.bulk_send_rate,
+                bulk_send_rate,
                 bulk_in_flight: Arc::new(RwLock::new(HashSet::new())),
                 bulk_dumps_in_flight: Arc::new(AtomicUsize::new(0)),
                 max_concurrent_bulk_dumps: config.max_concurrent_bulk_dumps,
@@ -1299,8 +1327,8 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
 
     /// Number of entries currently in the peers gossip-routing map.
     ///
-    /// Exposed for test assertions under the `internal-testing` feature gate.
-    #[cfg(any(test, feature = "internal-testing"))]
+    /// Exposed for test assertions under the `reconcile_internal_testing` cfg gate.
+    #[cfg(any(test, reconcile_internal_testing))]
     pub(crate) fn peers_map_len(&self) -> usize {
         self.peers.read().len()
     }
@@ -1310,32 +1338,32 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
     /// to confirm that at least one discovery round has observed a peer before the test mutates
     /// the discovery source.
     ///
-    /// Exposed for test assertions under the `internal-testing` feature gate.
-    #[cfg(any(test, feature = "internal-testing"))]
+    /// Exposed for test assertions under the `reconcile_internal_testing` cfg gate.
+    #[cfg(any(test, reconcile_internal_testing))]
     pub(crate) fn peers_contains(&self, peer: IpAddr) -> bool {
         self.peers.read().contains_key(&peer)
     }
 
     /// Number of entries currently in the per-peer replay filter.
     ///
-    /// Exposed for test assertions under the `internal-testing` feature gate.
-    #[cfg(any(test, feature = "internal-testing"))]
+    /// Exposed for test assertions under the `reconcile_internal_testing` cfg gate.
+    #[cfg(any(test, reconcile_internal_testing))]
     pub(crate) fn replay_filter_len(&self) -> usize {
         self.replay_filter.len()
     }
 
     /// Number of keys currently tracked in the tombstone-acknowledgment map.
     ///
-    /// Exposed for test assertions under the `internal-testing` feature gate.
-    #[cfg(any(test, feature = "internal-testing"))]
+    /// Exposed for test assertions under the `reconcile_internal_testing` cfg gate.
+    #[cfg(any(test, reconcile_internal_testing))]
     pub(crate) fn tombstone_acks_len(&self) -> usize {
         self.tombstone_acks.read().len()
     }
 
     /// Number of bulk dump tasks currently in flight across all peers.
     ///
-    /// Exposed for test assertions under the `internal-testing` feature gate.
-    #[cfg(any(test, feature = "internal-testing"))]
+    /// Exposed for test assertions under the `reconcile_internal_testing` cfg gate.
+    #[cfg(any(test, reconcile_internal_testing))]
     pub(crate) fn bulk_dumps_in_flight_count(&self) -> usize {
         self.bulk_dumps_in_flight.load(Ordering::Acquire)
     }
@@ -1944,6 +1972,46 @@ mod pacing {
         let messages = bulk_updates(256, 1024);
         assert!(time_send(&messages, None).await < Duration::from_millis(200));
         assert!(time_send(&messages, Some(0)).await < Duration::from_millis(200));
+    }
+
+    /// A configured `bulk_send_rate` below the floor must be raised to it at construction, so a
+    /// paced dump cannot sleep unboundedly while holding the per-peer in-flight mark. `None` (pacing
+    /// disabled) is an explicit choice and stays untouched.
+    #[tokio::test]
+    async fn sub_floor_bulk_send_rate_is_clamped_at_construction() {
+        use crate::clock::Timestamp;
+        use crate::reconcile_engine::ReconcileEngine;
+        use crate::reconcile_store::{Config, MIN_BULK_SEND_RATE};
+
+        type Tombstoned = (Timestamp, Option<i32>);
+
+        // Each case binds a distinct loopback address on an ephemeral port (port 0), so the sockets
+        // never collide while a prior engine is still in scope.
+        let make = |addr: &str, rate: Option<usize>| {
+            let mut config = Config::default().with_listen_addr(addr.parse().unwrap());
+            config.bulk_send_rate = rate;
+            config
+        };
+
+        // A 1 B/s rate is far below the floor and is raised to it.
+        let eng: ReconcileEngine<i32, Tombstoned> =
+            ReconcileEngine::new(make("127.0.0.71", Some(1)))
+                .await
+                .expect("bind failed");
+        assert_eq!(eng.bulk_send_rate, Some(MIN_BULK_SEND_RATE));
+
+        // A rate at or above the floor is preserved verbatim.
+        let eng: ReconcileEngine<i32, Tombstoned> =
+            ReconcileEngine::new(make("127.0.0.72", Some(MIN_BULK_SEND_RATE * 4)))
+                .await
+                .expect("bind failed");
+        assert_eq!(eng.bulk_send_rate, Some(MIN_BULK_SEND_RATE * 4));
+
+        // None disables pacing and is left untouched.
+        let eng: ReconcileEngine<i32, Tombstoned> = ReconcileEngine::new(make("127.0.0.73", None))
+            .await
+            .expect("bind failed");
+        assert_eq!(eng.bulk_send_rate, None);
     }
 }
 

--- a/src/reconcile_engine.rs
+++ b/src/reconcile_engine.rs
@@ -846,7 +846,7 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
         let remote_fanout = self.remote_fanout.load(Ordering::Relaxed);
         let round = self.round.fetch_add(1, Ordering::Relaxed);
         // Treat an interval of 0 as "every round" to avoid a modulo-by-zero.
-        let do_remote = round.is_multiple_of(remote_interval);
+        let do_remote = round % remote_interval == 0;
         let known = self.get_peers();
 
         // De-duplicate so a discovery probe that happens to hit a known peer is not sent twice.

--- a/src/reconcile_engine.rs
+++ b/src/reconcile_engine.rs
@@ -1217,6 +1217,40 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
         }
     }
 
+    /// Returns `true` when `peer` has at least one tombstone it has not yet acknowledged.
+    ///
+    /// The predicate iterates the local map (the authoritative domain) looking for tombstone
+    /// entries. For each tombstone it checks whether `peer` has acknowledged the exact current
+    /// version via `tombstone_acks`. A tombstone whose key has NO entry in `tombstone_acks` at
+    /// all (fresh deletion, no ack has arrived yet) is also treated as pending — exactly the
+    /// condition that `is_tombstone_stable` blocks on.
+    ///
+    /// Locks taken: `map` read, then `tombstone_acks` read — the established lock order
+    /// (map before tombstone_acks) so this can be called from the discovery task without
+    /// risk of deadlock. Cost: O(local map entries) — acceptable for the discovery cadence
+    /// (~5 s intervals, only when a member is missing from DNS).
+    pub(crate) fn has_pending_tombstone_acks(&self, peer: IpAddr) -> bool {
+        let map = self.map.read();
+        let acks = self.tombstone_acks.read();
+        for (key, value) in map.iter() {
+            if !value.is_tombstone() {
+                continue;
+            }
+            let current_version = version_hash(value);
+            // Mirror the per-key ack test that `is_tombstone_stable` uses: the peer must have
+            // acknowledged exactly this version. If the key has no ack entry at all (fresh
+            // deletion, nobody has acked yet), the peer is pending.
+            let peer_acked = acks
+                .get(key)
+                .and_then(|key_acks| key_acks.get(&peer))
+                .is_some_and(|v| *v == current_version);
+            if !peer_acked {
+                return true;
+            }
+        }
+        false
+    }
+
     /// Register (or refresh) a known peer at runtime, the `&self` counterpart of the
     /// [`with_seed`](crate::ReconcileStore::with_seed) builder.
     ///
@@ -1241,6 +1275,17 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
     #[cfg(any(test, feature = "internal-testing"))]
     pub(crate) fn peers_map_len(&self) -> usize {
         self.peers.read().len()
+    }
+
+    /// Whether `peer` is present in the gossip-routing peers map (i.e. discovery has seeded it
+    /// at least once and the entry has not yet expired). Used as a deterministic signal in tests
+    /// to confirm that at least one discovery round has observed a peer before the test mutates
+    /// the discovery source.
+    ///
+    /// Exposed for test assertions under the `internal-testing` feature gate.
+    #[cfg(any(test, feature = "internal-testing"))]
+    pub(crate) fn peers_contains(&self, peer: IpAddr) -> bool {
+        self.peers.read().contains_key(&peer)
     }
 
     /// Number of entries currently in the per-peer replay filter.
@@ -1726,6 +1771,48 @@ mod causal_stability {
         // Forgetting the tombstone clears its bookkeeping.
         eng.forget_tombstone(&key);
         assert!(eng.tombstone_acks.read().get(&key).is_none());
+    }
+
+    /// Regression: `has_pending_tombstone_acks` must detect a freshly-deleted tombstone that
+    /// has ZERO acks recorded (the `tombstone_acks` map has no entry for that key yet).
+    ///
+    /// The original implementation iterated `tombstone_acks.iter()` — which yields nothing when
+    /// the map is empty — and returned `false` ("no pending acks").  That is wrong: a tombstone
+    /// with no ack entry is the *most* pending of all states.  The fixed implementation iterates
+    /// the local map and treats any tombstone with a missing or mismatched ack as pending.
+    ///
+    /// If this test fails, the old predicate has been restored (see commit history).  The test
+    /// is intentionally self-contained so it can be run against either version of the predicate
+    /// to confirm the regression.
+    #[tokio::test]
+    async fn fresh_tombstone_with_zero_acks_is_pending() {
+        let eng = engine("127.0.0.66").await;
+        let peer: IpAddr = "127.0.0.67".parse().unwrap();
+        let key = 11i32;
+        let tombstone: Tombstoned = (Timestamp::new(2, 0, 0), None);
+
+        // B is a known member — gates tombstone GC.
+        eng.members.write().insert(peer);
+
+        // Insert the tombstone directly into the engine map (no gossip round needed).
+        eng.just_insert(key, tombstone);
+        assert!(eng.map.read().get(&key).is_some());
+
+        // No ack entry exists for this key yet — the tombstone is "fresh".
+        assert!(
+            eng.tombstone_acks.read().is_empty(),
+            "tombstone_acks must be empty — no ack has arrived"
+        );
+
+        // The predicate must report the peer as having pending work: `tombstone_acks` has no
+        // entry for this key, so `is_tombstone_stable` would also block.
+        assert!(
+            eng.has_pending_tombstone_acks(peer),
+            "has_pending_tombstone_acks returned false for a fresh tombstone with zero acks \
+             (resurrection hazard: the old tombstone_acks.iter() predicate iterates an empty map \
+             and returns false, triggering the fast-path decommission while the tombstone is \
+             still active)"
+        );
     }
 }
 

--- a/src/reconcile_engine.rs
+++ b/src/reconcile_engine.rs
@@ -240,6 +240,21 @@ pub(crate) struct Inner<K, V: Projectable> {
     /// Hard cap on the number of tracked remote peers. Datagrams from unknown senders are dropped
     /// before any per-sender state is allocated when the membership set reaches this size.
     max_peers: usize,
+    /// Running count of map mutations since the last snapshot.
+    ///
+    /// Shared with [`ReconcileStore`](crate::reconcile_store::ReconcileStore): the store keeps a
+    /// clone of the same `Arc` so that local-write methods (`insert`, `remove`, etc.) and the
+    /// gossip apply / GC paths — all of which live in the engine — bump a **single** atomic.
+    /// The store's snapshot loop reads and resets this counter to decide whether to write.
+    ///
+    /// **Increment sites (exactly one per mutation path, no double-counting):**
+    /// - Local writes: incremented by `ReconcileStore`'s public methods (`insert`, `remove`, …)
+    ///   before calling `just_insert` / `just_insert_bulk`.  Those methods call `map_insert`
+    ///   internally, but `map_insert` itself does *not* touch the counter.
+    /// - Gossip applies: incremented here, in `handle_messages`, after the re-reconcile write
+    ///   loop — once per entry actually written to `to_apply`.
+    /// - GC removes: incremented in `gc_remove` — one per tombstone purged.
+    pub(crate) change_counter: Arc<AtomicUsize>,
 }
 
 impl<K, V: Projectable> Clone for ReconcileEngine<K, V> {
@@ -385,6 +400,7 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
                 clock,
                 node_id_is_random,
                 max_peers: config.max_peers,
+                change_counter: Arc::new(AtomicUsize::new(0)),
             }),
         })
     }
@@ -413,7 +429,11 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
     pub(crate) fn gc_remove(&self, key: &K) -> Option<V> {
         let mut guard = self.map.write();
         self.projection.write().remove(key);
-        guard.remove(key)
+        let removed = guard.remove(key);
+        if removed.is_some() {
+            self.change_counter.fetch_add(1, Ordering::Relaxed);
+        }
+        removed
     }
 
     /// Mint a fresh Hybrid Logical Clock timestamp for a local write.
@@ -1094,6 +1114,7 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
             //    order, so re-applying a value that became stale meanwhile is a no-op — the stale
             //    case is handled identically to the direct path.
             if !to_apply.is_empty() {
+                let apply_count = to_apply.len();
                 let mut guard = self.map.write();
                 for (k, v) in to_apply {
                     let merged_v = match guard.get(&k) {
@@ -1106,6 +1127,13 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
                         acks_to_send.push(Message::Ack::<K, V, V::Projected>((k, version)));
                     }
                 }
+                // Count every entry actually written via gossip so the snapshot threshold is met
+                // even on a replica that only receives data through anti-entropy (never writes
+                // locally). This is the only site that bumps the counter for the gossip path;
+                // local-write methods bump it themselves before calling just_insert, so there is
+                // no overlap between the two paths.
+                self.change_counter
+                    .fetch_add(apply_count, Ordering::Relaxed);
             }
             if !acks_to_send.is_empty() {
                 send_messages_to(

--- a/src/reconcile_engine.rs
+++ b/src/reconcile_engine.rs
@@ -34,13 +34,13 @@ use tracing::{debug, error, info, instrument, trace, warn};
 
 use crate::auth;
 use crate::bounds::{Key, Value};
-use crate::clock::{Clock, HlcClock, Timestamp, Timestamped};
+use crate::clock::{Clock, HlcClock, Timestamp};
 use crate::discovery::{Discovery, RandomProbe};
 use crate::fingerprint::Fingerprint;
 use crate::gen_ip::{host_net, net_of};
 use crate::observability;
 use crate::proto::{self, HashSegment};
-use crate::reconcilable::{MaybeTombstone, Projectable, Reconcilable};
+use crate::reconcilable::{Entry, State};
 use crate::reconcile_store::{Config, MAX_NETS};
 use crate::replay;
 use crate::HRTree;
@@ -50,7 +50,7 @@ const PEER_EXPIRATION: Duration = Duration::from_secs(60);
 
 const MAX_SENDTO_RETRIES: u32 = 4;
 
-type PreInsertCallback<K, V> = Box<dyn Send + Sync + Fn(&K, &V)>;
+type PreInsertCallback<K, V> = Box<dyn Send + Sync + Fn(&K, &Entry<Timestamp, V>)>;
 
 /// Compute a deterministic, cross-node version token for a value.
 ///
@@ -128,7 +128,7 @@ fn set_socket_buffers(socket: &UdpSocket, config: &Config) {
 /// The internal reconciliation engine at the network level.
 /// This struct does not handle removals, which are managed by the external layer.
 /// For more information, see [`ReconcileStore`](crate::reconcile_store::ReconcileStore).
-pub(crate) struct ReconcileEngine<K, V: Projectable> {
+pub(crate) struct ReconcileEngine<K, V> {
     /// All engine state lives behind a single [`Arc`] so that cloning the engine (every clone
     /// shares the same maps, peers, clock, …) is a single refcount bump. Cloning is therefore
     /// cheap and bound-free, and the previously hand-written `Clone` impl reduces to a derive.
@@ -138,15 +138,15 @@ pub(crate) struct ReconcileEngine<K, V: Projectable> {
 }
 
 /// Shared, refcounted state of a [`ReconcileEngine`]; see that struct for the rationale.
-pub(crate) struct Inner<K, V: Projectable> {
-    pub(crate) map: Arc<RwLock<HRTree<K, V>>>,
+pub(crate) struct Inner<K, V> {
+    pub(crate) map: Arc<RwLock<HRTree<K, Entry<Timestamp, V>>>>,
     /// Value-only **projection** of [`map`](Self::map), kept in sync at every map mutation.
     ///
     /// Its range fingerprints are timestamp-less by construction (see
-    /// [`ValueOnly`](crate::reconcilable::ValueOnly)), which is what lets a dateless mirror
+    /// [`State`](crate::reconcilable::State)), which is what lets a dateless mirror
     /// converge with this dated store over the existing range-diff protocol. It is read-only state
     /// for the dated↔dated path and never touches the causal-stability bookkeeping.
-    pub(crate) projection: Arc<RwLock<HRTree<K, V::Projected>>>,
+    pub(crate) projection: Arc<RwLock<HRTree<K, State<V>>>>,
     port: u16,
     socket: Arc<UdpSocket>,
     /// The geographical networks the cluster spans, each a CIDR. One random address is
@@ -258,7 +258,7 @@ pub(crate) struct Inner<K, V: Projectable> {
     pub(crate) change_counter: Arc<AtomicUsize>,
 }
 
-impl<K, V: Projectable> Clone for ReconcileEngine<K, V> {
+impl<K, V> Clone for ReconcileEngine<K, V> {
     fn clone(&self) -> Self {
         ReconcileEngine {
             inner: Arc::clone(&self.inner),
@@ -266,7 +266,7 @@ impl<K, V: Projectable> Clone for ReconcileEngine<K, V> {
     }
 }
 
-impl<K, V: Projectable> std::ops::Deref for ReconcileEngine<K, V> {
+impl<K, V> std::ops::Deref for ReconcileEngine<K, V> {
     type Target = Inner<K, V>;
     fn deref(&self) -> &Self::Target {
         &self.inner
@@ -283,7 +283,7 @@ impl<K, V: Projectable> std::ops::Deref for ReconcileEngine<K, V> {
 /// against that), keeping the protocol backward compatible on a single port.
 ///
 /// `V` is the dated value carried by `Update`; `P` is its timestamp-less
-/// [`Projected`](crate::reconcilable::Projectable::Projected) form carried by `ValueUpdate`.
+/// [`State`](crate::reconcilable::State) projection carried by `ValueUpdate`.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub(crate) enum Message<K: Serialize, V: Serialize, P: Serialize> {
     /// Provides information about a set of keys that allows checking
@@ -305,9 +305,7 @@ pub(crate) enum Message<K: Serialize, V: Serialize, P: Serialize> {
     ValueUpdate((K, P)),
 }
 
-impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestamped>
-    ReconcileEngine<K, V>
-{
+impl<K: Key, V: Value> ReconcileEngine<K, V> {
     /// Create a new engine, binding the gossip UDP socket.
     ///
     /// # Errors
@@ -382,8 +380,8 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
                  this warning)."
             );
         }
-        let map = HRTree::<K, V>::new();
-        let projection = HRTree::<K, V::Projected>::new();
+        let map = HRTree::<K, Entry<Timestamp, V>>::new();
+        let projection = HRTree::<K, State<V>>::new();
         // The geographical networks this cluster spans. With none declared, fall back to the
         // historical flat loopback cluster.
         let mut nets: Vec<IpNet> = config.nets.iter().flatten().copied().collect();
@@ -448,13 +446,18 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
     /// Insert into the dated `map` **and** mirror the value-only projection, under a consistent
     /// lock order (`map` then `projection`) shared by every mutation path so the two trees never
     /// deadlock against each other. The caller already holds the `map` write guard.
-    fn map_insert(&self, guard: &mut HRTree<K, V>, key: K, value: V) -> Option<V> {
+    fn map_insert(
+        &self,
+        guard: &mut HRTree<K, Entry<Timestamp, V>>,
+        key: K,
+        value: Entry<Timestamp, V>,
+    ) -> Option<Entry<Timestamp, V>> {
         self.projection.write().insert(key.clone(), value.project());
         guard.insert(key, value)
     }
 
     /// Remove a key from the dated `map` and its value-only projection (the GC removal path).
-    pub(crate) fn gc_remove(&self, key: &K) -> Option<V> {
+    pub(crate) fn gc_remove(&self, key: &K) -> Option<Entry<Timestamp, V>> {
         let mut guard = self.map.write();
         self.projection.write().remove(key);
         let removed = guard.remove(key);
@@ -549,7 +552,7 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
         guard.keys().cloned().collect()
     }
 
-    pub fn just_insert(&self, key: K, value: V) -> Option<V> {
+    pub fn just_insert(&self, key: K, value: Entry<Timestamp, V>) -> Option<Entry<Timestamp, V>> {
         // 1) Call the pre-insert hook *before* taking the map lock
         (self.pre_insert.read())(&key, &value);
 
@@ -571,7 +574,7 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
     /// Spawns a detached task so the calling write path does not block on the network. Shared by
     /// every local-mutation broadcast path (`insert` / `insert_bulk`) so the spawn/loop/send
     /// boilerplate lives in exactly one place.
-    fn broadcast(&self, messages: Vec<Message<K, V, V::Projected>>) {
+    fn broadcast(&self, messages: Vec<Message<K, Entry<Timestamp, V>, State<V>>>) {
         let peers = self.get_peers();
         let port = self.port;
         let socket = Arc::clone(&self.socket);
@@ -662,7 +665,7 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
     ///    **before** building the snapshot Vec, so a skipped dump allocates nothing.
     fn spawn_paced_send(
         &self,
-        messages: Vec<Message<K, V, V::Projected>>,
+        messages: Vec<Message<K, Entry<Timestamp, V>, State<V>>>,
         peer: SocketAddr,
         peer_guard: BulkInFlightGuard,
         global_guard: BulkDumpCountGuard,
@@ -690,20 +693,24 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
         });
     }
 
-    pub fn insert(&self, key: K, value: V) -> Option<V> {
+    pub fn insert(&self, key: K, value: Entry<Timestamp, V>) -> Option<Entry<Timestamp, V>> {
         let ret = self.just_insert(key.clone(), value.clone());
-        self.broadcast(vec![Message::Update::<K, V, V::Projected>((key, value))]);
+        self.broadcast(vec![Message::Update::<K, Entry<Timestamp, V>, State<V>>((
+            key, value,
+        ))]);
         ret
     }
 
     /// Broadcast a single locally-mutated entry to peers, mirroring [`insert`](Self::insert)'s
     /// propagation. Used by in-place mutation paths (`ReconcileStore::get_mut`) that write the map
     /// directly and must still notify peers so the edit reconciles, without re-applying it locally.
-    pub(crate) fn broadcast_update(&self, key: K, value: V) {
-        self.broadcast(vec![Message::Update::<K, V, V::Projected>((key, value))]);
+    pub(crate) fn broadcast_update(&self, key: K, value: Entry<Timestamp, V>) {
+        self.broadcast(vec![Message::Update::<K, Entry<Timestamp, V>, State<V>>((
+            key, value,
+        ))]);
     }
 
-    pub fn just_insert_bulk(&self, key_values: &[(K, V)]) {
+    pub fn just_insert_bulk(&self, key_values: &[(K, Entry<Timestamp, V>)]) {
         // 1) First run all pre-insert hooks outside the map lock
         for (key, value) in key_values {
             (self.pre_insert.read())(key, value);
@@ -720,11 +727,11 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
         }
     }
 
-    pub fn insert_bulk(&self, key_values: &[(K, V)]) {
+    pub fn insert_bulk(&self, key_values: &[(K, Entry<Timestamp, V>)]) {
         self.just_insert_bulk(key_values);
         let messages: Vec<_> = key_values
             .iter()
-            .map(|kv| Message::Update::<K, V, V::Projected>(kv.clone()))
+            .map(|kv| Message::Update::<K, Entry<Timestamp, V>, State<V>>(kv.clone()))
             .collect();
         self.broadcast(messages);
     }
@@ -858,7 +865,7 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
         };
         send_buf.clear();
         for segment in segments {
-            Message::ComparisonItem::<K, V, V::Projected>(segment)
+            Message::ComparisonItem::<K, Entry<Timestamp, V>, State<V>>(segment)
                 .serialize(&mut Serializer::new(&mut *send_buf, DefaultOptions::new()))
                 .expect("serializing a ComparisonItem into an in-memory buffer cannot fail");
         }
@@ -956,13 +963,13 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
         let payload = payload.as_bytes();
         trace!("received {} bytes from {peer}", payload.len());
         let mut in_comparison = Vec::new();
-        let mut updates: Vec<(K, V)> = Vec::new();
+        let mut updates: Vec<(K, Entry<Timestamp, V>)> = Vec::new();
         let mut acks: Vec<(K, u64)> = Vec::new();
         let mut value_in_comparison = Vec::new();
         let mut deserializer = Deserializer::from_slice(payload, DefaultOptions::new());
         // read messages in buffer
         loop {
-            match Message::<K, V, V::Projected>::deserialize(&mut deserializer) {
+            match Message::<K, Entry<Timestamp, V>, State<V>>::deserialize(&mut deserializer) {
                 Err(ref kind) => {
                     if let bincode::ErrorKind::Io(err) = kind.as_ref() {
                         if err.kind() == std::io::ErrorKind::UnexpectedEof {
@@ -1023,8 +1030,9 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
                     if !already {
                         let holds_same_tombstone = version_hash(local_v) == version;
                         if holds_same_tombstone {
-                            reciprocal_acks
-                                .push(Message::Ack::<K, V, V::Projected>((key, version)));
+                            reciprocal_acks.push(Message::Ack::<K, Entry<Timestamp, V>, State<V>>(
+                                (key, version),
+                            ));
                         }
                     }
                 }
@@ -1056,7 +1064,7 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
                 trace!("segments: {out_comparison:?}");
                 let messages: Vec<_> = out_comparison
                     .into_iter()
-                    .map(Message::ComparisonItem::<K, V, V::Projected>)
+                    .map(Message::ComparisonItem::<K, Entry<Timestamp, V>, State<V>>)
                     .collect();
                 send_messages_to(
                     &messages,
@@ -1078,7 +1086,7 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
                 // into a Vec. A skipped dump allocates nothing; the peer re-initiates on its
                 // next diff round once a slot is free.
                 if let Some((peer_guard, global_guard)) = self.try_claim_dump_slot(peer) {
-                    let updates: Vec<Message<K, V, V::Projected>> = {
+                    let updates: Vec<Message<K, Entry<Timestamp, V>, State<V>>> = {
                         let guard = self.map.read();
                         let mut updates = Vec::new();
                         for range in differences {
@@ -1105,26 +1113,28 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
             //    NOT run the pre-insert hook here: hooks are contractually executed *outside* the
             //    map's write lock (matching `just_insert`), so a hook that re-inserts cannot
             //    re-enter the lock and deadlock.
-            let mut to_apply: Vec<(K, V)> = Vec::new();
+            let mut to_apply: Vec<(K, Entry<Timestamp, V>)> = Vec::new();
             {
                 let guard = self.map.read();
                 for (k, remote_v) in updates {
                     // Advance our clock past the timestamp carried by the remote value, so a
                     // later local write is ordered after everything we have seen. This is
                     // what prevents lost updates under clock skew.
-                    self.clock.observe(remote_v.timestamp());
+                    self.clock.observe(remote_v.stamp);
                     match guard.get(&k) {
                         Some(local_v) => {
-                            let merged_v = local_v.reconcile(&remote_v);
+                            let merged_v = local_v.merge(&remote_v);
                             if merged_v != *local_v {
                                 to_apply.push((k, merged_v));
                             } else if local_v.is_tombstone() {
                                 // We already hold an equal-or-newer value; still acknowledge it
                                 // if it is the same tombstone, so the peer learns we have it.
-                                acks_to_send.push(Message::Ack::<K, V, V::Projected>((
-                                    k,
-                                    version_hash(local_v),
-                                )));
+                                acks_to_send.push(
+                                    Message::Ack::<K, Entry<Timestamp, V>, State<V>>((
+                                        k,
+                                        version_hash(local_v),
+                                    )),
+                                );
                             }
                         }
                         None => to_apply.push((k, remote_v)),
@@ -1146,13 +1156,15 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
                 let mut guard = self.map.write();
                 for (k, v) in to_apply {
                     let merged_v = match guard.get(&k) {
-                        Some(local_v) => local_v.reconcile(&v),
+                        Some(local_v) => local_v.merge(&v),
                         None => v,
                     };
                     let version = merged_v.is_tombstone().then(|| version_hash(&merged_v));
                     self.map_insert(&mut guard, k.clone(), merged_v);
                     if let Some(version) = version {
-                        acks_to_send.push(Message::Ack::<K, V, V::Projected>((k, version)));
+                        acks_to_send.push(Message::Ack::<K, Entry<Timestamp, V>, State<V>>((
+                            k, version,
+                        )));
                     }
                 }
                 // Count every entry actually written via gossip so the snapshot threshold is met
@@ -1196,7 +1208,7 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
             if !out_comparison.is_empty() {
                 let messages: Vec<_> = out_comparison
                     .into_iter()
-                    .map(Message::ValueComparisonItem::<K, V, V::Projected>)
+                    .map(Message::ValueComparisonItem::<K, Entry<Timestamp, V>, State<V>>)
                     .collect();
                 send_messages_to(
                     &messages,
@@ -1212,7 +1224,7 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
             // background task, exactly like the dated bulk path.
             if !differences.is_empty() {
                 if let Some((peer_guard, global_guard)) = self.try_claim_dump_slot(peer) {
-                    let updates: Vec<Message<K, V, V::Projected>> = {
+                    let updates: Vec<Message<K, Entry<Timestamp, V>, State<V>>> = {
                         let guard = self.projection.read();
                         let mut updates = Vec::new();
                         for range in differences {
@@ -1536,7 +1548,7 @@ mod deadlock_regressions {
 
     use crate::auth;
     use crate::clock::Timestamp;
-    use crate::reconcilable::ValueOnly;
+    use crate::reconcilable::{Entry, State};
     use crate::reconcile_engine::ReconcileEngine;
     use crate::{reconcile_store::Config, ReconcileStore};
     use bincode::{DefaultOptions, Serializer};
@@ -1566,10 +1578,10 @@ mod deadlock_regressions {
         // Install a pre-insert hook that itself calls insert on the same Store
         let once = Arc::new(AtomicBool::new(false));
         let guard = once.clone();
-        svc.add_pre_insert(move |&k, &v| {
+        svc.add_pre_insert(move |&k, v| {
             // inner insert should no longer deadlock
             if !guard.swap(true, Ordering::SeqCst) {
-                let _ = hook_svc.just_insert(k + 100, v.1.unwrap_or_default() + 100);
+                let _ = hook_svc.just_insert(k + 100, v.value().copied().unwrap_or_default() + 100);
                 // TODO Check vs Utc::now()
             }
             flag2.store(true, Ordering::SeqCst);
@@ -1586,8 +1598,8 @@ mod deadlock_regressions {
     /// Serialize an `Update` so it can be fed straight into the engine's network ingest path
     /// (`handle_messages`), exactly as a peer's datagram would arrive once the (disabled)
     /// authentication gate has been cleared.
-    fn update_message_bytes(key: i32, value: (Timestamp, Option<u8>)) -> Vec<u8> {
-        let message = Message::Update::<i32, (Timestamp, Option<u8>), ValueOnly<u8>>((key, value));
+    fn update_message_bytes(key: i32, value: Entry<Timestamp, u8>) -> Vec<u8> {
+        let message = Message::Update::<i32, Entry<Timestamp, u8>, State<u8>>((key, value));
         let mut buf = Vec::new();
         message
             .serialize(&mut Serializer::new(&mut buf, DefaultOptions::new()))
@@ -1618,7 +1630,7 @@ mod deadlock_regressions {
                 let config = Config::default()
                     .with_port(8083)
                     .with_listen_addr("127.0.0.50".parse().unwrap());
-                let engine = ReconcileEngine::<i32, (Timestamp, Option<u8>)>::new(config)
+                let engine = ReconcileEngine::<i32, u8>::new(config)
                     .await
                     .expect("bind failed");
 
@@ -1629,20 +1641,20 @@ mod deadlock_regressions {
                 let hook_engine = engine.clone();
                 let once = Arc::new(AtomicBool::new(false));
                 let guard = once.clone();
-                *engine.pre_insert.write() =
-                    Box::new(move |&k: &i32, v: &(Timestamp, Option<u8>)| {
-                        if !guard.swap(true, Ordering::SeqCst) {
-                            let inner = (
-                                Timestamp::new(u64::MAX, 1, 0),
-                                Some(v.1.unwrap_or_default() + 100),
-                            );
-                            let _ = hook_engine.just_insert(k + 100, inner);
-                        }
-                    });
+                *engine.pre_insert.write() = Box::new(move |&k: &i32, v: &Entry<Timestamp, u8>| {
+                    if !guard.swap(true, Ordering::SeqCst) {
+                        let inner = Entry::present(
+                            Timestamp::new(u64::MAX, 1, 0),
+                            v.value().copied().unwrap_or_default() + 100,
+                        );
+                        let _ = hook_engine.just_insert(k + 100, inner);
+                    }
+                });
 
                 // Feed an `Update` (future timestamp, so it is integrated) through the real network
                 // ingest path. No cluster key, so `open` clears the bytes unchanged into a `Payload`.
-                let bytes = update_message_bytes(42, (Timestamp::new(u64::MAX, 0, 0), Some(99)));
+                let bytes =
+                    update_message_bytes(42, Entry::present(Timestamp::new(u64::MAX, 0, 0), 99));
                 let payload = auth::Authenticator::new(None, false)
                     .open(&bytes)
                     .expect("unauthenticated mode clears any datagram");
@@ -1653,7 +1665,7 @@ mod deadlock_regressions {
                 // Read back the value the re-entrant hook inserted from the network path. The read
                 // guard is dropped explicitly so it does not outlive `engine` at the block's end.
                 let map_guard = engine.map.read();
-                let reinserted = map_guard.get(&142).and_then(|(_, v)| *v);
+                let reinserted = map_guard.get(&142).and_then(|e| e.value().copied());
                 drop(map_guard);
                 reinserted
             });
@@ -1693,9 +1705,12 @@ mod auth_attack {
         let far_future = Timestamp::new(u64::MAX, 0, 0);
         let message = Message::Update::<
             i32,
-            (Timestamp, Option<String>),
-            crate::reconcilable::ValueOnly<String>,
-        >((0, (far_future, Some("evil".to_string()))));
+            crate::reconcilable::Entry<Timestamp, String>,
+            crate::reconcilable::State<String>,
+        >((
+            0,
+            crate::reconcilable::Entry::present(far_future, "evil".to_string()),
+        ));
         let mut buf = Vec::new();
         message
             .serialize(&mut Serializer::new(&mut buf, DefaultOptions::new()))
@@ -1747,12 +1762,13 @@ mod causal_stability {
     use std::net::IpAddr;
 
     use crate::clock::Timestamp;
+    use crate::reconcilable::Entry;
     use crate::reconcile_engine::{version_hash, ReconcileEngine};
     use crate::reconcile_store::Config;
 
-    type Tombstoned = (Timestamp, Option<i32>);
+    type Tombstoned = Entry<Timestamp, i32>;
 
-    async fn engine(addr: &str) -> ReconcileEngine<i32, Tombstoned> {
+    async fn engine(addr: &str) -> ReconcileEngine<i32, i32> {
         let config = Config::default()
             .with_port(8080)
             .with_listen_addr(addr.parse().unwrap());
@@ -1765,7 +1781,7 @@ mod causal_stability {
         let peer_a: IpAddr = "127.0.0.61".parse().unwrap();
         let peer_b: IpAddr = "127.0.0.62".parse().unwrap();
         let key = 7;
-        let tombstone: Tombstoned = (Timestamp::new(1, 0, 0), None);
+        let tombstone: Tombstoned = Entry::tombstone(Timestamp::new(1, 0, 0));
         let version = version_hash(&tombstone);
 
         // No member known yet: nothing could resurrect the value, so GC is allowed.
@@ -1807,7 +1823,7 @@ mod causal_stability {
         let live: IpAddr = "127.0.0.64".parse().unwrap();
         let gone: IpAddr = "127.0.0.65".parse().unwrap();
         let key = 9;
-        let tombstone: Tombstoned = (Timestamp::new(1, 0, 0), None);
+        let tombstone: Tombstoned = Entry::tombstone(Timestamp::new(1, 0, 0));
         let version = version_hash(&tombstone);
 
         eng.members.write().insert(live);
@@ -1845,7 +1861,7 @@ mod causal_stability {
         let eng = engine("127.0.0.66").await;
         let peer: IpAddr = "127.0.0.67".parse().unwrap();
         let key = 11i32;
-        let tombstone: Tombstoned = (Timestamp::new(2, 0, 0), None);
+        let tombstone: Tombstoned = Entry::tombstone(Timestamp::new(2, 0, 0));
 
         // B is a known member — gates tombstone GC.
         eng.members.write().insert(peer);
@@ -1889,10 +1905,9 @@ mod clock_port {
             .with_port(8080)
             .with_listen_addr("127.0.0.70".parse().unwrap());
         let clock = Arc::new(ManualClock::new(42));
-        let eng: ReconcileEngine<i32, (Timestamp, Option<i32>)> =
-            ReconcileEngine::new_with_clock(config, clock)
-                .await
-                .expect("bind failed");
+        let eng: ReconcileEngine<i32, i32> = ReconcileEngine::new_with_clock(config, clock)
+            .await
+            .expect("bind failed");
 
         assert_eq!(eng.clock_now(), Timestamp::new(0, 1, 42));
         assert_eq!(eng.clock_now(), Timestamp::new(0, 2, 42));
@@ -1908,10 +1923,10 @@ mod pacing {
     use tokio::net::UdpSocket;
 
     use crate::auth::Authenticator;
-    use crate::reconcilable::ValueOnly;
+    use crate::reconcilable::State;
     use crate::reconcile_engine::{send_messages_paced, Message};
 
-    type Msg = Message<u64, Vec<u8>, ValueOnly<u8>>;
+    type Msg = Message<u64, Vec<u8>, State<u8>>;
 
     /// `n` Update messages with `value_len`-byte values — enough to span several 64 KiB datagrams.
     fn bulk_updates(n: u64, value_len: usize) -> Vec<Msg> {
@@ -1979,11 +1994,8 @@ mod pacing {
     /// disabled) is an explicit choice and stays untouched.
     #[tokio::test]
     async fn sub_floor_bulk_send_rate_is_clamped_at_construction() {
-        use crate::clock::Timestamp;
         use crate::reconcile_engine::ReconcileEngine;
         use crate::reconcile_store::{Config, MIN_BULK_SEND_RATE};
-
-        type Tombstoned = (Timestamp, Option<i32>);
 
         // Each case binds a distinct loopback address on an ephemeral port (port 0), so the sockets
         // never collide while a prior engine is still in scope.
@@ -1994,21 +2006,20 @@ mod pacing {
         };
 
         // A 1 B/s rate is far below the floor and is raised to it.
-        let eng: ReconcileEngine<i32, Tombstoned> =
-            ReconcileEngine::new(make("127.0.0.71", Some(1)))
-                .await
-                .expect("bind failed");
+        let eng: ReconcileEngine<i32, i32> = ReconcileEngine::new(make("127.0.0.71", Some(1)))
+            .await
+            .expect("bind failed");
         assert_eq!(eng.bulk_send_rate, Some(MIN_BULK_SEND_RATE));
 
         // A rate at or above the floor is preserved verbatim.
-        let eng: ReconcileEngine<i32, Tombstoned> =
+        let eng: ReconcileEngine<i32, i32> =
             ReconcileEngine::new(make("127.0.0.72", Some(MIN_BULK_SEND_RATE * 4)))
                 .await
                 .expect("bind failed");
         assert_eq!(eng.bulk_send_rate, Some(MIN_BULK_SEND_RATE * 4));
 
         // None disables pacing and is left untouched.
-        let eng: ReconcileEngine<i32, Tombstoned> = ReconcileEngine::new(make("127.0.0.73", None))
+        let eng: ReconcileEngine<i32, i32> = ReconcileEngine::new(make("127.0.0.73", None))
             .await
             .expect("bind failed");
         assert_eq!(eng.bulk_send_rate, None);
@@ -2019,13 +2030,10 @@ mod pacing {
 mod socket_buffers {
     use socket2::SockRef;
 
-    use crate::clock::Timestamp;
     use crate::reconcile_engine::ReconcileEngine;
     use crate::reconcile_store::Config;
 
-    type Tombstoned = (Timestamp, Option<i32>);
-
-    async fn engine(addr: &str, config: Config) -> ReconcileEngine<i32, Tombstoned> {
+    async fn engine(addr: &str, config: Config) -> ReconcileEngine<i32, i32> {
         ReconcileEngine::new(config.with_listen_addr(addr.parse().unwrap()))
             .await
             .expect("bind failed")
@@ -2084,12 +2092,13 @@ mod tombstone_ack_bounds {
     use super::Message;
     use crate::auth;
     use crate::clock::Timestamp;
+    use crate::reconcilable::{Entry, State};
     use crate::reconcile_engine::{version_hash, ReconcileEngine};
     use crate::reconcile_store::Config;
 
-    type Tombstoned = (Timestamp, Option<i32>);
+    type Tombstoned = Entry<Timestamp, i32>;
 
-    async fn engine(addr: &str) -> ReconcileEngine<i32, Tombstoned> {
+    async fn engine(addr: &str) -> ReconcileEngine<i32, i32> {
         // Use a distinct port per module to avoid bind conflicts between parallel test runs.
         let config = Config::default()
             .with_port(0)
@@ -2098,8 +2107,7 @@ mod tombstone_ack_bounds {
     }
 
     fn ack_bytes(key: i32, version: u64) -> Vec<u8> {
-        let msg =
-            Message::Ack::<i32, Tombstoned, crate::reconcilable::ValueOnly<i32>>((key, version));
+        let msg = Message::Ack::<i32, Tombstoned, State<i32>>((key, version));
         let mut buf = Vec::new();
         msg.serialize(&mut Serializer::new(&mut buf, DefaultOptions::new()))
             .unwrap();
@@ -2135,7 +2143,7 @@ mod tombstone_ack_bounds {
         let eng = engine("127.0.0.95").await;
         let key = 10;
         // Insert a live value (Some(_) = not a tombstone).
-        eng.just_insert(key, (Timestamp::new(1, 0, 0), Some(42)));
+        eng.just_insert(key, Entry::present(Timestamp::new(1, 0, 0), 42));
 
         let peer: SocketAddr = "127.0.0.96:9000".parse().unwrap();
         let bytes = ack_bytes(key, 123);
@@ -2158,7 +2166,7 @@ mod tombstone_ack_bounds {
     async fn ack_for_local_tombstone_is_recorded() {
         let eng = engine("127.0.0.97").await;
         let key = 20;
-        let tombstone: Tombstoned = (Timestamp::new(2, 0, 0), None);
+        let tombstone: Tombstoned = Entry::tombstone(Timestamp::new(2, 0, 0));
         let version = version_hash(&tombstone);
         eng.just_insert(key, tombstone);
 
@@ -2213,16 +2221,13 @@ mod dump_budget {
     /// After the first slot is dropped its count returns to zero and a fresh claim succeeds.
     #[tokio::test]
     async fn budget_guard_limits_and_releases_slots() {
-        use crate::clock::Timestamp;
         use crate::reconcile_engine::ReconcileEngine;
-
-        type Tombstoned = (Timestamp, Option<i32>);
 
         let config = Config::default()
             .with_port(0)
             .with_listen_addr("127.0.0.99".parse().unwrap())
             .with_max_concurrent_bulk_dumps(1);
-        let eng = ReconcileEngine::<i32, Tombstoned>::new(config)
+        let eng = ReconcileEngine::<i32, i32>::new(config)
             .await
             .expect("bind failed");
 

--- a/src/reconcile_engine.rs
+++ b/src/reconcile_engine.rs
@@ -328,9 +328,29 @@ impl<K: Key, V: Value> ReconcileEngine<K, V, BincodeCodec> {
         ))
     }
 
-    /// Construct an engine over an injected [`Transport`] (and the default bincode codec + a
-    /// caller-supplied clock). Test-only seam: an in-memory transport makes convergence
-    /// deterministic without real sockets.
+    /// Construct an engine over a caller-supplied [`Transport`], with the default codec and clock.
+    ///
+    /// Infallible: the only fallible step in [`new`](Self::new) is binding the UDP socket, which
+    /// the caller has already done (or does not need to do at all).
+    pub(crate) fn with_transport(
+        config: Config,
+        transport: Arc<dyn Transport<Addr = SocketAddr>>,
+    ) -> Self {
+        let node_id_is_random = config.node_id.is_none();
+        let node_id = config.node_id.unwrap_or_else(rand::random);
+        let clock: Arc<dyn Clock> = Arc::new(HlcClock::new(node_id));
+        Self::build(
+            config,
+            transport,
+            BincodeCodec::new(),
+            clock,
+            node_id_is_random,
+        )
+    }
+
+    /// As [`with_transport`](Self::with_transport), but over a caller-supplied [`Clock`] too.
+    /// Test-only seam: pairing an in-memory transport with a `ManualClock` makes convergence
+    /// deterministic without real sockets or wall-clock time.
     #[cfg(test)]
     pub(crate) fn new_with_transport(
         config: Config,
@@ -522,6 +542,12 @@ impl<K: Key, V: Value, C: Codec> ReconcileEngine<K, V, C> {
     /// Returns `true` when the node id was generated at random (`Config::node_id` was `None`).
     pub(crate) fn node_id_is_random(&self) -> bool {
         self.node_id_is_random
+    }
+
+    /// This node's Hybrid-Logical-Clock identity, read back from the clock adapter so it can never
+    /// disagree with the `node_id` actually stamped onto minted timestamps.
+    pub(crate) fn node_id(&self) -> u64 {
+        self.clock.node_id()
     }
 
     /// (runtime) Replace the declared networks wholesale and re-derive the local network.
@@ -1198,9 +1224,14 @@ impl<K: Key, V: Value, C: Codec> ReconcileEngine<K, V, C> {
                     self.clock.observe(remote_v.stamp);
                     match guard.get(&k) {
                         Some(local_v) => {
-                            let merged_v = local_v.merge(&remote_v);
-                            if merged_v != *local_v {
-                                to_apply.push((k, merged_v));
+                            // Under last-write-wins, `Entry::merge` returns `other` exactly when
+                            // the remote stamp is strictly greater and `self` otherwise, so the
+                            // stamp comparison decides "would merging change state?" on its own.
+                            // Comparing stamps rather than merged values avoids cloning the value
+                            // on this hot path and is why `Value` needs no `PartialEq` bound. The
+                            // equivalence holds *only* under LWW — see ARCHITECTURE.md §7 D5.
+                            if remote_v.stamp > local_v.stamp {
+                                to_apply.push((k, remote_v));
                             } else if local_v.is_tombstone() {
                                 // We already hold an equal-or-newer value; still acknowledge it
                                 // if it is the same tombstone, so the peer learns we have it.

--- a/src/reconcile_engine.rs
+++ b/src/reconcile_engine.rs
@@ -20,21 +20,19 @@ use std::sync::atomic::{AtomicU32, AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use bincode::{DefaultOptions, Deserializer, Serializer};
 use ipnet::IpNet;
 use parking_lot::RwLock;
 use rand::rngs::StdRng;
 use rand::seq::SliceRandom;
 use rand::SeedableRng;
 use serde::{Deserialize, Serialize};
-use socket2::SockRef;
-use tokio::net::{ToSocketAddrs, UdpSocket};
 use tokio::time::{sleep, timeout};
 use tracing::{debug, error, info, instrument, trace, warn};
 
 use crate::auth;
 use crate::bounds::{Key, Value};
 use crate::clock::{Clock, HlcClock, Timestamp};
+use crate::codec::{BincodeCodec, Codec};
 use crate::discovery::{Discovery, RandomProbe};
 use crate::fingerprint::Fingerprint;
 use crate::gen_ip::{host_net, net_of};
@@ -43,9 +41,15 @@ use crate::proto::{self, HashSegment};
 use crate::reconcilable::{Entry, State};
 use crate::reconcile_store::{Config, MAX_NETS};
 use crate::replay;
+use crate::transport::{Transport, UdpTransport};
 use crate::HRTree;
 
 const BUFFER_SIZE: usize = 65507;
+/// Upper bound on protocol messages decoded from a single datagram. A datagram is at most
+/// [`BUFFER_SIZE`] bytes and the smallest message is at least one byte, so it can never legitimately
+/// contain more than this many messages; the cap turns a crafted datagram's decode-expansion into a
+/// bounded operation (issue #151) rather than an unbounded allocation.
+const MAX_MESSAGES_PER_DATAGRAM: usize = BUFFER_SIZE;
 const PEER_EXPIRATION: Duration = Duration::from_secs(60);
 /// Byte budget for the tombstone re-acknowledgments piggybacked onto each reconciliation datagram.
 /// Kept well under [`BUFFER_SIZE`] so the datagram still fits after authentication framing; when
@@ -90,60 +94,20 @@ fn derive_local_net(nets: &[IpNet], listen_addr: IpAddr) -> IpNet {
     })
 }
 
-/// Apply the configured `SO_RCVBUF` / `SO_SNDBUF` to the gossip socket.
-///
-/// `setsockopt` never errors for asking too much: the kernel clamps each request to the OS maximum
-/// (`net.core.rmem_max` / `wmem_max` on Linux), so a generous default only ever helps. Clamping is
-/// therefore expected on an untuned host — **not** a warning condition — so the achieved size is
-/// reported at `debug`; an operator who needs the full buffer raises the sysctl (see the README)
-/// and can confirm via `/proc/net/snmp` `RcvbufErrors`. Only an actual `setsockopt` failure (which
-/// does not happen for a buffer request on a valid socket) is surfaced as a `warn`. A `None` size
-/// leaves the inherited OS default untouched.
-///
-/// Note: on Linux `getsockopt` reports the *doubled* value (bookkeeping overhead), so a fully
-/// honoured request reads back larger than asked.
-fn set_socket_buffers(socket: &UdpSocket, config: &Config) {
-    let sock = SockRef::from(socket);
-    if let Some(size) = config.recv_buffer_size {
-        match sock.set_recv_buffer_size(size) {
-            Ok(()) => match sock.recv_buffer_size() {
-                Ok(actual) => debug!(
-                    "gossip socket SO_RCVBUF: requested {size} B, OS granted {actual} B \
-                     (raise net.core.rmem_max if a larger buffer is needed)"
-                ),
-                Err(e) => debug!("could not read back SO_RCVBUF: {e}"),
-            },
-            Err(e) => warn!("failed to set gossip socket SO_RCVBUF to {size} B: {e}"),
-        }
-    }
-    if let Some(size) = config.send_buffer_size {
-        match sock.set_send_buffer_size(size) {
-            Ok(()) => match sock.send_buffer_size() {
-                Ok(actual) => debug!(
-                    "gossip socket SO_SNDBUF: requested {size} B, OS granted {actual} B \
-                     (raise net.core.wmem_max if a larger buffer is needed)"
-                ),
-                Err(e) => debug!("could not read back SO_SNDBUF: {e}"),
-            },
-            Err(e) => warn!("failed to set gossip socket SO_SNDBUF to {size} B: {e}"),
-        }
-    }
-}
-
 /// The internal reconciliation engine at the network level.
 /// This struct does not handle removals, which are managed by the external layer.
 /// For more information, see [`ReconcileStore`](crate::reconcile_store::ReconcileStore).
-pub(crate) struct ReconcileEngine<K, V> {
+pub(crate) struct ReconcileEngine<K, V, C = BincodeCodec> {
     /// All engine state lives behind a single [`Arc`] so that cloning the engine (every clone
     /// shares the same maps, peers, clock, …) is a single refcount bump. Cloning is therefore
     /// cheap and bound-free, and the previously hand-written `Clone` impl reduces to a derive.
     /// Fields are reached transparently through the [`Deref`] impl below, so every existing
     /// `self.field` / `engine.field` access keeps working unchanged.
-    inner: Arc<Inner<K, V>>,
+    inner: Arc<Inner<K, V, C>>,
 }
 
 /// Shared, refcounted state of a [`ReconcileEngine`]; see that struct for the rationale.
-pub(crate) struct Inner<K, V> {
+pub(crate) struct Inner<K, V, C = BincodeCodec> {
     pub(crate) map: Arc<RwLock<HRTree<K, Entry<Timestamp, V>>>>,
     /// Value-only **projection** of [`map`](Self::map), kept in sync at every map mutation.
     ///
@@ -153,7 +117,12 @@ pub(crate) struct Inner<K, V> {
     /// for the dated↔dated path and never touches the causal-stability bookkeeping.
     pub(crate) projection: Arc<RwLock<HRTree<K, State<V>>>>,
     port: u16,
-    socket: Arc<UdpSocket>,
+    /// The datagram-I/O port (default adapter: [`UdpTransport`]). The engine sends and receives
+    /// only through this, so it never names a concrete socket type.
+    transport: Arc<dyn Transport<Addr = SocketAddr>>,
+    /// The wire-encoding port (default adapter: [`BincodeCodec`]). All (de)serialization of
+    /// protocol messages goes through this, so the engine never calls `bincode` directly.
+    codec: Arc<C>,
     /// The geographical networks the cluster spans, each a CIDR. One random address is
     /// probed per network each round for auto-discovery, and a peer's network is derived from its IP
     /// via `IpNet::contains`. Shared and mutable at runtime (see [`set_nets`](Self::set_nets)) so the
@@ -271,7 +240,7 @@ pub(crate) struct Inner<K, V> {
     pub(crate) change_counter: Arc<AtomicUsize>,
 }
 
-impl<K, V> Clone for ReconcileEngine<K, V> {
+impl<K, V, C> Clone for ReconcileEngine<K, V, C> {
     fn clone(&self) -> Self {
         ReconcileEngine {
             inner: Arc::clone(&self.inner),
@@ -279,8 +248,8 @@ impl<K, V> Clone for ReconcileEngine<K, V> {
     }
 }
 
-impl<K, V> std::ops::Deref for ReconcileEngine<K, V> {
-    type Target = Inner<K, V>;
+impl<K, V, C> std::ops::Deref for ReconcileEngine<K, V, C> {
+    type Target = Inner<K, V, C>;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
@@ -318,8 +287,9 @@ pub(crate) enum Message<K: Serialize, V: Serialize, P: Serialize> {
     ValueUpdate((K, P)),
 }
 
-impl<K: Key, V: Value> ReconcileEngine<K, V> {
-    /// Create a new engine, binding the gossip UDP socket.
+impl<K: Key, V: Value> ReconcileEngine<K, V, BincodeCodec> {
+    /// Create a new engine over the default adapters: a [`UdpTransport`] bound to the gossip socket
+    /// and a [`BincodeCodec`].
     ///
     /// # Errors
     ///
@@ -332,27 +302,67 @@ impl<K: Key, V: Value> ReconcileEngine<K, V> {
         let node_id_is_random = config.node_id.is_none();
         let node_id = config.node_id.unwrap_or_else(rand::random);
         let clock: Arc<dyn Clock> = Arc::new(HlcClock::new(node_id));
-        Self::build(config, clock, node_id_is_random).await
+        let transport = Self::bind_udp(&config).await?;
+        Ok(Self::build(
+            config,
+            transport,
+            BincodeCodec::new(),
+            clock,
+            node_id_is_random,
+        ))
     }
 
-    /// Construct an engine over an explicit [`Clock`] adapter. Test-only seam: a deterministic
-    /// clock (`ManualClock`) makes HLC behaviour reproducible without real wall-clock time.
+    /// Construct an engine over an explicit [`Clock`] adapter (default transport/codec). Test-only
+    /// seam: a deterministic clock (`ManualClock`) makes HLC behaviour reproducible.
     #[cfg(test)]
     pub(crate) async fn new_with_clock(config: Config, clock: Arc<dyn Clock>) -> io::Result<Self> {
         // A test-supplied clock implies a test-supplied (stable) identity; mark it as non-random
         // so persistence tests do not trigger the operator warning.
-        Self::build(config, clock, false).await
+        let transport = Self::bind_udp(&config).await?;
+        Ok(Self::build(
+            config,
+            transport,
+            BincodeCodec::new(),
+            clock,
+            false,
+        ))
     }
 
-    async fn build(
+    /// Construct an engine over an injected [`Transport`] (and the default bincode codec + a
+    /// caller-supplied clock). Test-only seam: an in-memory transport makes convergence
+    /// deterministic without real sockets.
+    #[cfg(test)]
+    pub(crate) fn new_with_transport(
         config: Config,
+        transport: Arc<dyn Transport<Addr = SocketAddr>>,
+        clock: Arc<dyn Clock>,
+    ) -> Self {
+        Self::build(config, transport, BincodeCodec::new(), clock, false)
+    }
+
+    /// Bind the default [`UdpTransport`] for `config` and log the bound address.
+    async fn bind_udp(config: &Config) -> io::Result<Arc<dyn Transport<Addr = SocketAddr>>> {
+        let transport = UdpTransport::bind(
+            SocketAddr::new(config.listen_addr, config.port),
+            config.recv_buffer_size,
+            config.send_buffer_size,
+        )
+        .await?;
+        info!("Listening on: {}", transport.local_addr()?);
+        Ok(Arc::new(transport))
+    }
+}
+
+impl<K: Key, V: Value, C: Codec> ReconcileEngine<K, V, C> {
+    /// Assemble an engine from already-constructed ports (transport, codec) and a clock. Pure
+    /// wiring — no I/O — so it is infallible; the fallible socket bind lives in [`new`](Self::new).
+    fn build(
+        config: Config,
+        transport: Arc<dyn Transport<Addr = SocketAddr>>,
+        codec: C,
         clock: Arc<dyn Clock>,
         node_id_is_random: bool,
-    ) -> io::Result<Self> {
-        let socket = UdpSocket::bind(SocketAddr::new(config.listen_addr, config.port)).await?;
-        info!("Listening on: {}", socket.local_addr()?);
-        // Size the kernel send/receive buffers before any traffic flows.
-        set_socket_buffers(&socket, &config);
+    ) -> Self {
         // Floor the bulk pacing rate. A non-None rate below the floor would make `pace()` sleep for
         // an effectively unbounded time while holding the per-peer in-flight mark, wedging that
         // peer's sync; raise it (with a warning) so the in-flight mark always turns over promptly.
@@ -410,12 +420,13 @@ impl<K: Key, V: Value> ReconcileEngine<K, V> {
         let rng = Arc::new(RwLock::new(StdRng::from_entropy()));
         let probe: Arc<dyn Discovery> =
             Arc::new(RandomProbe::new(Arc::clone(&nets), Arc::clone(&rng)));
-        Ok(ReconcileEngine {
+        ReconcileEngine {
             inner: Arc::new(Inner {
                 map: Arc::new(RwLock::new(map)),
                 projection: Arc::new(RwLock::new(projection)),
                 port: config.port,
-                socket: Arc::new(socket),
+                transport,
+                codec: Arc::new(codec),
                 nets,
                 local_net: Arc::new(RwLock::new(local_net)),
                 listen_addr: config.listen_addr,
@@ -442,7 +453,7 @@ impl<K: Key, V: Value> ReconcileEngine<K, V> {
                 max_peers: config.max_peers,
                 change_counter: Arc::new(AtomicUsize::new(0)),
             }),
-        })
+        }
     }
 
     pub fn fingerprint<R: RangeBounds<K>>(&self, range: R) -> Fingerprint {
@@ -605,7 +616,8 @@ impl<K: Key, V: Value> ReconcileEngine<K, V> {
     fn broadcast(&self, messages: Vec<Message<K, Entry<Timestamp, V>, State<V>>>) {
         let peers = self.get_peers();
         let port = self.port;
-        let socket = Arc::clone(&self.socket);
+        let transport = Arc::clone(&self.transport);
+        let codec = Arc::clone(&self.codec);
         let authenticator = self.authenticator.clone();
         let sender_counter = Arc::clone(&self.sender_counter);
         tokio::spawn(async move {
@@ -614,7 +626,8 @@ impl<K: Key, V: Value> ReconcileEngine<K, V> {
                 let peer = SocketAddr::new(addr, port);
                 send_messages_to(
                     &messages,
-                    Arc::clone(&socket),
+                    &*transport,
+                    &*codec,
                     &authenticator,
                     &sender_counter,
                     &peer,
@@ -698,7 +711,8 @@ impl<K: Key, V: Value> ReconcileEngine<K, V> {
         peer_guard: BulkInFlightGuard,
         global_guard: BulkDumpCountGuard,
     ) {
-        let socket = Arc::clone(&self.socket);
+        let transport = Arc::clone(&self.transport);
+        let codec = Arc::clone(&self.codec);
         let authenticator = self.authenticator.clone();
         let sender_counter = Arc::clone(&self.sender_counter);
         let rate = self.bulk_send_rate;
@@ -710,7 +724,8 @@ impl<K: Key, V: Value> ReconcileEngine<K, V> {
             let mut send_buf = Vec::new();
             send_messages_paced(
                 &messages,
-                socket,
+                &*transport,
+                &*codec,
                 &authenticator,
                 &sender_counter,
                 &peer,
@@ -779,7 +794,7 @@ impl<K: Key, V: Value> ReconcileEngine<K, V> {
         loop {
             // Re-read each iteration so the cadence can be retuned at runtime.
             let recv_timeout = *self.reconcile_interval.read();
-            match timeout(recv_timeout, self.socket.recv_from(&mut recv_buf)).await {
+            match timeout(recv_timeout, self.transport.recv_from(&mut recv_buf)).await {
                 Err(_) => {
                     // timeout
                     debug!("no recent activity; initiating diff protocol");
@@ -893,8 +908,11 @@ impl<K: Key, V: Value> ReconcileEngine<K, V> {
         };
         send_buf.clear();
         for segment in segments {
-            Message::ComparisonItem::<K, Entry<Timestamp, V>, State<V>>(segment)
-                .serialize(&mut Serializer::new(&mut *send_buf, DefaultOptions::new()))
+            self.codec
+                .encode(
+                    &Message::ComparisonItem::<K, Entry<Timestamp, V>, State<V>>(segment),
+                    send_buf,
+                )
                 .expect("serializing a ComparisonItem into an in-memory buffer cannot fail");
         }
         // Geography-aware target selection. With a single network this reduces to the
@@ -960,11 +978,11 @@ impl<K: Key, V: Value> ReconcileEngine<K, V> {
         for peer in targets {
             trace!("start_diff {} bytes to {peer}", send_buf.len());
             if let Err(err) = send_to_retry(
-                &self.socket,
+                &*self.transport,
                 &self.authenticator,
                 &self.sender_counter,
                 send_buf,
-                (peer, self.port),
+                SocketAddr::new(peer, self.port),
             )
             .await
             {
@@ -1011,8 +1029,14 @@ impl<K: Key, V: Value> ReconcileEngine<K, V> {
             // Re-confirm against the map: the tombstone may have been resurrected or GC'd since we
             // snapshotted the index, and only the live tombstone's version is a valid ack.
             if let Some(v) = map_guard.get(key).filter(|v| v.is_tombstone()) {
-                Message::Ack::<K, Entry<Timestamp, V>, State<V>>((key.clone(), version_hash(v)))
-                    .serialize(&mut Serializer::new(&mut *send_buf, DefaultOptions::new()))
+                self.codec
+                    .encode(
+                        &Message::Ack::<K, Entry<Timestamp, V>, State<V>>((
+                            key.clone(),
+                            version_hash(v),
+                        )),
+                        send_buf,
+                    )
                     .expect("serializing an Ack into an in-memory buffer cannot fail");
                 appended += 1;
             }
@@ -1050,31 +1074,28 @@ impl<K: Key, V: Value> ReconcileEngine<K, V> {
         let mut updates: Vec<(K, Entry<Timestamp, V>)> = Vec::new();
         let mut acks: Vec<(K, u64)> = Vec::new();
         let mut value_in_comparison = Vec::new();
-        let mut deserializer = Deserializer::from_slice(payload, DefaultOptions::new());
-        // read messages in buffer
-        loop {
-            match Message::<K, Entry<Timestamp, V>, State<V>>::deserialize(&mut deserializer) {
-                Err(ref kind) => {
-                    if let bincode::ErrorKind::Io(err) = kind.as_ref() {
-                        if err.kind() == std::io::ErrorKind::UnexpectedEof {
-                            break;
-                        }
-                    }
-                    // Never panic on network input: a single malformed datagram from any
-                    // host would otherwise kill the receive loop (unauthenticated remote
-                    // DoS). Drop the rest of the datagram and keep the loop alive, just like
-                    // the oversized-datagram case above.
+        // Decode the whole datagram through the `Codec` port. `MAX_MESSAGES_PER_DATAGRAM` bounds the
+        // message count (a datagram can hold no more one-byte messages than its byte length), so a
+        // crafted datagram cannot be expanded without limit. A malformed datagram is dropped whole —
+        // never panicking the receive loop, an unauthenticated remote-DoS hazard.
+        let messages: Vec<Message<K, Entry<Timestamp, V>, State<V>>> =
+            match self.codec.decode_stream(payload, MAX_MESSAGES_PER_DATAGRAM) {
+                Ok(messages) => messages,
+                Err(kind) => {
                     warn!("failed to deserialize datagram from {peer}, dropping it: {kind:?}");
                     observability::record_datagram_dropped("malformed");
-                    break;
+                    return false;
                 }
-                Ok(Message::ComparisonItem(segment)) => in_comparison.push(segment),
-                Ok(Message::Update(update)) => updates.push(update),
-                Ok(Message::Ack(ack)) => acks.push(ack),
-                Ok(Message::ValueComparisonItem(segment)) => value_in_comparison.push(segment),
+            };
+        for message in messages {
+            match message {
+                Message::ComparisonItem(segment) => in_comparison.push(segment),
+                Message::Update(update) => updates.push(update),
+                Message::Ack(ack) => acks.push(ack),
+                Message::ValueComparisonItem(segment) => value_in_comparison.push(segment),
                 // A dated store is authoritative and never integrates a value-only update; mirrors
                 // are the only consumers of `ValueUpdate`. Ignore it defensively.
-                Ok(Message::ValueUpdate(_)) => {}
+                Message::ValueUpdate(_) => {}
             }
         }
         let spoke_dated = !in_comparison.is_empty() || !updates.is_empty() || !acks.is_empty();
@@ -1126,7 +1147,8 @@ impl<K: Key, V: Value> ReconcileEngine<K, V> {
                     .collect();
                 send_messages_to(
                     &messages,
-                    Arc::clone(&self.socket),
+                    &*self.transport,
+                    &*self.codec,
                     &self.authenticator,
                     &self.sender_counter,
                     &peer,
@@ -1236,7 +1258,8 @@ impl<K: Key, V: Value> ReconcileEngine<K, V> {
             if !acks_to_send.is_empty() {
                 send_messages_to(
                     &acks_to_send,
-                    Arc::clone(&self.socket),
+                    &*self.transport,
+                    &*self.codec,
                     &self.authenticator,
                     &self.sender_counter,
                     &peer,
@@ -1270,7 +1293,8 @@ impl<K: Key, V: Value> ReconcileEngine<K, V> {
                     .collect();
                 send_messages_to(
                     &messages,
-                    Arc::clone(&self.socket),
+                    &*self.transport,
+                    &*self.codec,
                     &self.authenticator,
                     &self.sender_counter,
                     &peer,
@@ -1444,12 +1468,12 @@ impl<K: Key, V: Value> ReconcileEngine<K, V> {
     }
 }
 
-pub(crate) async fn send_to_retry<A: ToSocketAddrs>(
-    socket: &UdpSocket,
+pub(crate) async fn send_to_retry<T: Transport<Addr = SocketAddr> + ?Sized>(
+    transport: &T,
     authenticator: &auth::Authenticator,
     sender_counter: &replay::SenderCounter,
     buf: &[u8],
-    target: A,
+    target: SocketAddr,
 ) -> std::io::Result<usize> {
     // Allocate a sequence number and stamp, then frame the datagram once and reuse it across
     // retries. When authentication is disabled, `seal` returns `None` and the wire bytes are
@@ -1460,7 +1484,7 @@ pub(crate) async fn send_to_retry<A: ToSocketAddrs>(
     let wire: &[u8] = framed.as_deref().unwrap_or(buf);
     let mut res = Ok(0);
     for _ in 0..MAX_SENDTO_RETRIES {
-        res = socket.send_to(wire, &target).await;
+        res = transport.send_to(wire, &target).await;
         if res.is_ok() {
             break;
         }
@@ -1481,17 +1505,25 @@ pub(crate) async fn send_to_retry<A: ToSocketAddrs>(
 /// Used for the small, latency-sensitive batches — refinement comparison items, tombstone acks, and
 /// local-write broadcasts. The bulk anti-entropy value dump uses the paced variant instead;
 /// see [`send_messages_paced`] and [`ReconcileEngine::spawn_paced_send`].
-pub(crate) async fn send_messages_to<K: Serialize, V: Serialize, P: Serialize>(
+pub(crate) async fn send_messages_to<K, V, P, T, C>(
     messages: &[Message<K, V, P>],
-    socket: Arc<UdpSocket>,
+    transport: &T,
+    codec: &C,
     authenticator: &auth::Authenticator,
     sender_counter: &replay::SenderCounter,
     peer: &SocketAddr,
     send_buf: &mut Vec<u8>,
-) {
+) where
+    K: Serialize,
+    V: Serialize,
+    P: Serialize,
+    T: Transport<Addr = SocketAddr> + ?Sized,
+    C: Codec,
+{
     send_messages_paced(
         messages,
-        socket,
+        transport,
+        codec,
         authenticator,
         sender_counter,
         peer,
@@ -1510,15 +1542,23 @@ pub(crate) async fn send_messages_to<K: Serialize, V: Serialize, P: Serialize>(
 /// loop (see [`ReconcileEngine::spawn_paced_send`]); pacing inline in `handle_messages` would stall
 /// reception of every other peer for the duration of the transfer.
 #[instrument(name = "reconcile.send", skip_all, fields(peer = %peer, count = messages.len()))]
-pub(crate) async fn send_messages_paced<K: Serialize, V: Serialize, P: Serialize>(
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn send_messages_paced<K, V, P, T, C>(
     messages: &[Message<K, V, P>],
-    socket: Arc<UdpSocket>,
+    transport: &T,
+    codec: &C,
     authenticator: &auth::Authenticator,
     sender_counter: &replay::SenderCounter,
     peer: &SocketAddr,
     send_buf: &mut Vec<u8>,
     rate: Option<usize>,
-) {
+) where
+    K: Serialize,
+    V: Serialize,
+    P: Serialize,
+    T: Transport<Addr = SocketAddr> + ?Sized,
+    C: Codec,
+{
     debug!("sending {} messages to {peer}", messages.len());
     // Reserve room for the authentication tag so the sealed datagram still fits a UDP payload.
     let max_payload = BUFFER_SIZE - authenticator.overhead();
@@ -1528,17 +1568,17 @@ pub(crate) async fn send_messages_paced<K: Serialize, V: Serialize, P: Serialize
     let mut sent_bytes: usize = 0;
     for message in messages {
         let last_size = send_buf.len();
-        message
-            .serialize(&mut Serializer::new(&mut *send_buf, DefaultOptions::new()))
+        codec
+            .encode(message, send_buf)
             .expect("serializing a protocol Message into an in-memory buffer cannot fail");
         if send_buf.len() > max_payload {
             trace!("sending {} bytes to {peer}", last_size);
             if let Err(err) = send_to_retry(
-                &socket,
+                transport,
                 authenticator,
                 sender_counter,
                 &send_buf[..last_size],
-                peer,
+                *peer,
             )
             .await
             {
@@ -1552,7 +1592,8 @@ pub(crate) async fn send_messages_paced<K: Serialize, V: Serialize, P: Serialize
         }
     }
     trace!("sending last {} bytes to {peer}", send_buf.len());
-    if let Err(err) = send_to_retry(&socket, authenticator, sender_counter, send_buf, peer).await {
+    if let Err(err) = send_to_retry(transport, authenticator, sender_counter, send_buf, *peer).await
+    {
         warn!("failed to send final datagram to {peer}: {err}; continuing");
     } else {
         trace!("sent last {} bytes to {peer}", send_buf.len());
@@ -2021,8 +2062,10 @@ mod pacing {
     use tokio::net::UdpSocket;
 
     use crate::auth::Authenticator;
+    use crate::codec::BincodeCodec;
     use crate::reconcilable::State;
     use crate::reconcile_engine::{send_messages_paced, Message};
+    use crate::transport::UdpTransport;
 
     type Msg = Message<u64, Vec<u8>, State<u8>>;
 
@@ -2037,6 +2080,8 @@ mod pacing {
     /// unconnected UDP socket) at `rate` and return how long it took.
     async fn time_send(messages: &[Msg], rate: Option<usize>) -> Duration {
         let socket = Arc::new(UdpSocket::bind("127.0.0.1:0").await.unwrap());
+        let transport = UdpTransport::new(socket);
+        let codec = BincodeCodec::new();
         let authenticator = Authenticator::new(None, false);
         let sender_counter = crate::replay::SenderCounter::new();
         let peer: SocketAddr = "127.0.0.1:9".parse().unwrap(); // discard port
@@ -2044,7 +2089,8 @@ mod pacing {
         let start = Instant::now();
         send_messages_paced(
             messages,
-            socket,
+            &transport,
+            &codec,
             &authenticator,
             &sender_counter,
             &peer,
@@ -2128,54 +2174,41 @@ mod pacing {
 mod socket_buffers {
     use socket2::SockRef;
 
-    use crate::reconcile_engine::ReconcileEngine;
-    use crate::reconcile_store::Config;
+    use crate::transport::UdpTransport;
 
-    async fn engine(addr: &str, config: Config) -> ReconcileEngine<i32, i32> {
-        ReconcileEngine::new(config.with_listen_addr(addr.parse().unwrap()))
+    async fn bound(addr: &str, recv: Option<usize>, send: Option<usize>) -> UdpTransport {
+        UdpTransport::bind(addr.parse().unwrap(), recv, send)
             .await
             .expect("bind failed")
     }
 
     /// The receive-buffer knob must actually size the gossip socket. Asserting an
     /// absolute byte count would be flaky — the kernel clamps `SO_RCVBUF` to `net.core.rmem_max`,
-    /// which varies per host (and CI sandbox) — so we assert *monotonicity* instead: the multi-MiB
-    /// default must yield a strictly larger buffer than an explicitly tiny request. That holds for
+    /// which varies per host (and CI sandbox) — so we assert *monotonicity* instead: a multi-MiB
+    /// request must yield a strictly larger buffer than an explicitly tiny one. That holds for
     /// any `rmem_max` above a few KiB, which is true on every realistic host.
     #[tokio::test]
     async fn recv_buffer_size_is_configurable() {
-        // Default config requests the multi-MiB DEFAULT_SOCKET_BUFFER_SIZE.
-        let big = engine("127.0.0.90", Config::default()).await;
+        let big = bound("127.0.0.90:0", Some(4 * 1024 * 1024), None).await;
         // An explicit, tiny request — well below any plausible rmem_max, so it is honoured as-is.
-        let small = engine(
-            "127.0.0.91",
-            Config::default().with_recv_buffer_size(8 * 1024),
-        )
-        .await;
+        let small = bound("127.0.0.91:0", Some(8 * 1024), None).await;
 
-        let big_buf = SockRef::from(&*big.socket).recv_buffer_size().unwrap();
-        let small_buf = SockRef::from(&*small.socket).recv_buffer_size().unwrap();
+        let big_buf = SockRef::from(big.socket()).recv_buffer_size().unwrap();
+        let small_buf = SockRef::from(small.socket()).recv_buffer_size().unwrap();
 
         assert!(
             big_buf > small_buf,
-            "the multi-MiB default ({big_buf} B) should exceed an explicitly tiny buffer \
+            "the multi-MiB request ({big_buf} B) should exceed an explicitly tiny buffer \
              ({small_buf} B)"
         );
     }
 
-    /// `None` opts out of the tuning entirely, leaving the inherited OS default. Combined with the
-    /// test above (the default is large), this pins down both ends of the knob: a tiny explicit
-    /// request shrinks the buffer below the large default.
+    /// `None` opts out of the tuning entirely, leaving the inherited OS default: the call path does
+    /// not panic and the socket has a positive receive buffer.
     #[tokio::test]
     async fn recv_buffer_size_none_leaves_os_default() {
-        let config = Config {
-            recv_buffer_size: None,
-            ..Config::default()
-        };
-        let eng = engine("127.0.0.92", config).await;
-        // Just assert it builds and the socket is usable; the OS default is host-dependent, so we
-        // only check the call path does not panic and yields a positive buffer.
-        let buf = SockRef::from(&*eng.socket).recv_buffer_size().unwrap();
+        let t = bound("127.0.0.92:0", None, None).await;
+        let buf = SockRef::from(t.socket()).recv_buffer_size().unwrap();
         assert!(buf > 0, "a socket always has a positive receive buffer");
     }
 }
@@ -2353,5 +2386,97 @@ mod dump_budget {
             "slot must be available after release"
         );
         drop(slot_b_retry);
+    }
+}
+
+#[cfg(test)]
+mod in_memory_convergence {
+    //! Deterministic convergence over the [`InMemoryTransport`](crate::transport::InMemoryTransport):
+    //! two engines exchange datagrams entirely in-process — no real sockets — so the anti-entropy
+    //! protocol is exercised without any network flakiness. The engine reaches its I/O only through
+    //! the `Transport` / `Codec` ports, which is what makes this substitution possible.
+    use std::collections::BTreeMap;
+    use std::net::{IpAddr, SocketAddr};
+    use std::sync::Arc;
+    use std::time::{Duration, Instant};
+
+    use proptest::prelude::*;
+
+    use crate::clock::ManualClock;
+    use crate::reconcilable::Entry;
+    use crate::reconcile_engine::ReconcileEngine;
+    use crate::reconcile_store::Config;
+    use crate::transport::InMemoryNetwork;
+
+    /// Live (value-only) view of an engine's map, for comparing convergence regardless of stamps.
+    fn live_view(eng: &ReconcileEngine<u32, u32>) -> BTreeMap<u32, u32> {
+        eng.map
+            .read()
+            .iter()
+            .filter_map(|(k, e)| e.value().map(|v| (*k, *v)))
+            .collect()
+    }
+
+    /// Load `entries` into engine A and drive both engines over an in-memory network until B's live
+    /// view matches A's (or a short deadline elapses). Returns whether they converged.
+    async fn converges(entries: &[(u32, u32)]) -> bool {
+        let net = InMemoryNetwork::new();
+        let port = 5000u16;
+        let a_ip: IpAddr = "127.0.0.2".parse().unwrap();
+        let b_ip: IpAddr = "127.0.0.3".parse().unwrap();
+        let cfg = |ip: IpAddr| {
+            Config::default()
+                .with_listen_addr(ip)
+                .with_port(port)
+                .with_reconcile_interval(Duration::from_millis(5))
+        };
+        let a: ReconcileEngine<u32, u32> = ReconcileEngine::new_with_transport(
+            cfg(a_ip),
+            Arc::new(net.bind(SocketAddr::new(a_ip, port))),
+            Arc::new(ManualClock::new(1)),
+        );
+        let b: ReconcileEngine<u32, u32> = ReconcileEngine::new_with_transport(
+            cfg(b_ip),
+            Arc::new(net.bind(SocketAddr::new(b_ip, port))),
+            Arc::new(ManualClock::new(2)),
+        );
+        // Seed each as the other's known gossip peer (no real discovery over the in-memory fabric).
+        a.peers.write().insert(b_ip, Instant::now());
+        b.peers.write().insert(a_ip, Instant::now());
+        // Load A only; B must learn every entry purely through anti-entropy.
+        for (k, v) in entries {
+            a.just_insert(*k, Entry::present(a.clock_now(), *v));
+        }
+        let want = live_view(&a);
+
+        let ta = tokio::spawn(a.clone().run());
+        let tb = tokio::spawn(b.clone().run());
+
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let mut converged = false;
+        while Instant::now() < deadline {
+            tokio::time::sleep(Duration::from_millis(20)).await;
+            if live_view(&b) == want {
+                converged = true;
+                break;
+            }
+        }
+        ta.abort();
+        tb.abort();
+        converged
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(12))]
+
+        /// For any small map, a cold replica converges to it over the in-memory transport.
+        #[test]
+        fn cold_replica_converges_over_in_memory_transport(
+            entries in prop::collection::vec((0u32..64, 0u32..1000), 0..24)
+        ) {
+            let rt = tokio::runtime::Runtime::new().unwrap();
+            let ok = rt.block_on(converges(&entries));
+            prop_assert!(ok, "B did not converge to A's {} entries over the in-memory transport", entries.len());
+        }
     }
 }

--- a/src/reconcile_engine.rs
+++ b/src/reconcile_engine.rs
@@ -47,6 +47,11 @@ use crate::HRTree;
 
 const BUFFER_SIZE: usize = 65507;
 const PEER_EXPIRATION: Duration = Duration::from_secs(60);
+/// Byte budget for the tombstone re-acknowledgments piggybacked onto each reconciliation datagram.
+/// Kept well under [`BUFFER_SIZE`] so the datagram still fits after authentication framing; when
+/// more tombstones are held than fit in one round, a round-advancing window covers the remainder on
+/// subsequent rounds.
+const REACK_BYTE_BUDGET: usize = 8 * 1024;
 
 const MAX_SENDTO_RETRIES: u32 = 4;
 
@@ -229,6 +234,14 @@ pub(crate) struct Inner<K, V> {
     pub(crate) members: Arc<RwLock<HashSet<IpAddr>>>,
     /// Per-tombstone acknowledgments: `key -> (peer -> version token of the tombstone it holds)`.
     pub(crate) tombstone_acks: Arc<RwLock<HashMap<K, HashMap<IpAddr, u64>>>>,
+    /// The set of keys this node currently holds as a tombstone, maintained at the single map
+    /// mutation sink ([`map_insert`](ReconcileEngine::map_insert) /
+    /// [`gc_remove`](ReconcileEngine::gc_remove)). It lets the gossip round enumerate held
+    /// tombstones in O(1) (without scanning the map) and re-acknowledge each of them to every
+    /// member every round, so causal-stability acknowledgments keep flowing until a tombstone is
+    /// collected — without which the acknowledgment matrix never completes in a cluster of three or
+    /// more nodes.
+    pub(crate) live_tombstones: Arc<RwLock<HashSet<K>>>,
     /// This node's clock, reached only through the [`Clock`] port so the engine never reads
     /// physical time itself ([`HlcClock`] is the default adapter; a test injects a deterministic
     /// stub via [`new_with_clock`](ReconcileEngine::new_with_clock)). Shared across all clones so
@@ -423,6 +436,7 @@ impl<K: Key, V: Value> ReconcileEngine<K, V> {
                 replay_filter: Arc::new(replay::ReplayFilter::new(config.freshness_window)),
                 members: Arc::new(RwLock::new(HashSet::new())),
                 tombstone_acks: Arc::new(RwLock::new(HashMap::new())),
+                live_tombstones: Arc::new(RwLock::new(HashSet::new())),
                 clock,
                 node_id_is_random,
                 max_peers: config.max_peers,
@@ -443,15 +457,28 @@ impl<K: Key, V: Value> ReconcileEngine<K, V> {
         self.projection.read().hash(&range)
     }
 
-    /// Insert into the dated `map` **and** mirror the value-only projection, under a consistent
-    /// lock order (`map` then `projection`) shared by every mutation path so the two trees never
-    /// deadlock against each other. The caller already holds the `map` write guard.
+    /// Insert into the dated `map` **and** mirror the value-only projection (and the live-tombstone
+    /// index), under a consistent lock order (`map` → `live_tombstones` → `projection`) shared by
+    /// every mutation path so the structures never deadlock against each other. The caller already
+    /// holds the `map` write guard.
     fn map_insert(
         &self,
         guard: &mut HRTree<K, Entry<Timestamp, V>>,
         key: K,
         value: Entry<Timestamp, V>,
     ) -> Option<Entry<Timestamp, V>> {
+        // Keep the live-tombstone index in step with the map at its single mutation sink: a
+        // tombstone value adds the key; any live value (a fresh insert, or an LWW overwrite that
+        // resurrects a previously-deleted key) removes it. This index drives the per-round
+        // causal-stability re-acknowledgment in `start_reconciliation`.
+        {
+            let mut live_tombstones = self.live_tombstones.write();
+            if value.is_tombstone() {
+                live_tombstones.insert(key.clone());
+            } else {
+                live_tombstones.remove(&key);
+            }
+        }
         self.projection.write().insert(key.clone(), value.project());
         guard.insert(key, value)
     }
@@ -459,6 +486,7 @@ impl<K: Key, V: Value> ReconcileEngine<K, V> {
     /// Remove a key from the dated `map` and its value-only projection (the GC removal path).
     pub(crate) fn gc_remove(&self, key: &K) -> Option<Entry<Timestamp, V>> {
         let mut guard = self.map.write();
+        self.live_tombstones.write().remove(key);
         self.projection.write().remove(key);
         let removed = guard.remove(key);
         if removed.is_some() {
@@ -925,6 +953,9 @@ impl<K: Key, V: Value> ReconcileEngine<K, V> {
             }
         }
 
+        // Piggyback causal-stability re-acknowledgments for the tombstones we hold.
+        self.append_tombstone_reacks(send_buf, round);
+
         // initiate the reconciliation protocol with the selected peers and discovery probes
         for peer in targets {
             trace!("start_diff {} bytes to {peer}", send_buf.len());
@@ -941,6 +972,59 @@ impl<K: Key, V: Value> ReconcileEngine<K, V> {
             }
         }
         observability::record_round_duration(timer);
+    }
+
+    /// Append a causal-stability re-acknowledgment (`Message::Ack`) for each tombstone this node
+    /// currently holds onto `send_buf`, returning the number appended.
+    ///
+    /// Acks otherwise only flow back to the node a tombstone was *received* from, so in a cluster of
+    /// three or more nodes two non-originating replicas never learn that the other holds the
+    /// deletion and [`is_tombstone_stable`](Self::is_tombstone_stable) never completes. Re-acking
+    /// held tombstones every round — riding the broadcast `send_buf` to the same geography-throttled
+    /// targets as the diff itself — makes the ack matrix converge transitively. It also dissolves
+    /// the ack-before-tombstone ordering hazard: a receiver that does not hold the tombstone yet
+    /// drops the ack (the admission gate in `handle_messages`, which records an ack only for a
+    /// locally-held tombstone) and simply records it on a later round.
+    ///
+    /// The datagram is kept bounded: at most [`REACK_BYTE_BUDGET`] bytes of acks are appended, and
+    /// when more tombstones are held than fit, the window start advances with `round` so every
+    /// tombstone is re-acked within a bounded number of rounds. The keys are sorted so that window
+    /// is deterministic across rounds (`HashSet` iteration order is not).
+    fn append_tombstone_reacks(&self, send_buf: &mut Vec<u8>, round: u32) -> usize {
+        let mut keys: Vec<K> = self.live_tombstones.read().iter().cloned().collect();
+        if keys.is_empty() {
+            return 0;
+        }
+        keys.sort_unstable();
+        let n = keys.len();
+        let budget = send_buf.len() + REACK_BYTE_BUDGET;
+        let start = (round as usize) % n;
+        let map_guard = self.map.read();
+        let mut appended = 0;
+        let mut budget_truncated = false;
+        for offset in 0..n {
+            if send_buf.len() >= budget {
+                budget_truncated = true;
+                break;
+            }
+            let key = &keys[(start + offset) % n];
+            // Re-confirm against the map: the tombstone may have been resurrected or GC'd since we
+            // snapshotted the index, and only the live tombstone's version is a valid ack.
+            if let Some(v) = map_guard.get(key).filter(|v| v.is_tombstone()) {
+                Message::Ack::<K, Entry<Timestamp, V>, State<V>>((key.clone(), version_hash(v)))
+                    .serialize(&mut Serializer::new(&mut *send_buf, DefaultOptions::new()))
+                    .expect("serializing an Ack into an in-memory buffer cannot fail");
+                appended += 1;
+            }
+        }
+        if budget_truncated {
+            trace!(
+                "re-acked {appended}/{n} held tombstones this round (datagram byte budget reached); \
+                 the remainder rotates in on subsequent rounds"
+            );
+        }
+        observability::record_tombstone_reacks(appended);
+        appended
     }
 
     /// Handle the messages contained in an already-authenticated [`Payload`].
@@ -997,56 +1081,30 @@ impl<K: Key, V: Value> ReconcileEngine<K, V> {
         // record tombstone acknowledgments received from the peer
         if !acks.is_empty() {
             let peer_ip = peer.ip();
-            // Reciprocate acks for tombstones we also hold, so that the deletion originator
-            // (which never receives the tombstone as an inbound update, hence is never acked
-            // by the peer) can still reach causal stability. The `already`-guard bounds this
-            // to at most one extra round-trip and prevents an infinite ack ping-pong.
-            let mut reciprocal_acks = Vec::new();
-            {
-                let map_guard = self.map.read();
-                let mut guard = self.tombstone_acks.write();
-                for (key, version) in acks {
-                    // Accept an ack only for a key we locally hold as a tombstone. Acks for
-                    // never-existent or non-tombstone keys are dropped here so they cannot
-                    // accumulate in `tombstone_acks` without bound.
-                    //
-                    // Ordering hazard: this gate cannot tell "a key we will never hold" from
-                    // "a key we don't hold YET". In a cluster of three or more nodes an ack
-                    // can arrive before the deletion it acknowledges (the acking peer may have
-                    // learned the deletion via a different gossip edge), and a dropped ack is
-                    // not re-delivered. Any future change to causal-stability GC must account
-                    // for this rather than rely on early acks being retained.
-                    let local_tombstone = map_guard.get(&key).filter(|v| v.is_tombstone());
-                    let Some(local_v) = local_tombstone else {
-                        trace!(
-                            "dropped ack from {peer_ip} for key with no local tombstone; \
-                             ignoring to prevent unbounded bookkeeping"
-                        );
-                        continue;
-                    };
-                    let entry = guard.entry(key.clone()).or_default();
-                    let already = entry.get(&peer_ip) == Some(&version);
-                    entry.insert(peer_ip, version);
-                    if !already {
-                        let holds_same_tombstone = version_hash(local_v) == version;
-                        if holds_same_tombstone {
-                            reciprocal_acks.push(Message::Ack::<K, Entry<Timestamp, V>, State<V>>(
-                                (key, version),
-                            ));
-                        }
-                    }
+            let map_guard = self.map.read();
+            let mut guard = self.tombstone_acks.write();
+            for (key, version) in acks {
+                // Accept an ack only for a key we locally hold as a tombstone. Acks for
+                // never-existent or non-tombstone keys are dropped here so they cannot accumulate
+                // in `tombstone_acks` without bound.
+                //
+                // This gate cannot tell "a key we will never hold" from "a key we don't hold YET":
+                // in a cluster of three or more nodes an ack can arrive before the deletion it
+                // acknowledges (the acking peer learned the deletion via a different gossip edge),
+                // and the dropped ack is not re-delivered by the sender. That is benign because
+                // every node re-acknowledges the tombstones it holds on every reconciliation round
+                // (see `start_reconciliation`): once we hold the tombstone, the next round's re-ack
+                // records the peer's acknowledgment. Pairwise reciprocation is no longer needed —
+                // the periodic re-ack is what makes the ack matrix complete across three or more
+                // replicas.
+                if map_guard.get(&key).is_some_and(|v| v.is_tombstone()) {
+                    guard.entry(key).or_default().insert(peer_ip, version);
+                } else {
+                    trace!(
+                        "dropped ack from {peer_ip} for key with no local tombstone; \
+                         ignoring to prevent unbounded bookkeeping"
+                    );
                 }
-            }
-            if !reciprocal_acks.is_empty() {
-                send_messages_to(
-                    &reciprocal_acks,
-                    Arc::clone(&self.socket),
-                    &self.authenticator,
-                    &self.sender_counter,
-                    &peer,
-                    send_buf,
-                )
-                .await;
             }
         }
         // handle messages
@@ -1761,9 +1819,12 @@ mod auth_attack {
 mod causal_stability {
     use std::net::IpAddr;
 
+    use bincode::{DefaultOptions, Deserializer};
+    use serde::Deserialize;
+
     use crate::clock::Timestamp;
-    use crate::reconcilable::Entry;
-    use crate::reconcile_engine::{version_hash, ReconcileEngine};
+    use crate::reconcilable::{Entry, State};
+    use crate::reconcile_engine::{version_hash, Message, ReconcileEngine};
     use crate::reconcile_store::Config;
 
     type Tombstoned = Entry<Timestamp, i32>;
@@ -1815,6 +1876,43 @@ mod causal_stability {
             .or_default()
             .insert(peer_b, version);
         assert!(eng.is_tombstone_stable(&key, version));
+    }
+
+    /// Every reconciliation round must re-emit an `Ack` for each tombstone the node currently holds,
+    /// so the causal-stability ack matrix keeps converging at three or more nodes (where a held
+    /// tombstone is otherwise never re-advertised once two replicas agree on it).
+    /// Deterministic, socket-free: insert a tombstone, run one round, and inspect the datagram.
+    #[tokio::test]
+    async fn reconciliation_round_reacks_held_tombstones() {
+        let eng = engine("127.0.0.66").await;
+        let live_key = 1;
+        let tombstone_key = 2;
+        // A live value must NOT be re-acked; a tombstone must be.
+        eng.just_insert(live_key, Entry::present(Timestamp::new(1, 0, 0), 11));
+        let tombstone: Tombstoned = Entry::tombstone(Timestamp::new(2, 0, 0));
+        let expected_version = version_hash(&tombstone);
+        eng.just_insert(tombstone_key, tombstone);
+
+        let mut buf = Vec::new();
+        eng.start_reconciliation(&mut buf).await;
+
+        // Decode every message in the datagram and collect the acks.
+        let mut acks: Vec<(i32, u64)> = Vec::new();
+        let mut de = Deserializer::from_slice(&buf, DefaultOptions::new());
+        while let Ok(msg) = Message::<i32, Tombstoned, State<i32>>::deserialize(&mut de) {
+            if let Message::Ack(ack) = msg {
+                acks.push(ack);
+            }
+        }
+
+        assert!(
+            acks.contains(&(tombstone_key, expected_version)),
+            "the round must re-ack the held tombstone (key {tombstone_key}); got {acks:?}"
+        );
+        assert!(
+            !acks.iter().any(|(k, _)| *k == live_key),
+            "a live value must never be re-acked; got {acks:?}"
+        );
     }
 
     #[tokio::test]

--- a/src/reconcile_engine.rs
+++ b/src/reconcile_engine.rs
@@ -51,11 +51,11 @@ const BUFFER_SIZE: usize = 65507;
 /// bounded operation (issue #151) rather than an unbounded allocation.
 const MAX_MESSAGES_PER_DATAGRAM: usize = BUFFER_SIZE;
 const PEER_EXPIRATION: Duration = Duration::from_secs(60);
-/// Byte budget for the tombstone re-acknowledgments piggybacked onto each reconciliation datagram.
+/// Byte budget for the tombstone ack resends piggybacked onto each reconciliation datagram.
 /// Kept well under [`BUFFER_SIZE`] so the datagram still fits after authentication framing; when
 /// more tombstones are held than fit in one round, a round-advancing window covers the remainder on
 /// subsequent rounds.
-const REACK_BYTE_BUDGET: usize = 8 * 1024;
+const TOMBSTONE_ACK_RESEND_BYTE_BUDGET: usize = 8 * 1024;
 
 const MAX_SENDTO_RETRIES: u32 = 4;
 
@@ -591,6 +591,17 @@ impl<K: Key, V: Value, C: Codec> ReconcileEngine<K, V, C> {
         guard.keys().cloned().collect()
     }
 
+    /// Bundle this engine's outbound ports and send state for the batched-message helpers
+    /// ([`send_messages_to`] / [`send_messages_paced`]). See [`SendPorts`].
+    fn send_ports(&self) -> SendPorts<'_, dyn Transport<Addr = SocketAddr>, C> {
+        SendPorts {
+            transport: &*self.transport,
+            codec: &*self.codec,
+            authenticator: &self.authenticator,
+            sender_counter: &self.sender_counter,
+        }
+    }
+
     pub fn just_insert(&self, key: K, value: Entry<Timestamp, V>) -> Option<Entry<Timestamp, V>> {
         // 1) Call the pre-insert hook *before* taking the map lock
         (self.pre_insert.read())(&key, &value);
@@ -621,19 +632,16 @@ impl<K: Key, V: Value, C: Codec> ReconcileEngine<K, V, C> {
         let authenticator = self.authenticator.clone();
         let sender_counter = Arc::clone(&self.sender_counter);
         tokio::spawn(async move {
+            let ports = SendPorts {
+                transport: &*transport,
+                codec: &*codec,
+                authenticator: &authenticator,
+                sender_counter: &sender_counter,
+            };
             let mut send_buf = Vec::new();
             for addr in peers {
                 let peer = SocketAddr::new(addr, port);
-                send_messages_to(
-                    &messages,
-                    &*transport,
-                    &*codec,
-                    &authenticator,
-                    &sender_counter,
-                    &peer,
-                    &mut send_buf,
-                )
-                .await;
+                send_messages_to(&messages, &ports, &peer, &mut send_buf).await;
             }
         });
     }
@@ -721,18 +729,14 @@ impl<K: Key, V: Value, C: Codec> ReconcileEngine<K, V, C> {
             // slots on drop, even if this task is aborted or panics.
             let _peer_guard = peer_guard;
             let _global_guard = global_guard;
+            let ports = SendPorts {
+                transport: &*transport,
+                codec: &*codec,
+                authenticator: &authenticator,
+                sender_counter: &sender_counter,
+            };
             let mut send_buf = Vec::new();
-            send_messages_paced(
-                &messages,
-                &*transport,
-                &*codec,
-                &authenticator,
-                &sender_counter,
-                &peer,
-                &mut send_buf,
-                rate,
-            )
-            .await;
+            send_messages_paced(&messages, &ports, &peer, &mut send_buf, rate).await;
         });
     }
 
@@ -971,8 +975,8 @@ impl<K: Key, V: Value, C: Codec> ReconcileEngine<K, V, C> {
             }
         }
 
-        // Piggyback causal-stability re-acknowledgments for the tombstones we hold.
-        self.append_tombstone_reacks(send_buf, round);
+        // Piggyback causal-stability ack resends for the tombstones we hold.
+        self.resend_held_tombstone_acks(send_buf, round);
 
         // initiate the reconciliation protocol with the selected peers and discovery probes
         for peer in targets {
@@ -992,30 +996,30 @@ impl<K: Key, V: Value, C: Codec> ReconcileEngine<K, V, C> {
         observability::record_round_duration(timer);
     }
 
-    /// Append a causal-stability re-acknowledgment (`Message::Ack`) for each tombstone this node
+    /// Resend a causal-stability acknowledgment (`Message::Ack`) for each tombstone this node
     /// currently holds onto `send_buf`, returning the number appended.
     ///
     /// Acks otherwise only flow back to the node a tombstone was *received* from, so in a cluster of
     /// three or more nodes two non-originating replicas never learn that the other holds the
-    /// deletion and [`is_tombstone_stable`](Self::is_tombstone_stable) never completes. Re-acking
-    /// held tombstones every round — riding the broadcast `send_buf` to the same geography-throttled
-    /// targets as the diff itself — makes the ack matrix converge transitively. It also dissolves
-    /// the ack-before-tombstone ordering hazard: a receiver that does not hold the tombstone yet
-    /// drops the ack (the admission gate in `handle_messages`, which records an ack only for a
-    /// locally-held tombstone) and simply records it on a later round.
+    /// deletion and [`is_tombstone_stable`](Self::is_tombstone_stable) never completes. Resending the
+    /// ack for every held tombstone every round — riding the broadcast `send_buf` to the same
+    /// geography-throttled targets as the diff itself — makes the ack matrix converge transitively.
+    /// It also dissolves the ack-before-tombstone ordering hazard: a receiver that does not hold the
+    /// tombstone yet drops the ack (the admission gate in `handle_messages`, which records an ack
+    /// only for a locally-held tombstone) and simply records it on a later round.
     ///
-    /// The datagram is kept bounded: at most [`REACK_BYTE_BUDGET`] bytes of acks are appended, and
-    /// when more tombstones are held than fit, the window start advances with `round` so every
-    /// tombstone is re-acked within a bounded number of rounds. The keys are sorted so that window
-    /// is deterministic across rounds (`HashSet` iteration order is not).
-    fn append_tombstone_reacks(&self, send_buf: &mut Vec<u8>, round: u32) -> usize {
+    /// The datagram is kept bounded: at most [`TOMBSTONE_ACK_RESEND_BYTE_BUDGET`] bytes of acks are
+    /// appended, and when more tombstones are held than fit, the window start advances with `round`
+    /// so every tombstone's ack is resent within a bounded number of rounds. The keys are sorted so
+    /// the window is deterministic across rounds (`HashSet` iteration order is not).
+    fn resend_held_tombstone_acks(&self, send_buf: &mut Vec<u8>, round: u32) -> usize {
         let mut keys: Vec<K> = self.live_tombstones.read().iter().cloned().collect();
         if keys.is_empty() {
             return 0;
         }
         keys.sort_unstable();
         let n = keys.len();
-        let budget = send_buf.len() + REACK_BYTE_BUDGET;
+        let budget = send_buf.len() + TOMBSTONE_ACK_RESEND_BYTE_BUDGET;
         let start = (round as usize) % n;
         let map_guard = self.map.read();
         let mut appended = 0;
@@ -1043,11 +1047,11 @@ impl<K: Key, V: Value, C: Codec> ReconcileEngine<K, V, C> {
         }
         if budget_truncated {
             trace!(
-                "re-acked {appended}/{n} held tombstones this round (datagram byte budget reached); \
-                 the remainder rotates in on subsequent rounds"
+                "resent {appended}/{n} held-tombstone acks this round (datagram byte budget \
+                 reached); the remainder rotates in on subsequent rounds"
             );
         }
-        observability::record_tombstone_reacks(appended);
+        observability::record_tombstone_acks_resent(appended);
         appended
     }
 
@@ -1113,11 +1117,11 @@ impl<K: Key, V: Value, C: Codec> ReconcileEngine<K, V, C> {
                 // in a cluster of three or more nodes an ack can arrive before the deletion it
                 // acknowledges (the acking peer learned the deletion via a different gossip edge),
                 // and the dropped ack is not re-delivered by the sender. That is benign because
-                // every node re-acknowledges the tombstones it holds on every reconciliation round
-                // (see `start_reconciliation`): once we hold the tombstone, the next round's re-ack
-                // records the peer's acknowledgment. Pairwise reciprocation is no longer needed —
-                // the periodic re-ack is what makes the ack matrix complete across three or more
-                // replicas.
+                // every node resends the ack for the tombstones it holds on every reconciliation
+                // round (see `start_reconciliation`): once we hold the tombstone, the next round's
+                // ack resend records the peer's acknowledgment. Pairwise reciprocation is no longer
+                // needed — the periodic ack resend is what makes the ack matrix complete across
+                // three or more replicas.
                 if map_guard.get(&key).is_some_and(|v| v.is_tombstone()) {
                     guard.entry(key).or_default().insert(peer_ip, version);
                 } else {
@@ -1145,16 +1149,7 @@ impl<K: Key, V: Value, C: Codec> ReconcileEngine<K, V, C> {
                     .into_iter()
                     .map(Message::ComparisonItem::<K, Entry<Timestamp, V>, State<V>>)
                     .collect();
-                send_messages_to(
-                    &messages,
-                    &*self.transport,
-                    &*self.codec,
-                    &self.authenticator,
-                    &self.sender_counter,
-                    &peer,
-                    send_buf,
-                )
-                .await;
+                send_messages_to(&messages, &self.send_ports(), &peer, send_buf).await;
             }
             // The differing values are the bulk payload — a cold/empty peer pulls the whole dataset
             // here. Hand them to a rate-paced background task so the burst cannot overrun the
@@ -1256,16 +1251,7 @@ impl<K: Key, V: Value, C: Codec> ReconcileEngine<K, V, C> {
                     .fetch_add(apply_count, Ordering::Relaxed);
             }
             if !acks_to_send.is_empty() {
-                send_messages_to(
-                    &acks_to_send,
-                    &*self.transport,
-                    &*self.codec,
-                    &self.authenticator,
-                    &self.sender_counter,
-                    &peer,
-                    send_buf,
-                )
-                .await;
+                send_messages_to(&acks_to_send, &self.send_ports(), &peer, send_buf).await;
             }
         }
         // Value-only channel: answer a dateless mirror by diffing against the value-only
@@ -1291,16 +1277,7 @@ impl<K: Key, V: Value, C: Codec> ReconcileEngine<K, V, C> {
                     .into_iter()
                     .map(Message::ValueComparisonItem::<K, Entry<Timestamp, V>, State<V>>)
                     .collect();
-                send_messages_to(
-                    &messages,
-                    &*self.transport,
-                    &*self.codec,
-                    &self.authenticator,
-                    &self.sender_counter,
-                    &peer,
-                    send_buf,
-                )
-                .await;
+                send_messages_to(&messages, &self.send_ports(), &peer, send_buf).await;
             }
             // Bulk value-only payload — a dateless mirror pulling the dataset. Rate-pace it on a
             // background task, exactly like the dated bulk path.
@@ -1468,6 +1445,19 @@ impl<K: Key, V: Value, C: Codec> ReconcileEngine<K, V, C> {
     }
 }
 
+/// Bundles the outbound ports and per-node send state that a batched-message send needs: the
+/// [`Transport`] and [`Codec`] ports, the datagram authenticator, and the per-sender replay
+/// counter. These four pieces always travel together into [`send_messages_to`] and
+/// [`send_messages_paced`] from both call sites (the engine and
+/// [`ReconcileMirror`](crate::mirror::ReconcileMirror)); bundling them into one reference keeps
+/// each helper's signature short instead of repeating the same four parameters everywhere.
+pub(crate) struct SendPorts<'a, T: ?Sized, C> {
+    pub(crate) transport: &'a T,
+    pub(crate) codec: &'a C,
+    pub(crate) authenticator: &'a auth::Authenticator,
+    pub(crate) sender_counter: &'a replay::SenderCounter,
+}
+
 pub(crate) async fn send_to_retry<T: Transport<Addr = SocketAddr> + ?Sized>(
     transport: &T,
     authenticator: &auth::Authenticator,
@@ -1507,10 +1497,7 @@ pub(crate) async fn send_to_retry<T: Transport<Addr = SocketAddr> + ?Sized>(
 /// see [`send_messages_paced`] and [`ReconcileEngine::spawn_paced_send`].
 pub(crate) async fn send_messages_to<K, V, P, T, C>(
     messages: &[Message<K, V, P>],
-    transport: &T,
-    codec: &C,
-    authenticator: &auth::Authenticator,
-    sender_counter: &replay::SenderCounter,
+    ports: &SendPorts<'_, T, C>,
     peer: &SocketAddr,
     send_buf: &mut Vec<u8>,
 ) where
@@ -1520,17 +1507,7 @@ pub(crate) async fn send_messages_to<K, V, P, T, C>(
     T: Transport<Addr = SocketAddr> + ?Sized,
     C: Codec,
 {
-    send_messages_paced(
-        messages,
-        transport,
-        codec,
-        authenticator,
-        sender_counter,
-        peer,
-        send_buf,
-        None,
-    )
-    .await
+    send_messages_paced(messages, ports, peer, send_buf, None).await
 }
 
 /// Send `messages` to `peer` as ≤64 KiB datagrams, optionally metered to `rate` bytes/sec.
@@ -1542,13 +1519,9 @@ pub(crate) async fn send_messages_to<K, V, P, T, C>(
 /// loop (see [`ReconcileEngine::spawn_paced_send`]); pacing inline in `handle_messages` would stall
 /// reception of every other peer for the duration of the transfer.
 #[instrument(name = "reconcile.send", skip_all, fields(peer = %peer, count = messages.len()))]
-#[allow(clippy::too_many_arguments)]
 pub(crate) async fn send_messages_paced<K, V, P, T, C>(
     messages: &[Message<K, V, P>],
-    transport: &T,
-    codec: &C,
-    authenticator: &auth::Authenticator,
-    sender_counter: &replay::SenderCounter,
+    ports: &SendPorts<'_, T, C>,
     peer: &SocketAddr,
     send_buf: &mut Vec<u8>,
     rate: Option<usize>,
@@ -1561,22 +1534,23 @@ pub(crate) async fn send_messages_paced<K, V, P, T, C>(
 {
     debug!("sending {} messages to {peer}", messages.len());
     // Reserve room for the authentication tag so the sealed datagram still fits a UDP payload.
-    let max_payload = BUFFER_SIZE - authenticator.overhead();
+    let max_payload = BUFFER_SIZE - ports.authenticator.overhead();
     send_buf.clear();
     // Anchor the pacing schedule once, so it self-corrects rather than drifting per datagram.
     let start = Instant::now();
     let mut sent_bytes: usize = 0;
     for message in messages {
         let last_size = send_buf.len();
-        codec
+        ports
+            .codec
             .encode(message, send_buf)
             .expect("serializing a protocol Message into an in-memory buffer cannot fail");
         if send_buf.len() > max_payload {
             trace!("sending {} bytes to {peer}", last_size);
             if let Err(err) = send_to_retry(
-                transport,
-                authenticator,
-                sender_counter,
+                ports.transport,
+                ports.authenticator,
+                ports.sender_counter,
                 &send_buf[..last_size],
                 *peer,
             )
@@ -1592,7 +1566,14 @@ pub(crate) async fn send_messages_paced<K, V, P, T, C>(
         }
     }
     trace!("sending last {} bytes to {peer}", send_buf.len());
-    if let Err(err) = send_to_retry(transport, authenticator, sender_counter, send_buf, *peer).await
+    if let Err(err) = send_to_retry(
+        ports.transport,
+        ports.authenticator,
+        ports.sender_counter,
+        send_buf,
+        *peer,
+    )
+    .await
     {
         warn!("failed to send final datagram to {peer}: {err}; continuing");
     } else {
@@ -1924,11 +1905,11 @@ mod causal_stability {
     /// tombstone is otherwise never re-advertised once two replicas agree on it).
     /// Deterministic, socket-free: insert a tombstone, run one round, and inspect the datagram.
     #[tokio::test]
-    async fn reconciliation_round_reacks_held_tombstones() {
+    async fn reconciliation_round_resends_acks_for_held_tombstones() {
         let eng = engine("127.0.0.66").await;
         let live_key = 1;
         let tombstone_key = 2;
-        // A live value must NOT be re-acked; a tombstone must be.
+        // A live value's ack must NOT be resent; a tombstone's must be.
         eng.just_insert(live_key, Entry::present(Timestamp::new(1, 0, 0), 11));
         let tombstone: Tombstoned = Entry::tombstone(Timestamp::new(2, 0, 0));
         let expected_version = version_hash(&tombstone);
@@ -1948,11 +1929,11 @@ mod causal_stability {
 
         assert!(
             acks.contains(&(tombstone_key, expected_version)),
-            "the round must re-ack the held tombstone (key {tombstone_key}); got {acks:?}"
+            "the round must resend the ack for the held tombstone (key {tombstone_key}); got {acks:?}"
         );
         assert!(
             !acks.iter().any(|(k, _)| *k == live_key),
-            "a live value must never be re-acked; got {acks:?}"
+            "a live value's ack must never be resent; got {acks:?}"
         );
     }
 
@@ -2064,7 +2045,7 @@ mod pacing {
     use crate::auth::Authenticator;
     use crate::codec::BincodeCodec;
     use crate::reconcilable::State;
-    use crate::reconcile_engine::{send_messages_paced, Message};
+    use crate::reconcile_engine::{send_messages_paced, Message, SendPorts};
     use crate::transport::UdpTransport;
 
     type Msg = Message<u64, Vec<u8>, State<u8>>;
@@ -2084,20 +2065,16 @@ mod pacing {
         let codec = BincodeCodec::new();
         let authenticator = Authenticator::new(None, false);
         let sender_counter = crate::replay::SenderCounter::new();
+        let ports = SendPorts {
+            transport: &transport,
+            codec: &codec,
+            authenticator: &authenticator,
+            sender_counter: &sender_counter,
+        };
         let peer: SocketAddr = "127.0.0.1:9".parse().unwrap(); // discard port
         let mut send_buf = Vec::new();
         let start = Instant::now();
-        send_messages_paced(
-            messages,
-            &transport,
-            &codec,
-            &authenticator,
-            &sender_counter,
-            &peer,
-            &mut send_buf,
-            rate,
-        )
-        .await;
+        send_messages_paced(messages, &ports, &peer, &mut send_buf, rate).await;
         start.elapsed()
     }
 

--- a/src/reconcile_store.rs
+++ b/src/reconcile_store.rs
@@ -14,6 +14,7 @@ use std::hash::Hash;
 use std::io;
 use std::net::IpAddr;
 use std::ops::RangeBounds;
+use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -26,15 +27,35 @@ use crate::bounds::{Key, Value};
 use crate::clock::Timestamp;
 use crate::discovery::{Discovery, DnsDiscovery};
 use crate::fingerprint::Fingerprint;
-use crate::persistence::{DatedEntries, InMemoryPersistence, PersistedState, Persistence};
+use crate::persistence::{
+    DatedEntries, InMemoryPersistence, LoadError, PersistedState, Persistence,
+};
 use crate::reconcilable::Projectable;
 use crate::reconcile_engine::{version_hash, ReconcileEngine};
 use crate::timeout_wheel::TimeoutWheel;
 
 const TOMBSTONE_CLEARING: Duration = Duration::from_secs(1);
 
-/// How often the background task writes a full snapshot to the persistence backend.
-const SNAPSHOT_INTERVAL: Duration = Duration::from_secs(5);
+/// Default cadence of the periodic snapshot task (see [`ReconcileStore::with_snapshot_interval`]).
+const DEFAULT_SNAPSHOT_INTERVAL: Duration = Duration::from_secs(5);
+
+/// Default minimum number of changes between snapshots (see
+/// [`ReconcileStore::with_snapshot_change_threshold`]).
+///
+/// `1` means any change since the last snapshot triggers a write at the next tick. Set to `0` to
+/// snapshot even when the store is idle (every tick, regardless of changes).
+const DEFAULT_SNAPSHOT_CHANGE_THRESHOLD: usize = 1;
+
+/// Number of map entries collected per lock acquisition during a chunked snapshot.
+///
+/// This bounds the maximum time a single snapshot pass holds the map read lock: the lock is
+/// released after each chunk and re-acquired for the next, so writers are only blocked for the
+/// time it takes to clone at most this many entries. The resulting snapshot is **fuzzy** — entries
+/// are captured at slightly different instants across chunks — but every entry is individually
+/// valid LWW state: a restart followed by reconciliation with peers pulls any delta that changed
+/// between chunks. The fuzziness is equivalent to the store having briefly paused writes for a
+/// fraction of the snapshot window, which the LWW reconciliation protocol already handles.
+const SNAPSHOT_CHUNK_SIZE: usize = 1024;
 
 /// Default cadence of the dynamic-discovery task (see [`ReconcileStore::with_discovery_interval`]).
 const DEFAULT_DISCOVERY_INTERVAL: Duration = Duration::from_secs(5);
@@ -116,6 +137,16 @@ where
     /// decommissioned by the discovery task. Members with no pending tombstone acks skip this
     /// floor and are decommissioned as soon as `miss_threshold` rounds elapse.
     discovery_decommission_floor: Duration,
+    /// How often the snapshot task runs. `None` disables time-based snapshots entirely (snapshots
+    /// can still be triggered on-demand via `snapshot()`).
+    snapshot_interval: Option<Duration>,
+    /// Minimum number of changes (inserts / removes / reconciled applies) since the last snapshot
+    /// before the next timed snapshot is written. `0` means always snapshot at the tick, even when
+    /// idle. The counter is reset to zero after every snapshot.
+    snapshot_change_threshold: usize,
+    /// Running count of map mutations since the last snapshot. Shared so that `insert`, `remove`,
+    /// and the reconciliation apply path can all bump it without taking the map lock.
+    change_counter: Arc<AtomicUsize>,
 }
 
 impl<K, V> Clone for ReconcileStore<K, V>
@@ -133,6 +164,9 @@ where
             discovery_interval: self.discovery_interval,
             discovery_miss_threshold: self.discovery_miss_threshold,
             discovery_decommission_floor: self.discovery_decommission_floor,
+            snapshot_interval: self.snapshot_interval,
+            snapshot_change_threshold: self.snapshot_change_threshold,
+            change_counter: self.change_counter.clone(),
         }
     }
 }
@@ -146,14 +180,19 @@ impl<K: Key, V: Value> ReconcileStore<K, V> {
     /// `(config.listen_addr, config.port)` — for example, because the port is already in use or
     /// the address is not available on this host.
     pub async fn new(config: Config) -> io::Result<Self> {
+        let engine = ReconcileEngine::<K, (Timestamp, Option<V>)>::new(config).await?;
+        let change_counter = Arc::clone(&engine.change_counter);
         let svc = ReconcileStore {
-            engine: ReconcileEngine::<K, (Timestamp, Option<V>)>::new(config).await?,
+            engine,
             tombstones: TimeoutWheel::new(),
             persistence: Arc::new(InMemoryPersistence::default()),
             discovery: None,
             discovery_interval: DEFAULT_DISCOVERY_INTERVAL,
             discovery_miss_threshold: DEFAULT_DISCOVERY_MISS_THRESHOLD,
             discovery_decommission_floor: DEFAULT_DISCOVERY_DECOMMISSION_FLOOR,
+            snapshot_interval: Some(DEFAULT_SNAPSHOT_INTERVAL),
+            snapshot_change_threshold: DEFAULT_SNAPSHOT_CHANGE_THRESHOLD,
+            change_counter,
         };
         svc.add_pre_insert(|_, _| {});
         Ok(svc)
@@ -168,15 +207,20 @@ impl<K: Key, V: Value> ReconcileStore<K, V> {
         config: Config,
         clock: Arc<dyn crate::clock::Clock>,
     ) -> io::Result<Self> {
+        let engine =
+            ReconcileEngine::<K, (Timestamp, Option<V>)>::new_with_clock(config, clock).await?;
+        let change_counter = Arc::clone(&engine.change_counter);
         let svc = ReconcileStore {
-            engine: ReconcileEngine::<K, (Timestamp, Option<V>)>::new_with_clock(config, clock)
-                .await?,
+            engine,
             tombstones: TimeoutWheel::new(),
             persistence: Arc::new(InMemoryPersistence::default()),
             discovery: None,
             discovery_interval: DEFAULT_DISCOVERY_INTERVAL,
             discovery_miss_threshold: DEFAULT_DISCOVERY_MISS_THRESHOLD,
             discovery_decommission_floor: DEFAULT_DISCOVERY_DECOMMISSION_FLOOR,
+            snapshot_interval: Some(DEFAULT_SNAPSHOT_INTERVAL),
+            snapshot_change_threshold: DEFAULT_SNAPSHOT_CHANGE_THRESHOLD,
+            change_counter,
         };
         svc.add_pre_insert(|_, _| {});
         Ok(svc)
@@ -194,11 +238,22 @@ impl<K: Key, V: Value> ReconcileStore<K, V> {
     /// Loaded entries are replayed through the pre-insert hook, which preserves each tombstone's
     /// original deletion timestamp and rebuilds the tombstone-expiry wheel.
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// Panics if the backend fails to load (e.g. a corrupt snapshot file): recovering from a
-    /// damaged durable state is a deliberate, explicit decision rather than a silent fresh start.
-    pub fn with_persistence(mut self, backend: Arc<dyn Persistence<K, V>>) -> Self {
+    /// Returns a [`LoadError`] when the backend cannot load:
+    ///
+    /// - [`LoadError::Corrupt`] — the snapshot file exists but could not be decoded. **Do not
+    ///   silently start empty**: that drops tombstones and enables resurrection of previously
+    ///   deleted values. The recommended action is to log the error, alert an operator, and halt.
+    ///   If data loss is acceptable, delete the snapshot and restart.
+    /// - [`LoadError::Io`] — a transient I/O error persisted across all retries (e.g. a volume
+    ///   still mounting). Retrying after a short delay is appropriate.
+    ///
+    /// `NotFound` (no snapshot yet) is a clean fresh start and does not produce an error.
+    pub fn with_persistence(
+        mut self,
+        backend: Arc<dyn Persistence<K, V>>,
+    ) -> Result<Self, LoadError> {
         // Warn operators when a durable backend is used with a randomly-generated node id.
         // A random id changes on every restart, which silently alters this node's LWW
         // conflict-resolution identity: a write made before the restart by "node X" will now
@@ -217,7 +272,15 @@ impl<K: Key, V: Value> ReconcileStore<K, V> {
                  Config::with_node_id to preserve consistent LWW ordering across restarts."
             );
         }
-        if let Some(state) = backend.load().expect("failed to load persisted state") {
+        if let Some(state) = backend.load().map_err(|e| {
+            // Classify the io::Error coming from a generic Persistence impl: if it carried
+            // InvalidData we treat it as corrupt, otherwise as a transient I/O failure.
+            if e.kind() == io::ErrorKind::InvalidData {
+                LoadError::Corrupt(e.to_string())
+            } else {
+                LoadError::Io(e)
+            }
+        })? {
             *self.engine.members.write() = state.members;
             *self.engine.tombstone_acks.write() = state.tombstone_acks;
             // Advance the clock past every persisted timestamp so that the first post-restart
@@ -246,18 +309,60 @@ impl<K: Key, V: Value> ReconcileStore<K, V> {
             self.engine.just_insert_bulk(&state.entries);
         }
         self.persistence = backend;
+        Ok(self)
+    }
+
+    /// Set how often the background task writes a snapshot to the persistence backend
+    /// (default 5 s).
+    ///
+    /// Pass `None` to disable time-based snapshots entirely — snapshots will then only fire when
+    /// the change threshold is crossed and the caller explicitly triggers one (future on-demand
+    /// API), or not at all. When time-based snapshots are disabled and no on-demand mechanism is
+    /// in place, persistence is effectively write-only (saves never happen automatically).
+    ///
+    /// An incremental/segmented snapshot format (write amplification proportional to change
+    /// volume, not dataset size) is deferred to future work.
+    pub fn with_snapshot_interval(mut self, interval: impl Into<Option<Duration>>) -> Self {
+        self.snapshot_interval = interval.into();
         self
     }
 
-    /// Capture the full store state and hand it to the persistence backend.
+    /// Set the minimum number of changes (inserts, removes, and reconciled applies) since the
+    /// last snapshot before the next timed tick actually writes to the backend (default 1).
+    ///
+    /// - `0` — snapshot every tick unconditionally, even when the store is idle.
+    /// - `N > 0` — skip the tick if fewer than `N` changes have occurred since the last snapshot.
+    ///   Steady-state idle ⇒ zero snapshot I/O.
+    ///
+    /// The change counter is reset to zero after every snapshot write, so the threshold applies
+    /// to the *interval* between snapshots, not to the total lifetime change count.
+    pub fn with_snapshot_change_threshold(mut self, threshold: usize) -> Self {
+        self.snapshot_change_threshold = threshold;
+        self
+    }
+
+    /// Capture the store state and hand it to the persistence backend.
+    ///
+    /// # Chunked (fuzzy) snapshot
+    ///
+    /// The map is iterated in key-order chunks of [`SNAPSHOT_CHUNK_SIZE`] entries. The read lock
+    /// is **released between chunks**, so writers (inserts, removes, reconciliation applies) are
+    /// only blocked for the time it takes to clone one chunk — bounded independently of dataset
+    /// size. The resulting snapshot is **fuzzy**: entries captured in different chunks may reflect
+    /// slightly different instants. Every captured entry is individually valid LWW state, and a
+    /// restart followed by reconciliation with peers will pull any delta that changed between
+    /// chunks. This trade-off is equivalent to briefly pausing writes for a fraction of the
+    /// snapshot window, which the LWW protocol already handles.
+    ///
+    /// After the snapshot write the change counter is reset to zero so the threshold logic in
+    /// [`snapshot_periodically`] starts a fresh accounting window.
     fn snapshot(&self) {
-        let entries: DatedEntries<K, V> = self
-            .engine
-            .map
-            .read()
-            .iter()
-            .map(|(k, v)| (k.clone(), v.clone()))
-            .collect();
+        // Capture the counter BEFORE collecting entries so that any changes that arrive during the
+        // (potentially multi-chunk) collection are still counted in the next snapshot window.
+        // After a successful save we subtract exactly what we captured, not a blind zero: if more
+        // changes arrived during collection they remain pending and the next tick will see them.
+        let captured = self.change_counter.load(AtomicOrdering::Relaxed);
+        let entries = self.collect_entries_chunked();
         let state = PersistedState {
             entries,
             members: self.engine.members.read().clone(),
@@ -265,14 +370,80 @@ impl<K: Key, V: Value> ReconcileStore<K, V> {
         };
         if let Err(err) = self.persistence.save(&state) {
             warn!("failed to persist reconcile store snapshot: {err}");
+        } else {
+            // Subtract only the count we captured, not zero out the whole counter: any change
+            // that arrived during the chunked collection is still reflected after this subtraction
+            // and will trigger a snapshot at the next tick.
+            self.change_counter
+                .fetch_sub(captured, AtomicOrdering::Relaxed);
         }
     }
 
-    /// Periodically snapshot the full store state to the persistence backend.
-    async fn snapshot_periodically(&self) {
+    /// Collect all map entries in key order, releasing the read lock between chunks of
+    /// [`SNAPSHOT_CHUNK_SIZE`] entries. Returns the full `DatedEntries` vector.
+    fn collect_entries_chunked(&self) -> DatedEntries<K, V> {
+        use std::ops::Bound;
+
+        let mut entries: DatedEntries<K, V> = Vec::new();
+        // Cursor: the last key seen in the previous chunk, used to open the next range.
+        let mut cursor: Option<K> = None;
         loop {
-            tokio::time::sleep(SNAPSHOT_INTERVAL).await;
-            self.snapshot();
+            let chunk: Vec<(K, (Timestamp, Option<V>))> = {
+                let guard = self.engine.map.read();
+                match cursor.take() {
+                    None => guard
+                        .iter()
+                        .take(SNAPSHOT_CHUNK_SIZE)
+                        .map(|(k, v)| (k.clone(), v.clone()))
+                        .collect(),
+                    Some(last) => {
+                        // Iterate all keys strictly above `last`.
+                        // `(Bound::Excluded(K), Bound::Unbounded)` implements `RangeBounds<K>`.
+                        let range = (Bound::Excluded(last), Bound::Unbounded);
+                        guard
+                            .get_range(&range)
+                            .take(SNAPSHOT_CHUNK_SIZE)
+                            .map(|(k, v)| (k.clone(), v.clone()))
+                            .collect()
+                    }
+                }
+                // Lock released here (guard drops at end of block).
+            };
+
+            let done = chunk.len() < SNAPSHOT_CHUNK_SIZE;
+            if let Some((last_key, _)) = chunk.last() {
+                cursor = Some(last_key.clone());
+            }
+            entries.extend(chunk);
+            if done {
+                break;
+            }
+        }
+        entries
+    }
+
+    /// Periodically snapshot the full store state to the persistence backend.
+    ///
+    /// Snapshots are skipped when the change counter is below
+    /// [`snapshot_change_threshold`](Self::with_snapshot_change_threshold), so a steady-state idle
+    /// store produces no snapshot I/O. Time-based snapshotting can be disabled entirely via
+    /// [`with_snapshot_interval(None)`](Self::with_snapshot_interval).
+    async fn snapshot_periodically(&self) {
+        let Some(interval) = self.snapshot_interval else {
+            return; // time-based snapshots disabled
+        };
+        loop {
+            tokio::time::sleep(interval).await;
+            let changes = self.change_counter.load(AtomicOrdering::Relaxed);
+            if changes >= self.snapshot_change_threshold {
+                self.snapshot();
+            } else {
+                debug!(
+                    changes,
+                    threshold = self.snapshot_change_threshold,
+                    "skipping snapshot: change count below threshold"
+                );
+            }
         }
     }
 
@@ -438,6 +609,7 @@ impl<K: Key, V: Value> ReconcileStore<K, V> {
     ///
     /// Returns the overwritten value if the key already existed.
     pub fn just_insert(&self, key: K, value: V) -> Option<V> {
+        self.change_counter.fetch_add(1, AtomicOrdering::Relaxed);
         let ret = self
             .engine
             .just_insert(key, (self.engine.clock_now(), Some(value)));
@@ -446,6 +618,7 @@ impl<K: Key, V: Value> ReconcileStore<K, V> {
 
     /// Fully-qualified insert: just_insert + async broadcast.
     pub fn insert(&self, key: K, value: V) -> Option<V> {
+        self.change_counter.fetch_add(1, AtomicOrdering::Relaxed);
         let ret = self
             .engine
             .insert(key, (self.engine.clock_now(), Some(value)));
@@ -459,6 +632,8 @@ impl<K: Key, V: Value> ReconcileStore<K, V> {
     /// 1. Runs the pre-insert hook for each entry (outside any lock).
     /// 2. Acquires the write lock once and inserts all entries.
     pub fn just_insert_bulk(&self, key_values: &[(K, V)]) {
+        self.change_counter
+            .fetch_add(key_values.len(), AtomicOrdering::Relaxed);
         self.engine.just_insert_bulk(
             &key_values
                 .iter()
@@ -469,6 +644,8 @@ impl<K: Key, V: Value> ReconcileStore<K, V> {
 
     /// Bulk-insert + async broadcast.
     pub fn insert_bulk(&self, key_values: &[(K, V)]) {
+        self.change_counter
+            .fetch_add(key_values.len(), AtomicOrdering::Relaxed);
         self.engine.insert_bulk(
             &key_values
                 .iter()
@@ -478,6 +655,7 @@ impl<K: Key, V: Value> ReconcileStore<K, V> {
     }
 
     pub fn just_remove(&self, key: &K) -> Option<V> {
+        self.change_counter.fetch_add(1, AtomicOrdering::Relaxed);
         let ret = self
             .engine
             .just_insert(key.clone(), (self.engine.clock_now(), None));
@@ -485,6 +663,7 @@ impl<K: Key, V: Value> ReconcileStore<K, V> {
     }
 
     pub fn remove(&self, key: &K) -> Option<V> {
+        self.change_counter.fetch_add(1, AtomicOrdering::Relaxed);
         let ret = self
             .engine
             .insert(key.clone(), (self.engine.clock_now(), None));
@@ -492,6 +671,8 @@ impl<K: Key, V: Value> ReconcileStore<K, V> {
     }
 
     pub fn just_remove_bulk(&self, keys: &[K]) {
+        self.change_counter
+            .fetch_add(keys.len(), AtomicOrdering::Relaxed);
         self.engine.just_insert_bulk(
             &keys
                 .iter()
@@ -507,6 +688,8 @@ impl<K: Key, V: Value> ReconcileStore<K, V> {
     /// caller-chosen `DateTime` could collide with another replica's and trigger the
     /// non-commutative tie-break that caused permanent divergence.
     pub fn remove_bulk(&self, keys: &[K]) {
+        self.change_counter
+            .fetch_add(keys.len(), AtomicOrdering::Relaxed);
         self.engine.insert_bulk(
             &keys
                 .iter()
@@ -831,6 +1014,7 @@ impl<K: Key, V: Value> ReconcileStore<K, V> {
         // Notify peers of the re-stamped entry, just like `insert`, so the edit propagates eagerly
         // rather than being left to the next anti-entropy round (or failing to converge at all).
         if let Some(value) = updated {
+            self.change_counter.fetch_add(1, AtomicOrdering::Relaxed);
             self.engine.broadcast_update(k.clone(), value);
         }
     }
@@ -1246,7 +1430,8 @@ mod reconcile_store_tests {
         let store = ReconcileStore::<i32, i32>::new(ephemeral_config())
             .await
             .expect("bind failed")
-            .with_persistence(Arc::new(FileSnapshot::new(&path)));
+            .with_persistence(Arc::new(FileSnapshot::new(&path)))
+            .expect("load failed");
         store.insert(1, 11); // live value
         store.insert(2, 22);
         store.remove(&2); // tombstone
@@ -1257,7 +1442,8 @@ mod reconcile_store_tests {
         let restarted = ReconcileStore::<i32, i32>::new(ephemeral_config())
             .await
             .expect("bind failed")
-            .with_persistence(Arc::new(FileSnapshot::new(&path)));
+            .with_persistence(Arc::new(FileSnapshot::new(&path)))
+            .expect("load failed");
         assert_eq!(restarted.get(&1).as_deref(), Some(&11));
         assert!(restarted.get(&2).is_none(), "tombstone was not recovered");
         assert_eq!(
@@ -1280,7 +1466,8 @@ mod reconcile_store_tests {
         let store = ReconcileStore::<i32, i32>::new(ephemeral_config())
             .await
             .expect("bind failed")
-            .with_persistence(Arc::new(FileSnapshot::new(&path)));
+            .with_persistence(Arc::new(FileSnapshot::new(&path)))
+            .expect("load failed");
         store.engine.members.write().insert(peer);
         store.insert(5, 55);
         store.remove(&5); // tombstone
@@ -1296,7 +1483,8 @@ mod reconcile_store_tests {
         let restarted = ReconcileStore::<i32, i32>::new(ephemeral_config())
             .await
             .expect("bind failed")
-            .with_persistence(Arc::new(FileSnapshot::new(&path)));
+            .with_persistence(Arc::new(FileSnapshot::new(&path)))
+            .expect("load failed");
         assert!(
             restarted.engine.members.read().contains(&peer),
             "membership set was not restored"
@@ -1326,7 +1514,8 @@ mod reconcile_store_tests {
         let store = ReconcileStore::<i32, i32>::new(ephemeral_config())
             .await
             .expect("bind failed")
-            .with_persistence(Arc::new(FileSnapshot::new(&path)));
+            .with_persistence(Arc::new(FileSnapshot::new(&path)))
+            .expect("load failed");
         store.engine.members.write().insert(peer);
         store.insert(1, 11);
         store.remove(&1); // tombstone, never acknowledged by `peer`
@@ -1355,7 +1544,8 @@ mod reconcile_store_tests {
         let restarted = ReconcileStore::<i32, i32>::new(ephemeral_config())
             .await
             .expect("bind failed")
-            .with_persistence(Arc::new(FileSnapshot::new(&path)));
+            .with_persistence(Arc::new(FileSnapshot::new(&path)))
+            .expect("load failed");
         assert!(restarted.get(&1).is_none(), "tombstone was not recovered");
         let version = restarted
             .engine
@@ -1540,7 +1730,8 @@ mod reconcile_store_tests {
             ReconcileStore::<i32, i32>::new_with_clock(ephemeral_config().with_node_id(1), clock)
                 .await
                 .expect("bind failed")
-                .with_persistence(backend);
+                .with_persistence(backend)
+                .expect("load failed");
 
         // Insert a new value; the minted timestamp must be strictly greater than persisted_stamp.
         store.insert(99, 1);
@@ -1593,7 +1784,8 @@ mod reconcile_store_tests {
             ReconcileStore::<i32, i32>::new_with_clock(ephemeral_config().with_node_id(2), clock)
                 .await
                 .expect("bind failed")
-                .with_persistence(backend);
+                .with_persistence(backend)
+                .expect("load failed");
 
         // The tombstone was recovered (key 7 is absent from the live view).
         assert!(
@@ -1917,5 +2109,448 @@ mod reconcile_store_tests {
         );
 
         task.abort();
+    }
+
+    // ── Persistence robustness tests ──────────────────────────────────────────
+
+    /// Corrupt snapshot → `with_persistence` returns `LoadError::Corrupt`, no panic.
+    #[tokio::test]
+    async fn with_persistence_corrupt_snapshot_returns_error() {
+        use crate::persistence::LoadError;
+        use std::fs;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("snapshot.bin");
+        fs::write(&path, b"this is not valid bincode").unwrap();
+
+        let result = ReconcileStore::<i32, i32>::new(ephemeral_config())
+            .await
+            .expect("bind failed")
+            .with_persistence(Arc::new(FileSnapshot::new(&path)));
+
+        match result {
+            Err(LoadError::Corrupt(_)) => {} // expected
+            Err(LoadError::Io(e)) => panic!("expected Corrupt, got Io: {e}"),
+            Ok(_) => panic!("expected Err(Corrupt), got Ok"),
+        }
+    }
+
+    /// Transient I/O error (snapshot path is a directory) → `with_persistence` returns
+    /// `LoadError::Io` after retries, no panic.
+    #[tokio::test]
+    async fn with_persistence_transient_io_returns_error() {
+        use crate::persistence::LoadError;
+
+        // Using a directory as the snapshot path triggers EISDIR on read — a non-NotFound,
+        // non-InvalidData I/O error that should surface as LoadError::Io.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().to_path_buf(); // the directory itself, not a file inside it
+
+        let result = ReconcileStore::<i32, i32>::new(ephemeral_config())
+            .await
+            .expect("bind failed")
+            .with_persistence(Arc::new(FileSnapshot::new(&path)));
+
+        match result {
+            Err(LoadError::Io(_)) => {}      // expected
+            Err(LoadError::Corrupt(_)) => {} // also acceptable on platforms that surface EISDIR as invalid data
+            Ok(_) => panic!("expected Err when the snapshot path is a directory"),
+        }
+    }
+
+    /// `with_persistence` on a path that does not exist yet must return `Ok` (fresh start).
+    #[tokio::test]
+    async fn with_persistence_not_found_is_fresh_start() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("nonexistent.bin");
+
+        let store = ReconcileStore::<i32, i32>::new(ephemeral_config())
+            .await
+            .expect("bind failed")
+            .with_persistence(Arc::new(FileSnapshot::new(&path)))
+            .expect("NotFound must be a clean fresh start, not an error");
+
+        // Store is empty (no state was loaded).
+        assert!(store.get(&1).is_none());
+    }
+
+    // ── Chunked-snapshot stall-bound test ──────────────────────────────────────
+
+    /// Verify that the chunked snapshot path holds the read lock for at most
+    /// `SNAPSHOT_CHUNK_SIZE` entries per acquisition, regardless of total map size.
+    ///
+    /// Rather than asserting wall-clock latency (which is flaky in CI), we instrument
+    /// `collect_entries_chunked` indirectly: insert 3× the chunk size entries, run the chunked
+    /// collector, and verify that we get all entries back. The structural property — at most
+    /// SNAPSHOT_CHUNK_SIZE entries per lock hold — is guaranteed by the implementation; this test
+    /// confirms correct end-to-end assembly of the chunks.
+    #[tokio::test]
+    async fn chunked_snapshot_collects_all_entries() {
+        let n = super::SNAPSHOT_CHUNK_SIZE * 3 + 7; // straddle chunk boundaries
+
+        let store = ReconcileStore::<i32, i32>::new(ephemeral_config())
+            .await
+            .expect("bind failed");
+
+        for i in 0..(n as i32) {
+            store.just_insert(i, i * 2);
+        }
+
+        let entries = store.collect_entries_chunked();
+        assert_eq!(
+            entries.len(),
+            n,
+            "chunked snapshot must collect all {n} entries"
+        );
+
+        // Entries must be in ascending key order (the HRTree is ordered).
+        let keys: Vec<i32> = entries.iter().map(|(k, _)| *k).collect();
+        let mut sorted = keys.clone();
+        sorted.sort();
+        assert_eq!(keys, sorted, "entries must be in ascending key order");
+    }
+
+    // ── Snapshot interval + change threshold tests ────────────────────────────
+
+    /// With a threshold of N and fewer than N changes, no snapshot fires at the next tick.
+    /// With ≥ N changes, the snapshot fires.
+    #[tokio::test]
+    async fn snapshot_threshold_gates_writes() {
+        use crate::persistence::{InMemoryPersistence, Persistence};
+
+        let backend = Arc::new(InMemoryPersistence::<i32, i32>::new());
+
+        let store = ReconcileStore::<i32, i32>::new(ephemeral_config())
+            .await
+            .expect("bind failed")
+            .with_persistence(backend.clone())
+            .expect("load failed")
+            // Require at least 3 changes before a snapshot is written.
+            .with_snapshot_change_threshold(3)
+            // Very short interval so the test does not need to wait long.
+            .with_snapshot_interval(Duration::from_millis(20));
+
+        // Make only 2 changes (below threshold).
+        store.just_insert(1, 10);
+        store.just_insert(2, 20);
+
+        // Wait several tick periods — threshold not met, no snapshot should appear.
+        tokio::time::sleep(Duration::from_millis(120)).await;
+
+        // Simulate what snapshot_periodically does:
+        let changes = store
+            .change_counter
+            .load(std::sync::atomic::Ordering::Relaxed);
+        assert!(
+            changes < 3,
+            "precondition: fewer than threshold changes (got {changes})"
+        );
+        // The backend has never been written to.
+        assert!(
+            Persistence::<i32, i32>::load(backend.as_ref())
+                .unwrap()
+                .is_none(),
+            "snapshot must not fire when change count is below threshold"
+        );
+
+        // Add a third change to cross the threshold.
+        store.just_insert(3, 30);
+        // Manually trigger the snapshot (as snapshot_periodically would).
+        store.snapshot();
+
+        assert!(
+            Persistence::<i32, i32>::load(backend.as_ref())
+                .unwrap()
+                .is_some(),
+            "snapshot must fire once change count reaches threshold"
+        );
+    }
+
+    /// With threshold 0, snapshot fires every tick even when the store is idle.
+    #[tokio::test]
+    async fn snapshot_threshold_zero_always_fires() {
+        use crate::persistence::{InMemoryPersistence, Persistence};
+
+        let backend = Arc::new(InMemoryPersistence::<i32, i32>::new());
+        let store = ReconcileStore::<i32, i32>::new(ephemeral_config())
+            .await
+            .expect("bind failed")
+            .with_persistence(backend.clone())
+            .expect("load failed")
+            .with_snapshot_change_threshold(0);
+
+        // No changes at all — threshold 0 means always snapshot.
+        let changes = store
+            .change_counter
+            .load(std::sync::atomic::Ordering::Relaxed);
+        assert_eq!(changes, 0);
+        // At threshold 0, the condition `changes >= threshold` is `0 >= 0` = true.
+        assert!(
+            changes >= store.snapshot_change_threshold,
+            "threshold 0 must always be met"
+        );
+        store.snapshot();
+        assert!(
+            Persistence::<i32, i32>::load(backend.as_ref())
+                .unwrap()
+                .is_some(),
+            "threshold 0 must snapshot even when idle"
+        );
+    }
+
+    /// `with_snapshot_interval(None)` disables time-based snapshots: `snapshot_periodically`
+    /// returns immediately without writing anything.
+    #[tokio::test]
+    async fn snapshot_interval_none_disables_time_based_snapshots() {
+        use crate::persistence::{InMemoryPersistence, Persistence};
+
+        let backend = Arc::new(InMemoryPersistence::<i32, i32>::new());
+        let store = ReconcileStore::<i32, i32>::new(ephemeral_config())
+            .await
+            .expect("bind failed")
+            .with_persistence(backend.clone())
+            .expect("load failed")
+            .with_snapshot_interval(None);
+
+        assert!(
+            store.snapshot_interval.is_none(),
+            "snapshot_interval must be None after with_snapshot_interval(None)"
+        );
+
+        // snapshot_periodically returns immediately when interval is None.
+        // We verify by running it with a timeout: it must complete well within 50 ms.
+        let store2 = store.clone();
+        tokio::time::timeout(Duration::from_millis(50), async move {
+            store2.snapshot_periodically().await
+        })
+        .await
+        .expect("snapshot_periodically must return immediately when interval is None");
+
+        // No snapshot should have been written.
+        assert!(
+            Persistence::<i32, i32>::load(backend.as_ref())
+                .unwrap()
+                .is_none(),
+            "disabled time-based snapshots must not write anything"
+        );
+    }
+
+    // ── Regression tests for the gossip-path change counter bug ──────────────
+
+    /// **Gossip-durability regression**: a replica that receives entries ONLY via gossip (never
+    /// writes locally) must still snapshot, because the engine-side change counter is now bumped
+    /// by the gossip apply path.
+    ///
+    /// Two-node setup:
+    ///   - Node A writes two entries locally and runs the reconcile loop.
+    ///   - Node B has FileSnapshot + short interval + default threshold=1, but inserts NOTHING
+    ///     itself; it only receives updates via gossip.
+    ///
+    /// Expected: B's snapshot file is written (and contains the entries) within a bounded wait.
+    ///
+    /// This test FAILS against the unfixed code (B's counter stays 0 → no snapshot ever) and
+    /// PASSES with the fix.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn gossip_only_replica_snapshots() {
+        use crate::persistence::Persistence;
+        use tokio::time::{timeout, Duration};
+
+        // Bind on two distinct loopback addresses on the same /29, so they form a cluster.
+        let addr_a: IpAddr = "127.1.0.1".parse().unwrap();
+        let addr_b: IpAddr = "127.1.0.2".parse().unwrap();
+        let port = 9900u16;
+        let net: ipnet::IpNet = "127.1.0.0/29".parse().unwrap();
+
+        let config_a = Config {
+            port,
+            listen_addr: addr_a,
+            nets: {
+                let mut nets = [None; MAX_NETS];
+                nets[0] = Some(net);
+                nets
+            },
+            reconcile_interval: Duration::from_millis(50),
+            ..Config::default()
+        };
+        let config_b = Config {
+            port,
+            listen_addr: addr_b,
+            nets: {
+                let mut nets = [None; MAX_NETS];
+                nets[0] = Some(net);
+                nets
+            },
+            reconcile_interval: Duration::from_millis(50),
+            ..Config::default()
+        };
+
+        // Node A: just writes — no persistence needed.
+        let store_a = ReconcileStore::<i32, i32>::new(config_a)
+            .await
+            .expect("bind A failed")
+            .with_seed(addr_b);
+
+        // Node B: snapshot backend + short interval (100 ms) + threshold=1 (default).
+        let dir = tempfile::tempdir().unwrap();
+        let snap_path = dir.path().join("b.snapshot");
+        let backend_b = Arc::new(FileSnapshot::new(&snap_path));
+        let store_b = ReconcileStore::<i32, i32>::new(config_b)
+            .await
+            .expect("bind B failed")
+            .with_seed(addr_a)
+            .with_persistence(backend_b.clone())
+            .expect("load B failed")
+            .with_snapshot_interval(Duration::from_millis(100))
+            .with_snapshot_change_threshold(1); // default, but explicit for clarity
+
+        // Spawn both loops.
+        let task_a = tokio::spawn(store_a.clone().run());
+        let task_b = tokio::spawn(store_b.clone().run());
+
+        // A writes two entries; B receives them via gossip only.
+        store_a.insert(10, 100);
+        store_a.insert(20, 200);
+
+        // Wait up to 5 s for B's snapshot file to appear (it only takes a few gossip rounds +
+        // one snapshot tick, each ≤ 100 ms, so this is very generous).
+        let snap_written = timeout(Duration::from_secs(5), async {
+            loop {
+                if let Ok(Some(state)) = Persistence::<i32, i32>::load(backend_b.as_ref()) {
+                    if !state.entries.is_empty() {
+                        return state;
+                    }
+                }
+                tokio::time::sleep(Duration::from_millis(50)).await;
+            }
+        })
+        .await
+        .expect("B's snapshot was never written within 5 s — gossip-path counter not bumped");
+
+        // Confirm the snapshot actually contains the right data.
+        let keys: Vec<i32> = snap_written
+            .entries
+            .iter()
+            .filter_map(|(k, (_, v))| v.as_ref().map(|_| *k))
+            .collect();
+        assert!(
+            keys.contains(&10) || keys.contains(&20),
+            "B's snapshot exists but is missing entries from A: {keys:?}"
+        );
+
+        task_a.abort();
+        task_b.abort();
+    }
+
+    /// **Counter-capture regression**: a change that arrives **during** the save — after the
+    /// counter was captured, before the subtraction — must still be pending afterwards
+    /// (fetch_sub of the captured amount, not store-0, which would wipe it).
+    ///
+    /// The mid-save write is injected deterministically: the persistence backend's `save`
+    /// bumps the live change counter before returning, exactly like a concurrent writer
+    /// landing while the snapshot is on disk.
+    #[tokio::test]
+    async fn snapshot_counter_capture_preserves_mid_snapshot_changes() {
+        use crate::persistence::{InMemoryPersistence, PersistedState};
+
+        /// Backend whose `save` simulates one concurrent write landing mid-save.
+        struct MidSaveWrite {
+            inner: InMemoryPersistence<i32, i32>,
+            live_counter: std::sync::OnceLock<Arc<std::sync::atomic::AtomicUsize>>,
+        }
+
+        impl Persistence<i32, i32> for MidSaveWrite {
+            fn load(&self) -> std::io::Result<Option<PersistedState<i32, i32>>> {
+                Persistence::load(&self.inner)
+            }
+
+            fn save(&self, state: &PersistedState<i32, i32>) -> std::io::Result<()> {
+                if let Some(counter) = self.live_counter.get() {
+                    counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                }
+                Persistence::save(&self.inner, state)
+            }
+        }
+
+        let backend = Arc::new(MidSaveWrite {
+            inner: InMemoryPersistence::new(),
+            live_counter: std::sync::OnceLock::new(),
+        });
+        let store = ReconcileStore::<i32, i32>::new(ephemeral_config())
+            .await
+            .expect("bind failed")
+            .with_persistence(backend.clone())
+            .expect("load failed")
+            .with_snapshot_change_threshold(1);
+        backend
+            .live_counter
+            .set(Arc::clone(&store.change_counter))
+            .expect("backend counter wired once");
+
+        store.just_insert(1, 10);
+        let captured = store
+            .change_counter
+            .load(std::sync::atomic::Ordering::Relaxed);
+        assert_eq!(
+            captured, 1,
+            "precondition: one pending change before snapshot"
+        );
+
+        // snapshot() captures 1, collects, saves (the backend injects one more change),
+        // then subtracts the captured 1 — the injected change must survive as pending.
+        store.snapshot();
+        let after = store
+            .change_counter
+            .load(std::sync::atomic::Ordering::Relaxed);
+        assert_eq!(
+            after, 1,
+            "the change injected during save must still be pending (store(0) would wipe it)"
+        );
+
+        // Verify the snapshot was actually written.
+        assert!(
+            Persistence::<i32, i32>::load(backend.as_ref())
+                .unwrap()
+                .is_some(),
+            "snapshot must have been written"
+        );
+    }
+
+    /// **GC-removal counting**: a tombstone that is garbage-collected by `gc_remove` bumps the
+    /// change counter, so the snapshot fires on the next tick even with no other changes.
+    ///
+    /// We directly call `engine.gc_remove` (the path invoked by `clear_expired_tombstones`) and
+    /// assert the counter increases.
+    #[tokio::test]
+    async fn gc_remove_bumps_change_counter() {
+        let store = ReconcileStore::<i32, i32>::new(ephemeral_config())
+            .await
+            .expect("bind failed");
+
+        // Insert a live value so there is something to GC.
+        store.just_insert(42, 1);
+
+        // Reset the counter so we start from a known baseline.
+        store
+            .change_counter
+            .store(0, std::sync::atomic::Ordering::Relaxed);
+
+        let before = store
+            .change_counter
+            .load(std::sync::atomic::Ordering::Relaxed);
+        assert_eq!(
+            before, 0,
+            "precondition: counter must be 0 before gc_remove"
+        );
+
+        // Call gc_remove directly (the internal GC path).
+        store.engine.gc_remove(&42);
+
+        let after = store
+            .change_counter
+            .load(std::sync::atomic::Ordering::Relaxed);
+        assert_eq!(
+            after, 1,
+            "gc_remove must bump the change counter by 1 so the next snapshot tick fires"
+        );
     }
 }

--- a/src/reconcile_store.rs
+++ b/src/reconcile_store.rs
@@ -71,6 +71,16 @@ const DEFAULT_MAX_PEERS: usize = 1024;
 /// starving small clusters; raise via [`Config::with_max_concurrent_bulk_dumps`].
 const DEFAULT_MAX_CONCURRENT_BULK_DUMPS: usize = 4;
 
+/// Default wall-time floor before a member with pending unacked tombstones may be decommissioned
+/// by the discovery task (see [`ReconcileStore::with_discovery_decommission_floor`]).
+///
+/// 10 minutes is long enough to absorb a readiness-probe blip that drops a pod from a Kubernetes
+/// headless Service (the event this floor was designed for) while still reclaiming the GC gate
+/// within a reasonable horizon when a member is genuinely gone. Members with **no** pending
+/// tombstone acks are not subject to the floor and are decommissioned as soon as
+/// `miss_threshold` rounds have elapsed.
+const DEFAULT_DISCOVERY_DECOMMISSION_FLOOR: Duration = Duration::from_secs(600);
+
 /// Core service wrapping a key-value map to enable reconciliation between different instances over a network.
 ///
 /// The store also keeps track of the addresses of other instances.
@@ -102,6 +112,10 @@ where
     discovery_interval: Duration,
     /// Consecutive missed discovery rounds before a vanished member is decommissioned.
     discovery_miss_threshold: u32,
+    /// Minimum continuous absence time before a member with pending unacked tombstones is
+    /// decommissioned by the discovery task. Members with no pending tombstone acks skip this
+    /// floor and are decommissioned as soon as `miss_threshold` rounds elapse.
+    discovery_decommission_floor: Duration,
 }
 
 impl<K, V> Clone for ReconcileStore<K, V>
@@ -118,6 +132,7 @@ where
             discovery: self.discovery.clone(),
             discovery_interval: self.discovery_interval,
             discovery_miss_threshold: self.discovery_miss_threshold,
+            discovery_decommission_floor: self.discovery_decommission_floor,
         }
     }
 }
@@ -138,6 +153,7 @@ impl<K: Key, V: Value> ReconcileStore<K, V> {
             discovery: None,
             discovery_interval: DEFAULT_DISCOVERY_INTERVAL,
             discovery_miss_threshold: DEFAULT_DISCOVERY_MISS_THRESHOLD,
+            discovery_decommission_floor: DEFAULT_DISCOVERY_DECOMMISSION_FLOOR,
         };
         svc.add_pre_insert(|_, _| {});
         Ok(svc)
@@ -160,6 +176,7 @@ impl<K: Key, V: Value> ReconcileStore<K, V> {
             discovery: None,
             discovery_interval: DEFAULT_DISCOVERY_INTERVAL,
             discovery_miss_threshold: DEFAULT_DISCOVERY_MISS_THRESHOLD,
+            discovery_decommission_floor: DEFAULT_DISCOVERY_DECOMMISSION_FLOOR,
         };
         svc.add_pre_insert(|_, _| {});
         Ok(svc)
@@ -326,6 +343,30 @@ impl<K: Key, V: Value> ReconcileStore<K, V> {
     /// restarts at the cost of holding tombstones (and their GC gate) longer.
     pub fn with_discovery_miss_threshold(mut self, threshold: u32) -> Self {
         self.discovery_miss_threshold = threshold;
+        self
+    }
+
+    /// Set the minimum continuous absence before a member with **pending unacked tombstones**
+    /// may be decommissioned by the discovery task (default 10 minutes).
+    ///
+    /// When a member has been absent from consecutive discovery rounds for at least
+    /// `miss_threshold` but still has tombstones it has never acknowledged, the discovery task
+    /// will not release the member's causal-stability gate until it has been absent continuously
+    /// for at least this duration. The absence clock resets whenever the member reappears in a
+    /// discovery round, so a transient blip — including a Kubernetes readiness-probe hiccup that
+    /// momentarily drops a pod from the headless Service — cannot advance it.
+    ///
+    /// Members with **no** pending tombstone acks are unaffected by this floor: they are
+    /// decommissioned as soon as `miss_threshold` rounds have elapsed, preserving the existing
+    /// fast-path behaviour for the common case.
+    ///
+    /// **Trade-off**: a longer floor provides stronger protection against tombstone resurrection
+    /// (a member that was briefly absent cannot cause a deleted value to reappear on its return),
+    /// at the cost of delaying the GC-slot release for members that are genuinely gone. Tune
+    /// this value to be comfortably larger than the longest expected transient absence
+    /// (readiness-probe blip, rolling restart, brief network partition) in your environment.
+    pub fn with_discovery_decommission_floor(mut self, floor: Duration) -> Self {
+        self.discovery_decommission_floor = floor;
         self
     }
 
@@ -509,6 +550,16 @@ impl<K: Key, V: Value> ReconcileStore<K, V> {
         self.engine.peers_map_len()
     }
 
+    /// Whether `peer` is currently in the gossip-routing peers map (discovery has seeded it at
+    /// least once and the entry has not yet expired). Used in tests to deterministically confirm
+    /// that at least one discovery round has observed the peer before the resolver is mutated.
+    ///
+    /// Exposed for integration-test assertions under the `internal-testing` feature gate.
+    #[cfg(any(test, feature = "internal-testing"))]
+    pub fn peers_contains(&self, peer: std::net::IpAddr) -> bool {
+        self.engine.peers_contains(peer)
+    }
+
     /// Number of entries in the per-peer replay filter.
     ///
     /// Exposed for integration-test assertions under the `internal-testing` feature gate.
@@ -635,9 +686,13 @@ impl<K: Key, V: Value> ReconcileStore<K, V> {
     ///   as a known peer, re-arming its expiration and feeding it to the next gossip round.
     /// - A previously-seen **member** that is now absent has its miss count incremented; once it
     ///   reaches [`discovery_miss_threshold`](Self::with_discovery_miss_threshold) it is
-    ///   decommissioned, releasing the causal-stability gate it held on tombstone GC.
-    /// - A **failed** resolution (DNS blip) is skipped entirely — it never counts as a miss — so a
-    ///   transient resolver hiccup cannot decommission a healthy peer.
+    ///   decommissioned, releasing the causal-stability gate it held on tombstone GC. When the
+    ///   member has pending unacked tombstones, decommissioning additionally requires that its
+    ///   continuous absence has lasted at least
+    ///   [`discovery_decommission_floor`](Self::with_discovery_decommission_floor).
+    /// - A **failed** resolution (DNS blip) is skipped entirely — it never counts as a miss and
+    ///   never advances the absence clock — so a transient resolver hiccup cannot decommission a
+    ///   healthy peer.
     ///
     /// Only `members` are considered for decommissioning: membership is what gates tombstone GC, it
     /// is earned through a real authenticated datagram, and discovery never writes to it — so a
@@ -647,17 +702,20 @@ impl<K: Key, V: Value> ReconcileStore<K, V> {
             return; // no discovery source: leave peer-finding to the engine's per-net probing
         };
         let own_addr = self.engine.listen_addr();
-        // Consecutive missed rounds per member, and the set of addresses discovery has ever
-        // reported (so we only grace-decommission members we actually discovered, never peers
-        // learned by other means).
+        // Consecutive missed rounds per member, the set of addresses discovery has ever reported
+        // (so we only grace-decommission members we actually discovered, never peers learned by
+        // other means), and the wall-clock instant at which each member first went absent in the
+        // current consecutive run (reset whenever the member reappears).
         let mut miss_counts: HashMap<IpAddr, u32> = HashMap::new();
         let mut seen_ever: HashSet<IpAddr> = HashSet::new();
+        let mut absent_since: HashMap<IpAddr, Instant> = HashMap::new();
         loop {
             tokio::time::sleep(self.discovery_interval).await;
             let resolved = match discovery.discover().await {
                 Ok(addrs) => addrs,
                 Err(err) => {
-                    // Transient failure: do not touch miss counts, do not decommission anyone.
+                    // Transient failure: do not touch miss counts or absence clocks; never
+                    // decommission anyone.
                     debug!("discovery round failed, skipping: {err}");
                     continue;
                 }
@@ -666,25 +724,50 @@ impl<K: Key, V: Value> ReconcileStore<K, V> {
                 .into_iter()
                 .filter(|addr| *addr != own_addr)
                 .collect();
-            // 1) Refresh every currently-present peer.
+            // 1) Refresh every currently-present peer; reset the absence clock on reappearance.
             for addr in &current {
                 seen_ever.insert(*addr);
                 self.engine.seed_peer(*addr);
                 miss_counts.remove(addr);
+                absent_since.remove(addr);
             }
             // 2) Grace-account members that were discovered before but are now absent.
             for member in self.engine.members_snapshot() {
                 if member == own_addr || current.contains(&member) || !seen_ever.contains(&member) {
                     continue;
                 }
+                // Record the first moment of this consecutive absence run.
+                let first_absent = *absent_since.entry(member).or_insert_with(Instant::now);
                 let misses = miss_counts.entry(member).or_insert(0);
                 *misses += 1;
-                if *misses >= self.discovery_miss_threshold {
-                    info!("decommissioning vanished peer {member} after {misses} missed discovery rounds");
+                if *misses < self.discovery_miss_threshold {
+                    continue;
+                }
+                // miss_threshold reached. Fast path: no pending acks → decommission immediately.
+                if !self.engine.has_pending_tombstone_acks(member) {
+                    info!(
+                        "decommissioning vanished peer {member} after {misses} missed discovery rounds"
+                    );
                     self.engine.decommission_peer(member);
                     miss_counts.remove(&member);
                     seen_ever.remove(&member);
+                    absent_since.remove(&member);
+                    continue;
                 }
+                // Slow path: member has pending unacked tombstones — require the floor to have
+                // elapsed before releasing its causal-stability gate.
+                if first_absent.elapsed() >= self.discovery_decommission_floor {
+                    info!(
+                        "decommissioning vanished peer {member} after {misses} missed discovery \
+                         rounds and {} s of continuous absence (pending tombstone acks present)",
+                        first_absent.elapsed().as_secs()
+                    );
+                    self.engine.decommission_peer(member);
+                    miss_counts.remove(&member);
+                    seen_ever.remove(&member);
+                    absent_since.remove(&member);
+                }
+                // Otherwise: floor not yet elapsed; keep waiting.
             }
         }
     }

--- a/src/reconcile_store.rs
+++ b/src/reconcile_store.rs
@@ -71,6 +71,18 @@ const DEFAULT_DISCOVERY_MISS_THRESHOLD: u32 = 3;
 /// over ranges still in flight (the byte amplification this caps).
 const DEFAULT_BULK_SEND_RATE: usize = 32 * 1024 * 1024;
 
+/// Floor, in bytes per second, applied to a configured [`Config::bulk_send_rate`]. A non-`None`
+/// rate below this is raised to it (with a warning) when the engine is built.
+///
+/// A paced bulk dump holds the per-peer in-flight mark for the whole transfer, and `pace()` sleeps
+/// `sent_bytes / rate` between datagrams. A tiny rate turns that sleep into an effectively unbounded
+/// stall that wedges the peer's sync (it is the single in-flight dump for that peer, so no further
+/// reconciliation with it can start). 1 MiB/s keeps even one full-size datagram (`BUFFER_SIZE`,
+/// ~64 KiB) pacing in well under a second (~62 ms), so the in-flight mark always turns over
+/// promptly while still allowing operators to throttle a cold sync hard. `None` (pacing disabled)
+/// is left untouched — it is an explicit choice, not a misconfiguration.
+pub(crate) const MIN_BULK_SEND_RATE: usize = 1024 * 1024;
+
 /// Default size requested for the gossip socket's send/receive buffers (`SO_SNDBUF` / `SO_RCVBUF`),
 /// in bytes (see [`Config::recv_buffer_size`]). A generous 8 MiB: the kernel silently clamps the
 /// request to the OS maximum (`net.core.rmem_max` / `wmem_max` on Linux), so this is an improvement
@@ -717,18 +729,18 @@ impl<K: Key, V: Value> ReconcileStore<K, V> {
 
     /// Return the current membership set.
     ///
-    /// Exposed for integration-test assertions under the `internal-testing` feature gate. Members
+    /// Exposed for integration-test assertions under the `reconcile_internal_testing` cfg gate. Members
     /// are peers that have sent at least one dated, authenticated datagram and gate tombstone
     /// garbage collection via causal stability.
-    #[cfg(any(test, feature = "internal-testing"))]
+    #[cfg(any(test, reconcile_internal_testing))]
     pub fn members_snapshot(&self) -> std::collections::HashSet<std::net::IpAddr> {
         self.engine.members_snapshot()
     }
 
     /// Number of entries in the peers gossip-routing map.
     ///
-    /// Exposed for integration-test assertions under the `internal-testing` feature gate.
-    #[cfg(any(test, feature = "internal-testing"))]
+    /// Exposed for integration-test assertions under the `reconcile_internal_testing` cfg gate.
+    #[cfg(any(test, reconcile_internal_testing))]
     pub fn peers_map_len(&self) -> usize {
         self.engine.peers_map_len()
     }
@@ -737,32 +749,32 @@ impl<K: Key, V: Value> ReconcileStore<K, V> {
     /// least once and the entry has not yet expired). Used in tests to deterministically confirm
     /// that at least one discovery round has observed the peer before the resolver is mutated.
     ///
-    /// Exposed for integration-test assertions under the `internal-testing` feature gate.
-    #[cfg(any(test, feature = "internal-testing"))]
+    /// Exposed for integration-test assertions under the `reconcile_internal_testing` cfg gate.
+    #[cfg(any(test, reconcile_internal_testing))]
     pub fn peers_contains(&self, peer: std::net::IpAddr) -> bool {
         self.engine.peers_contains(peer)
     }
 
     /// Number of entries in the per-peer replay filter.
     ///
-    /// Exposed for integration-test assertions under the `internal-testing` feature gate.
-    #[cfg(any(test, feature = "internal-testing"))]
+    /// Exposed for integration-test assertions under the `reconcile_internal_testing` cfg gate.
+    #[cfg(any(test, reconcile_internal_testing))]
     pub fn replay_filter_len(&self) -> usize {
         self.engine.replay_filter_len()
     }
 
     /// Number of keys currently tracked in the tombstone-acknowledgment map.
     ///
-    /// Exposed for integration-test assertions under the `internal-testing` feature gate.
-    #[cfg(any(test, feature = "internal-testing"))]
+    /// Exposed for integration-test assertions under the `reconcile_internal_testing` cfg gate.
+    #[cfg(any(test, reconcile_internal_testing))]
     pub fn tombstone_acks_len(&self) -> usize {
         self.engine.tombstone_acks_len()
     }
 
     /// Number of bulk dump tasks currently in flight across all peers.
     ///
-    /// Exposed for integration-test assertions under the `internal-testing` feature gate.
-    #[cfg(any(test, feature = "internal-testing"))]
+    /// Exposed for integration-test assertions under the `reconcile_internal_testing` cfg gate.
+    #[cfg(any(test, reconcile_internal_testing))]
     pub fn bulk_dumps_in_flight_count(&self) -> usize {
         self.engine.bulk_dumps_in_flight_count()
     }
@@ -1058,7 +1070,28 @@ pub struct Config {
     /// UDP datagram to the port can forge updates and poison the cluster. When set, every node in
     /// the cluster must use the **same** 32-byte key (and the same MAC backend feature). See
     /// [`Config::with_cluster_key`].
+    ///
+    /// # Keyless mode leaks the entire dataset
+    ///
+    /// Keyless mode is not merely unauthenticated *writes*; it also leaks *reads*. The discovery
+    /// probe (`RandomProbe`) answers any host inside a configured network/CIDR, and the anti-entropy
+    /// protocol then serves that host whatever it is missing. A stranger that squats a single IP in
+    /// the range — or spoofs one, since UDP source addresses are forgeable — eventually receives the
+    /// **entire dataset** through the paced bulk diff dumps, with no key and no per-peer identity to
+    /// stop it. Run keyless only on a fully trusted network underlay. To both authenticate and stop
+    /// the leak, set [`with_cluster_key`](Self::with_cluster_key) on every node; to keep keyless mode
+    /// deliberately (and silence the startup warning), acknowledge it with
+    /// [`with_insecure_no_key`](Self::with_insecure_no_key).
     pub cluster_key: Option<[u8; 32]>,
+    /// Operator acknowledgment that running without a [`cluster_key`](Self::cluster_key) is
+    /// intentional (set via [`with_insecure_no_key`](Self::with_insecure_no_key)).
+    ///
+    /// Purely advisory: it changes **nothing** about the protocol — keyless mode is still
+    /// unauthenticated and still leaks the dataset (see [`cluster_key`](Self::cluster_key)). Its only
+    /// effect is to downgrade the loud startup `SECURITY` warning to a single acknowledged-once line,
+    /// so an operator who has accepted the trust model is not nagged on every restart. It is ignored
+    /// when a key *is* set.
+    pub acknowledged_no_key: bool,
     /// Identity of this node, used as the deterministic tie-break in the Hybrid Logical
     /// Clock total order. When `None` (the default), a random id is generated at startup.
     ///
@@ -1102,6 +1135,11 @@ pub struct Config {
     /// so a re-issued diff cannot re-send in-flight ranges. Together these make a cold sync transfer
     /// ≈ the dataset size, fast, regardless of `reconcile_interval`. Only the bulk value dump is
     /// paced; small refinement comparisons, acks, and local-write broadcasts are sent immediately.
+    ///
+    /// A non-`None` rate is floored at 1 MiB/s when the store is built: a paced dump holds the
+    /// per-peer in-flight mark for its whole duration, so a tiny rate would make pacing sleep for
+    /// an effectively unbounded time and wedge that peer's sync. A configured value below the floor
+    /// is raised to it with a warning; `None` (pacing disabled) is left untouched.
     pub bulk_send_rate: Option<usize>,
     /// Size to request for the gossip socket's receive buffer (`SO_RCVBUF`), in bytes.
     ///
@@ -1174,6 +1212,7 @@ impl Default for Config {
             remote_interval: 6,
             remote_fanout: 2,
             cluster_key: None,
+            acknowledged_no_key: false,
             node_id: None,
             encrypt: false,
             reconcile_interval: Duration::from_secs(1),
@@ -1251,7 +1290,8 @@ impl Config {
     }
 
     /// Set the rate, in bytes per second, at which a single bulk anti-entropy value transfer to one
-    /// peer is paced (default 32 MiB/s). See [`bulk_send_rate`](Config::bulk_send_rate); to disable
+    /// peer is paced (default 32 MiB/s). Values below the 1 MiB/s floor are raised to it (with a
+    /// warning) when the store is built. See [`bulk_send_rate`](Config::bulk_send_rate); to disable
     /// pacing (the historical back-to-back burst), set that field to `None` directly.
     pub fn with_bulk_send_rate(mut self, bytes_per_sec: usize) -> Self {
         self.bulk_send_rate = Some(bytes_per_sec);
@@ -1292,6 +1332,22 @@ impl Config {
     /// logs a loud warning at startup and runs unauthenticated.
     pub fn with_cluster_key(mut self, key: [u8; 32]) -> Self {
         self.cluster_key = Some(key);
+        self
+    }
+
+    /// Explicitly acknowledge running **without** a cluster key.
+    ///
+    /// Keyless mode is the default, but it is unauthenticated *and leaks the entire dataset* to any
+    /// host that can reach the port (see [`cluster_key`](Config::cluster_key) for the concrete
+    /// leak). Calling this is an operator statement that the keyless trust model — a fully trusted
+    /// network underlay — is understood and intended. It is purely advisory: it does **not** change
+    /// the protocol or add any protection. Its only effect is to downgrade the loud startup
+    /// `SECURITY` warning to a single acknowledged line, so a deliberately keyless deployment is not
+    /// nagged on every restart.
+    ///
+    /// Has no effect once [`with_cluster_key`](Config::with_cluster_key) is set; do not call both.
+    pub fn with_insecure_no_key(mut self) -> Self {
+        self.acknowledged_no_key = true;
         self
     }
 
@@ -1381,6 +1437,7 @@ mod reconcile_store_tests {
             remote_interval: 6,
             remote_fanout: 2,
             cluster_key: None,
+            acknowledged_no_key: false,
             node_id: None,
             encrypt: false,
             reconcile_interval: Duration::from_secs(1),

--- a/src/reconcile_store.rs
+++ b/src/reconcile_store.rs
@@ -30,7 +30,7 @@ use crate::fingerprint::Fingerprint;
 use crate::persistence::{
     DatedEntries, InMemoryPersistence, LoadError, PersistedState, Persistence,
 };
-use crate::reconcilable::Projectable;
+use crate::reconcilable::Entry;
 use crate::reconcile_engine::{version_hash, ReconcileEngine};
 use crate::timeout_wheel::TimeoutWheel;
 
@@ -128,10 +128,9 @@ const DEFAULT_DISCOVERY_DECOMMISSION_FLOOR: Duration = Duration::from_secs(600);
 pub struct ReconcileStore<K, V>
 where
     K: Clone + Hash + std::cmp::Eq + Send + Sync,
-    (Timestamp, Option<V>): Projectable,
 {
     /// Internal map and hooks container.
-    engine: ReconcileEngine<K, (Timestamp, Option<V>)>,
+    engine: ReconcileEngine<K, V>,
     /// Tombstone timestamps for deleted entries.
     tombstones: TimeoutWheel<K>,
     /// Durable backend. Always present (the trait is mandatory); defaults to the non-durable
@@ -164,7 +163,6 @@ where
 impl<K, V> Clone for ReconcileStore<K, V>
 where
     K: Clone + Hash + std::cmp::Eq + Send + Sync,
-    (Timestamp, Option<V>): Projectable,
 {
     /// Allows cloning of the `ReconcileStore` handle for lightweight sharing in hooks or tests.
     fn clone(&self) -> Self {
@@ -192,7 +190,7 @@ impl<K: Key, V: Value> ReconcileStore<K, V> {
     /// `(config.listen_addr, config.port)` — for example, because the port is already in use or
     /// the address is not available on this host.
     pub async fn new(config: Config) -> io::Result<Self> {
-        let engine = ReconcileEngine::<K, (Timestamp, Option<V>)>::new(config).await?;
+        let engine = ReconcileEngine::<K, V>::new(config).await?;
         let change_counter = Arc::clone(&engine.change_counter);
         let svc = ReconcileStore {
             engine,
@@ -219,8 +217,7 @@ impl<K: Key, V: Value> ReconcileStore<K, V> {
         config: Config,
         clock: Arc<dyn crate::clock::Clock>,
     ) -> io::Result<Self> {
-        let engine =
-            ReconcileEngine::<K, (Timestamp, Option<V>)>::new_with_clock(config, clock).await?;
+        let engine = ReconcileEngine::<K, V>::new_with_clock(config, clock).await?;
         let change_counter = Arc::clone(&engine.change_counter);
         let svc = ReconcileStore {
             engine,
@@ -312,8 +309,8 @@ impl<K: Key, V: Value> ReconcileStore<K, V> {
             // far-future clamp protects the clock during live gossip; this restore path is not
             // live gossip. A poisoned stamp that made it into the snapshot is accepted here and
             // consumed where stored stamps are used (e.g. tombstone expiry arithmetic).
-            for (_, (stamp, _)) in &state.entries {
-                self.engine.clock_observe_trusted(*stamp);
+            for (_, entry) in &state.entries {
+                self.engine.clock_observe_trusted(entry.stamp);
             }
             // Replay through the wrapped pre-insert hook so the tombstone wheel is rebuilt with the
             // original deletion timestamps (do NOT route through the public insert helpers, which
@@ -400,7 +397,7 @@ impl<K: Key, V: Value> ReconcileStore<K, V> {
         // Cursor: the last key seen in the previous chunk, used to open the next range.
         let mut cursor: Option<K> = None;
         loop {
-            let chunk: Vec<(K, (Timestamp, Option<V>))> = {
+            let chunk: Vec<(K, Entry<Timestamp, V>)> = {
                 let guard = self.engine.map.read();
                 match cursor.take() {
                     None => guard
@@ -569,21 +566,21 @@ impl<K: Key, V: Value> ReconcileStore<K, V> {
     ///
     /// Hooks are executed outside of the map’s write lock, so calling back into any insert
     /// method from within a hook will not block or deadlock.
-    pub fn add_pre_insert<F: Send + Sync + Fn(&K, &(Timestamp, Option<V>)) + 'static>(
+    pub fn add_pre_insert<F: Send + Sync + Fn(&K, &Entry<Timestamp, V>) + 'static>(
         &self,
         pre_insert: F,
     ) {
         let tombstones = self.tombstones.clone();
-        let wrapped_pre_insert = move |k: &K, v: &(Timestamp, Option<V>)| {
+        let wrapped_pre_insert = move |k: &K, v: &Entry<Timestamp, V>| {
             pre_insert(k, v);
-            if v.1.is_some() {
+            if !v.is_tombstone() {
                 tombstones.remove(k);
             } else {
                 // The timeout wheel ages tombstones by wall-clock time; use the HLC's
                 // physical component so all replicas expire a tombstone at the same logical
                 // wall time. GC is in any case gated on causal stability.
-                let when =
-                    DateTime::from_timestamp_millis(v.0.wall_ms() as i64).unwrap_or_else(Utc::now);
+                let when = DateTime::from_timestamp_millis(v.stamp.wall_ms() as i64)
+                    .unwrap_or_else(Utc::now);
                 tombstones.insert(k.clone(), when);
             }
         };
@@ -606,10 +603,7 @@ impl<K: Key, V: Value> ReconcileStore<K, V> {
 
     pub fn get(&self, k: &K) -> Option<MappedRwLockReadGuard<'_, V>> {
         let guard = self.engine.map.read();
-        RwLockReadGuard::try_map(guard, |map| {
-            map.get(k).and_then(|(_, ref opt)| opt.as_ref())
-        })
-        .ok()
+        RwLockReadGuard::try_map(guard, |map| map.get(k).and_then(|entry| entry.value())).ok()
     }
 
     /// Insert a single key/value pair, running the pre-insert hook first.
@@ -624,8 +618,8 @@ impl<K: Key, V: Value> ReconcileStore<K, V> {
         self.change_counter.fetch_add(1, AtomicOrdering::Relaxed);
         let ret = self
             .engine
-            .just_insert(key, (self.engine.clock_now(), Some(value)));
-        ret.and_then(|t| t.1)
+            .just_insert(key, Entry::present(self.engine.clock_now(), value));
+        ret.and_then(|e| e.into_value())
     }
 
     /// Fully-qualified insert: just_insert + async broadcast.
@@ -633,8 +627,8 @@ impl<K: Key, V: Value> ReconcileStore<K, V> {
         self.change_counter.fetch_add(1, AtomicOrdering::Relaxed);
         let ret = self
             .engine
-            .insert(key, (self.engine.clock_now(), Some(value)));
-        ret.and_then(|t| t.1)
+            .insert(key, Entry::present(self.engine.clock_now(), value));
+        ret.and_then(|e| e.into_value())
     }
 
     /// Bulk-insert multiple key/value pairs with hook invocation.
@@ -649,7 +643,12 @@ impl<K: Key, V: Value> ReconcileStore<K, V> {
         self.engine.just_insert_bulk(
             &key_values
                 .iter()
-                .map(|(k, v)| (k.clone(), (self.engine.clock_now(), Some(v.clone()))))
+                .map(|(k, v)| {
+                    (
+                        k.clone(),
+                        Entry::present(self.engine.clock_now(), v.clone()),
+                    )
+                })
                 .collect::<Vec<_>>(),
         );
     }
@@ -661,7 +660,12 @@ impl<K: Key, V: Value> ReconcileStore<K, V> {
         self.engine.insert_bulk(
             &key_values
                 .iter()
-                .map(|(k, v)| (k.clone(), (self.engine.clock_now(), Some(v.clone()))))
+                .map(|(k, v)| {
+                    (
+                        k.clone(),
+                        Entry::present(self.engine.clock_now(), v.clone()),
+                    )
+                })
                 .collect::<Vec<_>>(),
         );
     }
@@ -670,16 +674,16 @@ impl<K: Key, V: Value> ReconcileStore<K, V> {
         self.change_counter.fetch_add(1, AtomicOrdering::Relaxed);
         let ret = self
             .engine
-            .just_insert(key.clone(), (self.engine.clock_now(), None));
-        ret.and_then(|t| t.1)
+            .just_insert(key.clone(), Entry::tombstone(self.engine.clock_now()));
+        ret.and_then(|e| e.into_value())
     }
 
     pub fn remove(&self, key: &K) -> Option<V> {
         self.change_counter.fetch_add(1, AtomicOrdering::Relaxed);
         let ret = self
             .engine
-            .insert(key.clone(), (self.engine.clock_now(), None));
-        ret.and_then(|t| t.1)
+            .insert(key.clone(), Entry::tombstone(self.engine.clock_now()));
+        ret.and_then(|e| e.into_value())
     }
 
     pub fn just_remove_bulk(&self, keys: &[K]) {
@@ -688,7 +692,7 @@ impl<K: Key, V: Value> ReconcileStore<K, V> {
         self.engine.just_insert_bulk(
             &keys
                 .iter()
-                .map(|k| (k.clone(), (self.engine.clock_now(), None)))
+                .map(|k| (k.clone(), Entry::tombstone(self.engine.clock_now())))
                 .collect::<Vec<_>>(),
         );
     }
@@ -705,7 +709,7 @@ impl<K: Key, V: Value> ReconcileStore<K, V> {
         self.engine.insert_bulk(
             &keys
                 .iter()
-                .map(|k| (k.clone(), (self.engine.clock_now(), None)))
+                .map(|k| (k.clone(), Entry::tombstone(self.engine.clock_now())))
                 .collect::<Vec<_>>(),
         );
     }
@@ -999,18 +1003,17 @@ impl<K: Key, V: Value> ReconcileStore<K, V> {
     /// read-modify-write holds the map write lock for the duration of the callback, so it is atomic
     /// against the reconciliation loop.
     pub fn get_mut<F: FnOnce(Option<&mut V>)>(&self, k: &K, callback: F) {
-        use crate::reconcilable::Projectable;
         // Mint the timestamp before taking the map lock, matching the lock order of `insert`
         // (clock, then map → projection).
         let now = self.engine.clock_now();
-        let mut updated: Option<(Timestamp, Option<V>)> = None;
+        let mut updated: Option<Entry<Timestamp, V>> = None;
         let mut guard = self.engine.map.write();
         guard.with_mut(k, |maybe_tv| {
             if let Some(tv) = maybe_tv {
-                callback(tv.1.as_mut());
+                callback(tv.value_mut());
                 // Re-stamp so the edit wins last-write-wins on peers and reconciles; `with_mut`
-                // recomputes the dated fingerprint from the whole (timestamp, value) afterwards.
-                tv.0 = now;
+                // recomputes the dated fingerprint from the whole entry afterwards.
+                tv.stamp = now;
                 updated = Some(tv.clone());
             } else {
                 callback(None);
@@ -1776,7 +1779,7 @@ mod reconcile_store_tests {
         let backend = Arc::new(InMemoryPersistence::<i32, i32>::new());
         backend
             .save(&PersistedState {
-                entries: vec![(42, (persisted_stamp, Some(999)))],
+                entries: vec![(42, crate::Entry::present(persisted_stamp, 999))],
                 members: Default::default(),
                 tombstone_acks: Default::default(),
             })
@@ -1799,7 +1802,7 @@ mod reconcile_store_tests {
             .map
             .read()
             .get(&99)
-            .map(|(ts, _)| *ts)
+            .map(|e| e.stamp)
             .expect("key 99 must be present after insert");
 
         assert!(
@@ -1831,7 +1834,7 @@ mod reconcile_store_tests {
         let backend = Arc::new(InMemoryPersistence::<i32, i32>::new());
         backend
             .save(&PersistedState {
-                entries: vec![(7, (tombstone_stamp, None))], // None = tombstone
+                entries: vec![(7, crate::Entry::tombstone(tombstone_stamp))], // tombstone
                 members: Default::default(),
                 tombstone_acks: Default::default(),
             })
@@ -1857,7 +1860,7 @@ mod reconcile_store_tests {
             .map
             .read()
             .get(&7)
-            .map(|(ts, _)| *ts)
+            .map(|e| e.stamp)
             .expect("key 7 must be present after insert");
 
         // The minted stamp must be strictly greater than the tombstone's stamp. Without this,
@@ -2487,7 +2490,7 @@ mod reconcile_store_tests {
         let keys: Vec<i32> = snap_written
             .entries
             .iter()
-            .filter_map(|(k, (_, v))| v.as_ref().map(|_| *k))
+            .filter_map(|(k, e)| e.value().map(|_| *k))
             .collect();
         assert!(
             keys.contains(&10) || keys.contains(&20),

--- a/src/reconcile_store.rs
+++ b/src/reconcile_store.rs
@@ -12,7 +12,7 @@
 use std::collections::{HashMap, HashSet};
 use std::hash::Hash;
 use std::io;
-use std::net::IpAddr;
+use std::net::{IpAddr, SocketAddr};
 use std::ops::RangeBounds;
 use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
 use std::sync::Arc;
@@ -33,6 +33,7 @@ use crate::persistence::{
 use crate::reconcilable::Entry;
 use crate::reconcile_engine::{version_hash, ReconcileEngine};
 use crate::timeout_wheel::TimeoutWheel;
+use crate::transport::Transport;
 
 const TOMBSTONE_CLEARING: Duration = Duration::from_secs(1);
 
@@ -190,22 +191,43 @@ impl<K: Key, V: Value> ReconcileStore<K, V> {
     /// `(config.listen_addr, config.port)` — for example, because the port is already in use or
     /// the address is not available on this host.
     pub async fn new(config: Config) -> io::Result<Self> {
-        let engine = ReconcileEngine::<K, V>::new(config).await?;
-        let change_counter = Arc::clone(&engine.change_counter);
-        let svc = ReconcileStore {
-            engine,
-            tombstones: TimeoutWheel::new(),
-            persistence: Arc::new(InMemoryPersistence::default()),
-            discovery: None,
-            discovery_interval: DEFAULT_DISCOVERY_INTERVAL,
-            discovery_miss_threshold: DEFAULT_DISCOVERY_MISS_THRESHOLD,
-            discovery_decommission_floor: DEFAULT_DISCOVERY_DECOMMISSION_FLOOR,
-            snapshot_interval: Some(DEFAULT_SNAPSHOT_INTERVAL),
-            snapshot_change_threshold: DEFAULT_SNAPSHOT_CHANGE_THRESHOLD,
-            change_counter,
-        };
-        svc.add_pre_insert(|_, _| {});
-        Ok(svc)
+        Ok(Self::from_engine(
+            ReconcileEngine::<K, V>::new(config).await?,
+        ))
+    }
+
+    /// Create a `ReconcileStore` over a caller-supplied [`Transport`] adapter instead of the
+    /// default UDP one.
+    ///
+    /// Infallible, because the only fallible step in [`new`](Self::new) is binding the socket —
+    /// which the caller has already done, or does not need to do at all. Two uses motivate this
+    /// seam (`ARCHITECTURE.md` §7 D2):
+    ///
+    /// - a different datagram transport, e.g. QUIC unreliable datagrams (RFC 9221), whose shape
+    ///   fits this trait;
+    /// - a lossy, reordering or delaying transport, so convergence can be tested under adversity;
+    ///   [`InMemoryNetwork`](crate::InMemoryNetwork) provides the reliable in-process case.
+    ///
+    /// The protocol already assumes datagrams may be lost, duplicated or reordered, so a transport
+    /// cannot violate an invariant by being unreliable. (The [`Clock`](crate::Clock) port is
+    /// deliberately *not* injectable for the opposite reason: a non-monotonic clock silently breaks
+    /// the causal ordering that tombstone collection depends on.)
+    ///
+    /// ```rust,no_run
+    /// # use std::sync::Arc;
+    /// # use reconcile::{reconcile_store::Config, InMemoryNetwork, ReconcileStore};
+    /// let network = InMemoryNetwork::new();
+    /// let transport = Arc::new(network.bind("127.0.0.1:8080".parse().unwrap()));
+    /// let store = ReconcileStore::<String, String>::new_with_transport(
+    ///     Config::default(),
+    ///     transport,
+    /// );
+    /// ```
+    pub fn new_with_transport(
+        config: Config,
+        transport: Arc<dyn Transport<Addr = SocketAddr>>,
+    ) -> Self {
+        Self::from_engine(ReconcileEngine::<K, V>::with_transport(config, transport))
     }
 
     /// Test-only constructor that accepts an explicit [`Clock`] adapter.
@@ -217,7 +239,15 @@ impl<K: Key, V: Value> ReconcileStore<K, V> {
         config: Config,
         clock: Arc<dyn crate::clock::Clock>,
     ) -> io::Result<Self> {
-        let engine = ReconcileEngine::<K, V>::new_with_clock(config, clock).await?;
+        Ok(Self::from_engine(
+            ReconcileEngine::<K, V>::new_with_clock(config, clock).await?,
+        ))
+    }
+
+    /// Wrap a constructed engine in the store's own bookkeeping (tombstone wheel, persistence,
+    /// discovery and snapshot defaults). The single place those defaults are spelled out, so the
+    /// constructors above cannot drift apart.
+    fn from_engine(engine: ReconcileEngine<K, V>) -> Self {
         let change_counter = Arc::clone(&engine.change_counter);
         let svc = ReconcileStore {
             engine,
@@ -232,7 +262,18 @@ impl<K: Key, V: Value> ReconcileStore<K, V> {
             change_counter,
         };
         svc.add_pre_insert(|_, _| {});
-        Ok(svc)
+        svc
+    }
+
+    /// This node's Hybrid-Logical-Clock identity — the `node_id` component of every
+    /// [`Timestamp`] it mints, and the deterministic tie-break that makes the
+    /// conflict order total.
+    ///
+    /// Set explicitly with [`Config::with_node_id`]; otherwise randomly generated at construction,
+    /// in which case it changes on every restart. Reading it back is useful for diagnostics and for
+    /// asserting that a durable deployment really did pin a stable identity.
+    pub fn node_id(&self) -> u64 {
+        self.engine.node_id()
     }
 
     /// Plug in a durable persistence backend, **loading any previously saved state first**.
@@ -622,7 +663,21 @@ impl<K: Key, V: Value> ReconcileStore<K, V> {
         ret.and_then(|e| e.into_value())
     }
 
-    /// Fully-qualified insert: just_insert + async broadcast.
+    /// Fully-qualified insert: `just_insert` + async broadcast.
+    ///
+    /// # Value-size ceiling
+    ///
+    /// The send path packs protocol messages into datagrams but never **fragments** one, so a
+    /// single encoded `(key, entry)` must fit in `65507 - authentication overhead` bytes. Above
+    /// that ceiling the update is never delivered and **the key never converges on any peer** —
+    /// the local map still holds it, so the failure is silent from this node's point of view and
+    /// shows up only as a `warn!` on the send path.
+    ///
+    /// The API stays infallible deliberately: the fix belongs at the root (chunking), not in an
+    /// `io::Result` on every write. See invariant 9 and `ARCHITECTURE.md` §7 D3, tracked in
+    /// [issue #230](https://github.com/Akvize/reconcile-rs/issues/230). Keep values well clear of
+    /// the ceiling — and well clear of the network MTU, since an IP-fragmented datagram is lost
+    /// entirely if any fragment is.
     pub fn insert(&self, key: K, value: V) -> Option<V> {
         self.change_counter.fetch_add(1, AtomicOrdering::Relaxed);
         let ret = self
@@ -1451,6 +1506,71 @@ mod reconcile_store_tests {
             max_peers: super::DEFAULT_MAX_PEERS,
             max_concurrent_bulk_dumps: super::DEFAULT_MAX_CONCURRENT_BULK_DUMPS,
         }
+    }
+
+    /// D4: the node id is settable through `Config` and readable back off the store, and the
+    /// value reported is the one the clock actually stamps onto minted timestamps.
+    #[tokio::test]
+    async fn node_id_is_readable_and_matches_the_minted_stamp() {
+        let store = ReconcileStore::<i32, i32>::new(ephemeral_config().with_node_id(0xABCD))
+            .await
+            .unwrap();
+        assert_eq!(store.node_id(), 0xABCD);
+        store.insert(1, 1);
+        let stamp = store.engine.map.read().get(&1).unwrap().stamp;
+        assert_eq!(stamp.node_id(), store.node_id());
+    }
+
+    /// D2: two stores wired to a caller-supplied `Transport` converge over it, with no UDP socket
+    /// bound anywhere. This is the public seam, exercised exactly as a downstream crate would.
+    #[tokio::test]
+    async fn stores_converge_over_an_injected_transport() {
+        use std::net::SocketAddr;
+        use std::time::Instant;
+
+        use crate::transport::InMemoryNetwork;
+
+        let net = InMemoryNetwork::new();
+        let port = 5100u16;
+        let a_ip: IpAddr = "127.0.0.4".parse().unwrap();
+        let b_ip: IpAddr = "127.0.0.5".parse().unwrap();
+        let cfg = |ip: IpAddr, id: u64| {
+            ephemeral_config()
+                .with_listen_addr(ip)
+                .with_port(port)
+                .with_node_id(id)
+                .with_reconcile_interval(Duration::from_millis(5))
+        };
+        let a = ReconcileStore::<i32, i32>::new_with_transport(
+            cfg(a_ip, 1),
+            Arc::new(net.bind(SocketAddr::new(a_ip, port))),
+        );
+        let b = ReconcileStore::<i32, i32>::new_with_transport(
+            cfg(b_ip, 2),
+            Arc::new(net.bind(SocketAddr::new(b_ip, port))),
+        );
+        // Seed each as the other's gossip peer: the in-memory fabric has no discovery.
+        a.engine.peers.write().insert(b_ip, Instant::now());
+        b.engine.peers.write().insert(a_ip, Instant::now());
+        a.insert(7, 42);
+
+        let ta = tokio::spawn(a.clone().run());
+        let tb = tokio::spawn(b.clone().run());
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let mut converged = false;
+        while Instant::now() < deadline {
+            tokio::time::sleep(Duration::from_millis(20)).await;
+            if b.get(&7).as_deref() == Some(&42) {
+                converged = true;
+                break;
+            }
+        }
+        ta.abort();
+        tb.abort();
+        assert!(
+            converged,
+            "B never learned A's write over the injected transport"
+        );
     }
 
     #[tokio::test]

--- a/src/replay.rs
+++ b/src/replay.rs
@@ -380,8 +380,8 @@ impl ReplayFilter {
 
     /// Number of peers currently tracked by the filter.
     ///
-    /// Exposed for test assertions under the `internal-testing` feature gate.
-    #[cfg(any(test, feature = "internal-testing"))]
+    /// Exposed for test assertions under the `reconcile_internal_testing` cfg gate.
+    #[cfg(any(test, reconcile_internal_testing))]
     pub(crate) fn len(&self) -> usize {
         self.peers.lock().len()
     }

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -20,7 +20,9 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use socket2::SockRef;
 use tokio::net::UdpSocket;
+use tracing::{debug, warn};
 
 /// Abstracts connectionless datagram I/O (send / receive / local address).
 ///
@@ -54,9 +56,70 @@ impl UdpTransport {
         UdpTransport(socket)
     }
 
+    /// Bind a UDP socket at `addr` and size its kernel send/receive buffers, returning the ready
+    /// transport. `recv_buffer_size` / `send_buffer_size` size `SO_RCVBUF` / `SO_SNDBUF`
+    /// respectively; `None` leaves the inherited OS default.
+    ///
+    /// # Errors
+    ///
+    /// Returns an `io::Error` if the socket cannot be bound to `addr` (e.g. the port is in use).
+    pub async fn bind(
+        addr: SocketAddr,
+        recv_buffer_size: Option<usize>,
+        send_buffer_size: Option<usize>,
+    ) -> io::Result<Self> {
+        let socket = UdpSocket::bind(addr).await?;
+        set_socket_buffers(&socket, recv_buffer_size, send_buffer_size);
+        Ok(UdpTransport(Arc::new(socket)))
+    }
+
     /// Borrow the underlying socket (e.g. to tune `SO_RCVBUF` / `SO_SNDBUF`).
     pub fn socket(&self) -> &UdpSocket {
         &self.0
+    }
+}
+
+/// Apply the requested `SO_RCVBUF` / `SO_SNDBUF` sizes to a gossip socket.
+///
+/// `setsockopt` never errors for asking too much: the kernel clamps each request to the OS maximum
+/// (`net.core.rmem_max` / `wmem_max` on Linux), so a generous default only ever helps. Clamping is
+/// therefore expected on an untuned host — **not** a warning condition — so the achieved size is
+/// reported at `debug`; an operator who needs the full buffer raises the sysctl (see the README)
+/// and can confirm via `/proc/net/snmp` `RcvbufErrors`. Only an actual `setsockopt` failure (which
+/// does not happen for a buffer request on a valid socket) is surfaced as a `warn`. A `None` size
+/// leaves the inherited OS default untouched.
+///
+/// Note: on Linux `getsockopt` reports the *doubled* value (bookkeeping overhead), so a fully
+/// honoured request reads back larger than asked.
+fn set_socket_buffers(
+    socket: &UdpSocket,
+    recv_buffer_size: Option<usize>,
+    send_buffer_size: Option<usize>,
+) {
+    let sock = SockRef::from(socket);
+    if let Some(size) = recv_buffer_size {
+        match sock.set_recv_buffer_size(size) {
+            Ok(()) => match sock.recv_buffer_size() {
+                Ok(actual) => debug!(
+                    "gossip socket SO_RCVBUF: requested {size} B, OS granted {actual} B \
+                     (raise net.core.rmem_max if a larger buffer is needed)"
+                ),
+                Err(e) => debug!("could not read back SO_RCVBUF: {e}"),
+            },
+            Err(e) => warn!("failed to set gossip socket SO_RCVBUF to {size} B: {e}"),
+        }
+    }
+    if let Some(size) = send_buffer_size {
+        match sock.set_send_buffer_size(size) {
+            Ok(()) => match sock.send_buffer_size() {
+                Ok(actual) => debug!(
+                    "gossip socket SO_SNDBUF: requested {size} B, OS granted {actual} B \
+                     (raise net.core.wmem_max if a larger buffer is needed)"
+                ),
+                Err(e) => debug!("could not read back SO_SNDBUF: {e}"),
+            },
+            Err(e) => warn!("failed to set gossip socket SO_SNDBUF to {size} B: {e}"),
+        }
     }
 }
 

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -48,7 +48,7 @@ pub trait Transport: Send + Sync + 'static {
 
 /// The default [`Transport`] adapter: a tokio UDP socket.
 #[derive(Clone, Debug)]
-pub struct UdpTransport(pub Arc<UdpSocket>);
+pub struct UdpTransport(Arc<UdpSocket>);
 
 impl UdpTransport {
     /// Wrap an already-bound UDP socket.

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -140,14 +140,16 @@ impl Transport for UdpTransport {
     }
 }
 
-/// An in-process [`Transport`] used by tests: datagrams are routed between transports sharing an
+/// An in-process [`Transport`]: datagrams are routed between transports sharing an
 /// [`InMemoryNetwork`], with no real sockets. Delivery is reliable and FIFO per (sender→receiver)
 /// pair, which — under a single-threaded runtime — makes convergence deterministic. A datagram to
 /// an unknown/closed address is dropped, exactly like UDP.
-#[cfg(any(test, reconcile_internal_testing))]
+///
+/// Exposed (not test-gated) so downstream crates can test *their own* application against a
+/// deterministic cluster, which is the second of the two uses that earn `Transport` a public
+/// injection point — see `ARCHITECTURE.md` §7 D2.
 pub use in_memory::{InMemoryNetwork, InMemoryTransport};
 
-#[cfg(any(test, reconcile_internal_testing))]
 mod in_memory {
     use super::*;
     use std::collections::HashMap;

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -1,0 +1,188 @@
+// Copyright 2023 Developers of the reconcile project.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! The [`Transport`] port — the domain's datagram-I/O boundary — and its default
+//! [`UdpTransport`] adapter (`ARCHITECTURE.md` §3.4).
+//!
+//! The reconciliation engine drives itself over this port instead of calling `tokio::net` directly,
+//! so the socket is a substitutable adapter. A test-only [`InMemoryTransport`] delivers datagrams
+//! between engines in-process (no real sockets), which is what makes convergence tests
+//! deterministic.
+
+use std::hash::Hash;
+use std::io;
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use tokio::net::UdpSocket;
+
+/// Abstracts connectionless datagram I/O (send / receive / local address).
+///
+/// The associated `Addr` is the peer-address type; the default [`UdpTransport`] uses
+/// [`SocketAddr`], and the reconciliation engine is written against `Addr = SocketAddr` (its peer,
+/// membership and geography bookkeeping are all keyed on IP). A different adapter (e.g.
+/// [`InMemoryTransport`]) reuses the same address type so none of that logic changes.
+#[async_trait]
+pub trait Transport: Send + Sync + 'static {
+    /// The peer-address type carried by [`recv_from`](Transport::recv_from) /
+    /// [`send_to`](Transport::send_to).
+    type Addr: Clone + Eq + Hash + Send + Sync;
+
+    /// Receive one datagram into `buf`, returning the number of bytes read and the sender address.
+    async fn recv_from(&self, buf: &mut [u8]) -> io::Result<(usize, Self::Addr)>;
+
+    /// Send one datagram to `dst`, returning the number of bytes written.
+    async fn send_to(&self, buf: &[u8], dst: &Self::Addr) -> io::Result<usize>;
+
+    /// The local address this transport is bound to.
+    fn local_addr(&self) -> io::Result<Self::Addr>;
+}
+
+/// The default [`Transport`] adapter: a tokio UDP socket.
+#[derive(Clone, Debug)]
+pub struct UdpTransport(pub Arc<UdpSocket>);
+
+impl UdpTransport {
+    /// Wrap an already-bound UDP socket.
+    pub fn new(socket: Arc<UdpSocket>) -> Self {
+        UdpTransport(socket)
+    }
+
+    /// Borrow the underlying socket (e.g. to tune `SO_RCVBUF` / `SO_SNDBUF`).
+    pub fn socket(&self) -> &UdpSocket {
+        &self.0
+    }
+}
+
+#[async_trait]
+impl Transport for UdpTransport {
+    type Addr = SocketAddr;
+
+    async fn recv_from(&self, buf: &mut [u8]) -> io::Result<(usize, SocketAddr)> {
+        self.0.recv_from(buf).await
+    }
+
+    async fn send_to(&self, buf: &[u8], dst: &SocketAddr) -> io::Result<usize> {
+        self.0.send_to(buf, dst).await
+    }
+
+    fn local_addr(&self) -> io::Result<SocketAddr> {
+        self.0.local_addr()
+    }
+}
+
+/// An in-process [`Transport`] used by tests: datagrams are routed between transports sharing an
+/// [`InMemoryNetwork`], with no real sockets. Delivery is reliable and FIFO per (sender→receiver)
+/// pair, which — under a single-threaded runtime — makes convergence deterministic. A datagram to
+/// an unknown/closed address is dropped, exactly like UDP.
+#[cfg(any(test, reconcile_internal_testing))]
+pub use in_memory::{InMemoryNetwork, InMemoryTransport};
+
+#[cfg(any(test, reconcile_internal_testing))]
+mod in_memory {
+    use super::*;
+    use std::collections::HashMap;
+
+    use parking_lot::Mutex;
+    use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
+    use tokio::sync::Mutex as AsyncMutex;
+
+    type Datagram = (SocketAddr, Vec<u8>);
+
+    /// A shared in-process datagram fabric. [`bind`](InMemoryNetwork::bind) a
+    /// [`InMemoryTransport`] per node onto the same network and they can exchange datagrams.
+    #[derive(Clone, Default)]
+    pub struct InMemoryNetwork {
+        routes: Arc<Mutex<HashMap<SocketAddr, UnboundedSender<Datagram>>>>,
+    }
+
+    impl InMemoryNetwork {
+        /// Create an empty network.
+        pub fn new() -> Self {
+            InMemoryNetwork::default()
+        }
+
+        /// Bind a transport at `addr`. A datagram sent to `addr` by any peer on this network is
+        /// delivered to the returned transport's [`recv_from`](Transport::recv_from).
+        pub fn bind(&self, addr: SocketAddr) -> InMemoryTransport {
+            let (tx, rx) = unbounded_channel();
+            self.routes.lock().insert(addr, tx);
+            InMemoryTransport {
+                network: self.clone(),
+                addr,
+                rx: AsyncMutex::new(rx),
+            }
+        }
+    }
+
+    /// One endpoint on an [`InMemoryNetwork`].
+    pub struct InMemoryTransport {
+        network: InMemoryNetwork,
+        addr: SocketAddr,
+        rx: AsyncMutex<UnboundedReceiver<Datagram>>,
+    }
+
+    #[async_trait]
+    impl Transport for InMemoryTransport {
+        type Addr = SocketAddr;
+
+        async fn recv_from(&self, buf: &mut [u8]) -> io::Result<(usize, SocketAddr)> {
+            let (src, bytes) = self.rx.lock().await.recv().await.ok_or_else(|| {
+                io::Error::new(io::ErrorKind::BrokenPipe, "in-memory network closed")
+            })?;
+            let n = bytes.len().min(buf.len());
+            buf[..n].copy_from_slice(&bytes[..n]);
+            Ok((n, src))
+        }
+
+        async fn send_to(&self, buf: &[u8], dst: &SocketAddr) -> io::Result<usize> {
+            // Deliver if the destination is bound; otherwise drop silently, like UDP to nowhere.
+            if let Some(tx) = self.network.routes.lock().get(dst) {
+                let _ = tx.send((self.addr, buf.to_vec()));
+            }
+            Ok(buf.len())
+        }
+
+        fn local_addr(&self) -> io::Result<SocketAddr> {
+            Ok(self.addr)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn in_memory_delivers_between_endpoints() {
+        let net = InMemoryNetwork::new();
+        let a: SocketAddr = "127.0.0.1:1".parse().unwrap();
+        let b: SocketAddr = "127.0.0.1:2".parse().unwrap();
+        let ta = net.bind(a);
+        let tb = net.bind(b);
+
+        ta.send_to(b"hello", &b).await.unwrap();
+        let mut buf = [0u8; 16];
+        let (n, src) = tb.recv_from(&mut buf).await.unwrap();
+        assert_eq!(&buf[..n], b"hello");
+        assert_eq!(src, a);
+        assert_eq!(tb.local_addr().unwrap(), b);
+    }
+
+    #[tokio::test]
+    async fn in_memory_drops_datagram_to_unknown_address() {
+        let net = InMemoryNetwork::new();
+        let a: SocketAddr = "127.0.0.1:1".parse().unwrap();
+        let ta = net.bind(a);
+        let unknown: SocketAddr = "127.0.0.1:9".parse().unwrap();
+        // No panic, no delivery: reports the bytes as "sent" then dropped.
+        let n = ta.send_to(b"lost", &unknown).await.unwrap();
+        assert_eq!(n, 4);
+    }
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,58 @@
+// Copyright 2023 Developers of the reconcile project.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Shared test helpers for the integration test suite.
+
+use std::sync::OnceLock;
+use std::time::Duration;
+
+/// Scaling factor for `wait_until` poll budgets.
+///
+/// Set `RECONCILE_TEST_TIME_MULTIPLIER` to an integer or float to stretch the
+/// budget; the default is 1 (unscaled, same as the hard-coded original budget).
+/// The coverage job sets it to 3 because `cargo llvm-cov` instrumentation
+/// slows the integration suite by 2-5×, and a 1-second budget produces
+/// spurious "convergence timed out" failures on shared CI runners.
+fn time_multiplier() -> u32 {
+    static MULTIPLIER: OnceLock<u32> = OnceLock::new();
+    *MULTIPLIER.get_or_init(|| {
+        std::env::var("RECONCILE_TEST_TIME_MULTIPLIER")
+            .ok()
+            .and_then(|s| s.parse::<f64>().ok())
+            .map(|f| f.max(1.0).round() as u32)
+            .unwrap_or(1)
+    })
+}
+
+/// Wait for a while until the provided predicate becomes true.
+///
+/// Returns `true` if the predicate became true within the budget, or `false`
+/// if it timed out.  The budget is `base_iters` × 10 ms by default, scaled by
+/// `RECONCILE_TEST_TIME_MULTIPLIER`.  Most callers pass 100; test files that
+/// already used a larger base (e.g. 200 for discovery tests) pass their
+/// original value so relative timing is preserved.
+pub async fn wait_until_with_budget<F: FnMut() -> bool>(mut f: F, base_iters: u32) -> bool {
+    let iters = base_iters.saturating_mul(time_multiplier());
+    for _ in 0..iters {
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        if f() {
+            return true;
+        }
+    }
+    false
+}
+
+/// Wait for a while until the provided predicate becomes true.
+///
+/// Returns `true` if the predicate became true within the budget, or `false`
+/// if it timed out.  The budget is 100 × 10 ms by default, scaled by
+/// `RECONCILE_TEST_TIME_MULTIPLIER`.
+#[allow(dead_code)] // used by service.rs; not every test file that includes this module uses it
+pub async fn wait_until<F: FnMut() -> bool>(f: F) -> bool {
+    wait_until_with_budget(f, 100).await
+}

--- a/tests/diff.rs
+++ b/tests/diff.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "internal-testing")]
+#![cfg(reconcile_internal_testing)]
 
 use std::hash::Hash;
 use std::ops::Bound;

--- a/tests/discovery.rs
+++ b/tests/discovery.rs
@@ -17,14 +17,14 @@ use std::time::Duration;
 use reconcile::discovery::{DiscoverFuture, Discovery};
 use reconcile::{reconcile_store::Config, ReconcileStore};
 
-async fn wait_until<F: FnMut() -> bool>(mut f: F) -> bool {
-    for _ in 0..200 {
-        tokio::time::sleep(Duration::from_millis(10)).await;
-        if f() {
-            return true;
-        }
-    }
-    false
+mod common;
+
+// Discovery tests use a 200-iteration base (2 s at default speed) because the
+// decommission/floor scenarios involve multiple discovery rounds with non-trivial
+// sleeps between them.
+#[allow(dead_code)]
+async fn wait_until<F: FnMut() -> bool>(f: F) -> bool {
+    common::wait_until_with_budget(f, 200).await
 }
 
 macro_rules! assert_until {

--- a/tests/discovery.rs
+++ b/tests/discovery.rs
@@ -126,10 +126,10 @@ async fn vanished_peer_is_decommissioned_and_tombstone_collected() {
 
 // ── Wall-time floor tests ─────────────────────────────────────────────────────────────────────
 //
-// These tests inspect the membership set directly, which requires the `internal-testing` feature
-// gate (the same gate used by the peer-cap and replay tests in `tests/service.rs`).
+// These tests inspect the membership set directly, which requires the `reconcile_internal_testing`
+// cfg gate (the same gate used by the peer-cap and replay tests in `tests/service.rs`).
 
-#[cfg(feature = "internal-testing")]
+#[cfg(reconcile_internal_testing)]
 mod floor {
     use super::*;
     use reconcile::testing::{members_snapshot, peers_contains, tombstone_acks_len};

--- a/tests/discovery.rs
+++ b/tests/discovery.rs
@@ -6,9 +6,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-//! End-to-end test of dynamic discovery through the public `run()` path: a peer that disappears
-//! from the discovery source is decommissioned after the grace period, releasing the causal
-//! stability gate that was holding back a tombstone's garbage collection.
+//! End-to-end tests of dynamic discovery through the public `run()` path: decommissioning,
+//! tombstone-GC gating, and the wall-time floor that guards against resurrection under DNS
+//! flakiness.
 
 use std::net::IpAddr;
 use std::sync::{Arc, Mutex};
@@ -83,7 +83,11 @@ async fn vanished_peer_is_decommissioned_and_tombstone_collected() {
         .with_tombstone_timeout(Duration::from_millis(50))
         .with_discovery(Arc::new(discovery.clone()))
         .with_discovery_interval(Duration::from_millis(20))
-        .with_discovery_miss_threshold(3);
+        .with_discovery_miss_threshold(3)
+        // A short floor so the test completes in reasonable time after the peer vanishes.
+        // The floor only delays decommission when tombstone acks are pending; using 150 ms
+        // here lets the test exercise the slow path (ack pending → wait floor → GC) quickly.
+        .with_discovery_decommission_floor(Duration::from_millis(150));
     let store2 = ReconcileStore::<i32, i32>::new(cfg2)
         .await
         .expect("bind failed")
@@ -112,10 +116,381 @@ async fn vanished_peer_is_decommissioned_and_tombstone_collected() {
         "tombstone collected while the peer was still reported present (resurrection hazard)"
     );
 
-    // The peer now disappears from discovery: after the grace period it is decommissioned and the
-    // tombstone becomes causally stable, so GC proceeds.
+    // The peer now disappears from discovery: after the grace period (miss_threshold rounds) and
+    // the decommission floor (150 ms) the peer is decommissioned and the tombstone is GC'd.
     discovery.set(vec![]);
     assert_until!(store1.fingerprint(..) != hash_with_tombstone);
 
     task1.abort();
+}
+
+// ── Wall-time floor tests ─────────────────────────────────────────────────────────────────────
+//
+// These tests inspect the membership set directly, which requires the `internal-testing` feature
+// gate (the same gate used by the peer-cap and replay tests in `tests/service.rs`).
+
+#[cfg(feature = "internal-testing")]
+mod floor {
+    use super::*;
+    use reconcile::testing::{members_snapshot, peers_contains, tombstone_acks_len};
+
+    /// Helper: build a `Config` for a loopback address + port with an isolated /32 net so random
+    /// probing never escapes to other tests' ports.
+    fn floor_cfg(addr: IpAddr, port: u16) -> Config {
+        let net = format!("{addr}/32").parse().unwrap();
+        Config::default()
+            .with_port(port)
+            .with_listen_addr(addr)
+            .with_net(net)
+    }
+
+    /// **Resurrection regression test (test 1)**: when member B vanishes from DNS and
+    /// `miss_threshold` rounds elapse but the wall-time floor has not, B must NOT be
+    /// decommissioned and the tombstone must NOT be GC'd.
+    ///
+    /// This is the acceptance criterion for the resurrection hazard: the tombstone is kept alive
+    /// exactly because B is still a member of the causal-stability set.  If the floor were absent,
+    /// `miss_threshold` rounds alone would fire `decommission_peer`, remove B from the GC gate, and
+    /// allow the tombstone to be collected — so a returning B could push the deleted value back.
+    /// With a 10 s floor (far beyond the test window) decommission is blocked even after
+    /// `miss_threshold` rounds when pending tombstone acks exist.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn floor_prevents_premature_decommission_and_resurrection() {
+        let port = 8098u16;
+        let addr_a: IpAddr = "127.0.0.88".parse().unwrap();
+        let addr_b: IpAddr = "127.0.0.89".parse().unwrap();
+
+        let discovery = ScriptedDiscovery::new(vec![addr_b]);
+        // Floor is 10 s — far longer than the test runs, so the floor never elapses here.
+        let store_a = ReconcileStore::<i32, i32>::new(floor_cfg(addr_a, port))
+            .await
+            .expect("bind failed")
+            .with_seed(addr_b)
+            .with_tombstone_timeout(Duration::from_millis(50))
+            .with_discovery(Arc::new(discovery.clone()))
+            .with_discovery_interval(Duration::from_millis(20))
+            .with_discovery_miss_threshold(2)
+            .with_discovery_decommission_floor(Duration::from_secs(10));
+        let store_b = ReconcileStore::<i32, i32>::new(floor_cfg(addr_b, port))
+            .await
+            .expect("bind failed")
+            .with_seed(addr_a)
+            .with_tombstone_timeout(Duration::from_millis(50));
+
+        let task_a = tokio::spawn(store_a.clone().run());
+        let task_b = tokio::spawn(store_b.clone().run());
+
+        // Establish mutual membership: both stores exchange dated datagrams.
+        store_a.insert(1, 100);
+        assert_until!(store_b.get(&1).as_deref() == Some(&100));
+        store_b.insert(2, 200);
+        assert_until!(store_a.get(&2).as_deref() == Some(&200));
+
+        // Abort B and delete key 1 on A so a tombstone is outstanding with B's ack pending.
+        task_b.abort();
+        store_a.remove(&1);
+        assert!(store_a.get(&1).is_none());
+        let hash_with_tombstone = store_a.fingerprint(..);
+
+        // Confirm discovery has observed B at least once (B is in the peers map) before clearing
+        // the resolver, so the `seen_ever` guard inside `discover_periodically` cannot skip it.
+        assert_until!(peers_contains(&store_a, addr_b));
+
+        // Remove B from discovery: miss_threshold rounds will elapse but the floor has not.
+        discovery.set(vec![]);
+
+        // Wait long enough for miss_threshold rounds to pass (2 × 20 ms + slack).
+        tokio::time::sleep(Duration::from_millis(300)).await;
+
+        // B must still be a member (floor not elapsed) and the tombstone must not be GC'd.
+        // This is the core of the resurrection guard: as long as B is a member the tombstone
+        // cannot be collected, so B cannot push the value back on its return.
+        assert!(
+            members_snapshot(&store_a).contains(&addr_b),
+            "B was prematurely decommissioned before the floor elapsed"
+        );
+        assert_eq!(
+            store_a.fingerprint(..),
+            hash_with_tombstone,
+            "tombstone was GC'd before the decommission floor elapsed (resurrection hazard)"
+        );
+
+        task_a.abort();
+    }
+
+    /// **Test 2**: when the floor elapses with a pending tombstone ack, the member IS
+    /// decommissioned and the GC slot is released.  Uses a 100 ms floor so the test completes
+    /// quickly without sleeping for 10 minutes.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn floor_elapsed_decommissions_member_with_pending_tombstones() {
+        let port = 8099u16;
+        let addr_a: IpAddr = "127.0.0.90".parse().unwrap();
+        let addr_b: IpAddr = "127.0.0.91".parse().unwrap();
+
+        let discovery = ScriptedDiscovery::new(vec![addr_b]);
+        let store_a = ReconcileStore::<i32, i32>::new(floor_cfg(addr_a, port))
+            .await
+            .expect("bind failed")
+            .with_seed(addr_b)
+            .with_tombstone_timeout(Duration::from_millis(50))
+            .with_discovery(Arc::new(discovery.clone()))
+            .with_discovery_interval(Duration::from_millis(20))
+            .with_discovery_miss_threshold(2)
+            .with_discovery_decommission_floor(Duration::from_millis(100));
+        let store_b = ReconcileStore::<i32, i32>::new(floor_cfg(addr_b, port))
+            .await
+            .expect("bind failed")
+            .with_seed(addr_a)
+            .with_tombstone_timeout(Duration::from_millis(50));
+
+        let task_a = tokio::spawn(store_a.clone().run());
+        let task_b = tokio::spawn(store_b.clone().run());
+
+        // Establish mutual membership.
+        store_a.insert(10, 1000);
+        assert_until!(store_b.get(&10).as_deref() == Some(&1000));
+        store_b.insert(20, 2000);
+        assert_until!(store_a.get(&20).as_deref() == Some(&2000));
+
+        // Abort B and create a tombstone on A.
+        task_b.abort();
+        store_a.remove(&10);
+        let hash_with_tombstone = store_a.fingerprint(..);
+
+        // Confirm discovery has observed B at least once before clearing the resolver.
+        assert_until!(peers_contains(&store_a, addr_b));
+
+        // Remove B from discovery; floor is 100 ms, so after enough time B is decommissioned.
+        discovery.set(vec![]);
+
+        // Wait for decommission: floor (100 ms) + miss_threshold (2 × 20 ms) + slack.
+        assert_until!(!members_snapshot(&store_a).contains(&addr_b));
+
+        // Once B is gone the tombstone should be GC'd.
+        assert_until!(store_a.fingerprint(..) != hash_with_tombstone);
+
+        task_a.abort();
+    }
+
+    /// **Test 3**: a member with NO pending tombstone acks is decommissioned after exactly
+    /// `miss_threshold` rounds, with no wall-time floor delay — the existing fast path is
+    /// preserved.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn no_pending_tombstones_decommissions_at_miss_threshold() {
+        let port = 8100u16;
+        let addr_a: IpAddr = "127.0.0.92".parse().unwrap();
+        let addr_b: IpAddr = "127.0.0.93".parse().unwrap();
+
+        let discovery = ScriptedDiscovery::new(vec![addr_b]);
+        // Floor is 10 s; it must NOT delay decommission when there are no pending acks.
+        let store_a = ReconcileStore::<i32, i32>::new(floor_cfg(addr_a, port))
+            .await
+            .expect("bind failed")
+            .with_seed(addr_b)
+            .with_discovery(Arc::new(discovery.clone()))
+            .with_discovery_interval(Duration::from_millis(20))
+            .with_discovery_miss_threshold(2)
+            .with_discovery_decommission_floor(Duration::from_secs(10));
+        let store_b = ReconcileStore::<i32, i32>::new(floor_cfg(addr_b, port))
+            .await
+            .expect("bind failed")
+            .with_seed(addr_a);
+
+        let task_a = tokio::spawn(store_a.clone().run());
+        let task_b = tokio::spawn(store_b.clone().run());
+
+        // Establish mutual membership (no tombstones involved).
+        store_a.insert(100, 1);
+        assert_until!(store_b.get(&100).as_deref() == Some(&1));
+        store_b.insert(200, 2);
+        assert_until!(store_a.get(&200).as_deref() == Some(&2));
+
+        // Confirm discovery has observed B at least once (so the `seen_ever` guard inside
+        // `discover_periodically` will not skip B when it goes absent) before clearing the
+        // resolver. Without this wait the clear can race ahead of the first discovery round and
+        // B would never enter `seen_ever`, causing the decommission logic to skip it forever.
+        assert_until!(peers_contains(&store_a, addr_b));
+
+        // Abort B and remove it from discovery; no tombstones are outstanding.
+        task_b.abort();
+        discovery.set(vec![]);
+
+        // B should be decommissioned promptly (miss_threshold rounds, no floor delay).
+        assert_until!(!members_snapshot(&store_a).contains(&addr_b));
+
+        task_a.abort();
+    }
+
+    /// **Test 4**: reappearance resets the absence clock.  Scenario: B vanishes, then reappears
+    /// before the floor, then vanishes again.  The floor is measured from the *second* vanish.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn reappearance_resets_absence_clock() {
+        let port = 8101u16;
+        let addr_a: IpAddr = "127.0.0.94".parse().unwrap();
+        let addr_b: IpAddr = "127.0.0.95".parse().unwrap();
+
+        let discovery = ScriptedDiscovery::new(vec![addr_b]);
+        // 200 ms floor; short enough to test elapsed in the second-absence window.
+        let store_a = ReconcileStore::<i32, i32>::new(floor_cfg(addr_a, port))
+            .await
+            .expect("bind failed")
+            .with_seed(addr_b)
+            .with_tombstone_timeout(Duration::from_millis(50))
+            .with_discovery(Arc::new(discovery.clone()))
+            .with_discovery_interval(Duration::from_millis(20))
+            .with_discovery_miss_threshold(2)
+            .with_discovery_decommission_floor(Duration::from_millis(200));
+        let store_b = ReconcileStore::<i32, i32>::new(floor_cfg(addr_b, port))
+            .await
+            .expect("bind failed")
+            .with_seed(addr_a)
+            .with_tombstone_timeout(Duration::from_millis(50));
+
+        let task_a = tokio::spawn(store_a.clone().run());
+        let task_b = tokio::spawn(store_b.clone().run());
+
+        // Establish mutual membership and leave a tombstone pending.
+        store_a.insert(1000, 42);
+        assert_until!(store_b.get(&1000).as_deref() == Some(&42));
+        store_b.insert(2000, 84);
+        assert_until!(store_a.get(&2000).as_deref() == Some(&84));
+
+        task_b.abort();
+        store_a.remove(&1000);
+        let hash_with_tombstone = store_a.fingerprint(..);
+
+        // Confirm discovery has observed B at least once before clearing the resolver so the
+        // `seen_ever` guard inside `discover_periodically` tracks B correctly.
+        assert_until!(peers_contains(&store_a, addr_b));
+
+        // First absence: vanish for a bit but reappear before the floor.
+        discovery.set(vec![]);
+        // Less than the 200 ms floor; absence clock must not yet have triggered decommission.
+        tokio::time::sleep(Duration::from_millis(80)).await;
+        // Reappear: absence clock must reset.
+        discovery.set(vec![addr_b]);
+        tokio::time::sleep(Duration::from_millis(60)).await;
+
+        // B must still be a member (the first-absence clock was reset on reappearance).
+        assert!(
+            members_snapshot(&store_a).contains(&addr_b),
+            "B was decommissioned during or just after the first absence window"
+        );
+        assert_eq!(
+            store_a.fingerprint(..),
+            hash_with_tombstone,
+            "tombstone GC'd during the first absence window"
+        );
+
+        // Second absence: remove B again; floor is 200 ms.
+        discovery.set(vec![]);
+
+        // Wait for the floor measured from the second vanish to elapse.
+        assert_until!(!members_snapshot(&store_a).contains(&addr_b));
+        assert_until!(store_a.fingerprint(..) != hash_with_tombstone);
+
+        task_a.abort();
+    }
+
+    /// **Test 5 — zero-ack deletion**: the floor must hold for a tombstone that has received no
+    /// acknowledgment at all.
+    ///
+    /// A tombstone nobody has acked yet has no `tombstone_acks` entry, so a pending-acks
+    /// predicate that iterates `tombstone_acks` cannot see it and reports "nothing pending" —
+    /// triggering the fast-path decommission while `is_tombstone_stable` is still false, letting
+    /// GC collect the tombstone and opening the resurrection window.  The predicate iterates the
+    /// map itself (the authoritative domain), so a fresh tombstone with zero acks is pending.
+    ///
+    /// Construction: B's run loop is aborted and **awaited to full termination before the
+    /// deletion is issued**, so the tombstone cannot reach B and zero acks is guaranteed by
+    /// ordering (asserted below), not by racing the abort.  A's config deliberately has NO
+    /// probe net: with the usual self-/32 net, A random-probes its own address, reconciles
+    /// with itself, and acks its own tombstone — which would break the zero-ack invariant
+    /// this test exists to exercise.  The `peers_contains` wait ensures discovery observed B
+    /// beforehand (the `seen_ever` guard admits B to the decommission path), and B stays in
+    /// `members` from the pre-deletion exchange.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn zero_ack_deletion_floor_holds() {
+        let port = 8102u16;
+        let addr_a: IpAddr = "127.0.0.96".parse().unwrap();
+        let addr_b: IpAddr = "127.0.0.97".parse().unwrap();
+
+        let discovery = ScriptedDiscovery::new(vec![addr_b]);
+        // Floor is 10 s — far longer than the test window, so it must never elapse here.
+        // No `.with_net(...)`: seeded/discovered peers are contacted every round regardless;
+        // only the self-probing has to go.
+        let store_a = ReconcileStore::<i32, i32>::new(
+            Config::default().with_port(port).with_listen_addr(addr_a),
+        )
+        .await
+        .expect("bind failed")
+        .with_seed(addr_b)
+        .with_tombstone_timeout(Duration::from_millis(50))
+        .with_discovery(Arc::new(discovery.clone()))
+        .with_discovery_interval(Duration::from_millis(20))
+        .with_discovery_miss_threshold(2)
+        .with_discovery_decommission_floor(Duration::from_secs(10));
+        let store_b = ReconcileStore::<i32, i32>::new(floor_cfg(addr_b, port))
+            .await
+            .expect("bind failed")
+            .with_seed(addr_a)
+            .with_tombstone_timeout(Duration::from_millis(50));
+
+        let task_a = tokio::spawn(store_a.clone().run());
+        let task_b = tokio::spawn(store_b.clone().run());
+
+        // Establish mutual membership so B enters the causal-stability gate.
+        store_a.insert(42, 1);
+        assert_until!(store_b.get(&42).as_deref() == Some(&1));
+        store_b.insert(99, 2);
+        assert_until!(store_a.get(&99).as_deref() == Some(&2));
+
+        // Wait until B is in A's membership set (the causal-stability gate that blocks tombstone
+        // GC). This requires a dated datagram from B to have been processed by A, which the data
+        // exchange above triggers. We wait explicitly rather than relying on implicit timing.
+        assert_until!(members_snapshot(&store_a).contains(&addr_b));
+
+        // Wait until discovery has seeded B in the peers map, confirming that at least one
+        // discovery round has run and B will enter `seen_ever` inside `discover_periodically`.
+        assert_until!(peers_contains(&store_a, addr_b));
+
+        // Terminate B completely BEFORE the deletion exists: abort the run loop and await the
+        // join handle, so B can never receive the tombstone, never ack it, and never send
+        // another dated datagram that would re-assert its membership.
+        task_b.abort();
+        let _ = task_b.await;
+        drop(store_b);
+
+        store_a.remove(&42);
+        let hash_with_tombstone = store_a.fingerprint(..);
+        discovery.set(vec![]);
+
+        // Allow miss_threshold rounds to pass (2 × 20 ms + slack) but well within the 10 s floor.
+        tokio::time::sleep(Duration::from_millis(300)).await;
+
+        // Pin the construction: the tombstone for key 42 must have received no acks. If this
+        // ever fires, the ordering guarantee above broke and the test no longer exercises the
+        // zero-ack path it exists for.
+        assert_eq!(
+            tombstone_acks_len(&store_a),
+            0,
+            "construction broken: an ack arrived for the tombstone after B was terminated"
+        );
+
+        // Core assertions: with zero acks, a predicate blind to un-acked tombstones would have
+        // taken the fast path and decommissioned B at miss_threshold (~40 ms); the floor must
+        // instead hold B's membership and keep the tombstone un-GC'd.
+        assert!(
+            members_snapshot(&store_a).contains(&addr_b),
+            "B was prematurely decommissioned despite a zero-ack pending tombstone \
+             (resurrection hazard)"
+        );
+        assert_eq!(
+            store_a.fingerprint(..),
+            hash_with_tombstone,
+            "tombstone GC'd despite zero acks from B (resurrection hazard)"
+        );
+
+        task_a.abort();
+    }
 }

--- a/tests/proptest_hrtree.rs
+++ b/tests/proptest_hrtree.rs
@@ -20,7 +20,7 @@
 //!    key sets, and convergence survives reordered, duplicated and dropped
 //!    messages — modelling the lossy UDP transport.
 
-#![cfg(feature = "internal-testing")]
+#![cfg(reconcile_internal_testing)]
 
 use std::collections::BTreeMap;
 use std::ops::Bound;

--- a/tests/service.rs
+++ b/tests/service.rs
@@ -7,19 +7,9 @@ use rand::{
 
 use reconcile::{reconcile_store::Config, Fingerprint, ReconcileStore};
 
-/// Wait for a while until the provided predicate becomes true
-///
-/// If the predicate become true in the delay, return true, otherwise return false. This functions
-/// minimizes the wait time by checking regularly if the predicate is true.
-async fn wait_until<F: FnMut() -> bool>(mut f: F) -> bool {
-    for _ in 0..100 {
-        tokio::time::sleep(Duration::from_millis(10)).await;
-        if f() {
-            return true;
-        }
-    }
-    false
-}
+mod common;
+
+use common::wait_until;
 
 macro_rules! assert_until {
     ( $x:expr ) => {

--- a/tests/service.rs
+++ b/tests/service.rs
@@ -880,7 +880,7 @@ async fn runtime_config_setters() {
 /// freshness check.  Any correctly-MAC-tagged datagram was accepted regardless of its timestamp,
 /// so an attacker who captured a datagram hours earlier could replay it indefinitely.  The
 /// `seal_datagram` helper also did not exist in the testing seam before this change.
-#[cfg(feature = "internal-testing")]
+#[cfg(reconcile_internal_testing)]
 #[tokio::test(flavor = "multi_thread")]
 async fn stale_datagram_outside_freshness_window_is_rejected() {
     use reconcile::testing::seal_datagram;
@@ -943,7 +943,7 @@ async fn stale_datagram_outside_freshness_window_is_rejected() {
 /// Replaying the same sealed datagram (identical bytes, same seq) must be silently rejected after
 /// the first delivery.
 ///
-/// This test crafts a valid authenticated datagram via the `internal-testing` seam, delivers it to
+/// This test crafts a valid authenticated datagram via the `reconcile::testing` seam, delivers it to
 /// an authenticated store, and then delivers the exact same bytes a second time.  Because the
 /// sequence number (seq=1) is already recorded in the per-peer replay filter, the second delivery
 /// is dropped silently and the engine continues running normally.
@@ -951,7 +951,7 @@ async fn stale_datagram_outside_freshness_window_is_rejected() {
 /// This test would FAIL against the pre-change code: old code had no replay header, no
 /// `SenderCounter`, and no `ReplayFilter`.  The `Authenticator::seal` function did not accept
 /// `seq` or `stamp` parameters, and `seal_datagram` did not exist in the testing seam.
-#[cfg(feature = "internal-testing")]
+#[cfg(reconcile_internal_testing)]
 #[tokio::test(flavor = "multi_thread")]
 async fn replayed_sealed_datagram_is_rejected() {
     use reconcile::testing::seal_datagram;
@@ -1020,7 +1020,7 @@ async fn replayed_sealed_datagram_is_rejected() {
 /// This test must FAIL against the pre-fix code (commit 4391c82): `decommission_peer` called
 /// `replay_filter.evict(peer)`, erasing per-peer state, so the replayed datagram was accepted
 /// as first contact.
-#[cfg(feature = "internal-testing")]
+#[cfg(reconcile_internal_testing)]
 #[tokio::test(flavor = "multi_thread")]
 async fn decommissioned_peer_replay_is_rejected() {
     use reconcile::testing::{members_snapshot, seal_datagram};

--- a/tests/service.rs
+++ b/tests/service.rs
@@ -17,6 +17,25 @@ macro_rules! assert_until {
     };
 }
 
+/// Like [`wait_until`] but waits up to ~10 s. Tombstone GC is gated on a 1 s scan loop
+/// (`TOMBSTONE_CLEARING`) plus the wall-clock tombstone timeout, so events that depend on a
+/// completed GC need a longer budget than the 1 s [`wait_until`].
+async fn wait_until_slow<F: FnMut() -> bool>(mut f: F) -> bool {
+    for _ in 0..1000 {
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        if f() {
+            return true;
+        }
+    }
+    false
+}
+
+macro_rules! assert_until_slow {
+    ( $x:expr ) => {
+        assert!(wait_until_slow(|| $x).await, stringify!($x))
+    };
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn test() {
     let port = 8080;
@@ -1090,4 +1109,161 @@ async fn decommissioned_peer_replay_is_rejected() {
 
     assert!(!task.is_finished(), "engine must still be running");
     task.abort();
+}
+
+/// Regression test: in a cluster of three or more nodes, a deleted key's tombstone must eventually
+/// be garbage-collected on **every** node once they have all held it long enough —
+/// with **no** manual `forget_peer`/decommission. Before the periodic re-acknowledgment fix the
+/// causal-stability ack matrix never completed at N≥3 (two non-originating replicas never learned
+/// that the other held the deletion), so this assertion hung forever.
+///
+/// Full-mesh topology: every node seeds the other two.
+#[tokio::test(flavor = "multi_thread")]
+async fn tombstone_gc_converges_in_3_node_cluster_mesh() {
+    // Dedicated port for test isolation (see `tombstone_is_retained_until_peer_acknowledges`).
+    let port = 8120;
+    let net = "127.0.0.1/8".parse().unwrap();
+    let addr1 = "127.0.0.110".parse().unwrap();
+    let addr2 = "127.0.0.111".parse().unwrap();
+    let addr3 = "127.0.0.112".parse().unwrap();
+
+    // Short tombstone timeout (quick GC eligibility) and short reconcile interval (re-acks flow
+    // fast) keep the test brief; GC still cannot fire until causal stability is reached.
+    let mk = |addr| {
+        Config::default()
+            .with_port(port)
+            .with_listen_addr(addr)
+            .with_net(net)
+            .with_reconcile_interval(Duration::from_millis(100))
+    };
+    let store1 = ReconcileStore::<i32, i32>::new(mk(addr1))
+        .await
+        .expect("bind failed")
+        .with_seed(addr2)
+        .with_seed(addr3)
+        .with_tombstone_timeout(Duration::from_millis(200));
+    let store2 = ReconcileStore::<i32, i32>::new(mk(addr2))
+        .await
+        .expect("bind failed")
+        .with_seed(addr1)
+        .with_seed(addr3)
+        .with_tombstone_timeout(Duration::from_millis(200));
+    let store3 = ReconcileStore::<i32, i32>::new(mk(addr3))
+        .await
+        .expect("bind failed")
+        .with_seed(addr1)
+        .with_seed(addr2)
+        .with_tombstone_timeout(Duration::from_millis(200));
+
+    let task1 = tokio::spawn(store1.clone().run());
+    let task2 = tokio::spawn(store2.clone().run());
+    let task3 = tokio::spawn(store3.clone().run());
+
+    // Each node writes a distinct live key; once all keys are visible everywhere, every pair has
+    // exchanged dated messages, so all three are mutual causal-stability members.
+    store1.insert(1, 11);
+    store2.insert(2, 22);
+    store3.insert(3, 33);
+    assert_until!(store1.get(&2).as_deref() == Some(&22) && store1.get(&3).as_deref() == Some(&33));
+    assert_until!(store2.get(&1).as_deref() == Some(&11) && store2.get(&3).as_deref() == Some(&33));
+    assert_until!(store3.get(&1).as_deref() == Some(&11) && store3.get(&2).as_deref() == Some(&22));
+
+    // Delete key 1 on store1 and let the tombstone propagate to both other nodes.
+    store1.remove(&1);
+    assert_until!(store2.get(&1).is_none() && store3.get(&1).is_none());
+
+    // Once all three converge on the tombstone state, capture that fingerprint. It only changes
+    // again when the tombstone is actually GC'd (the live keys 2 and 3 are never rewritten).
+    let fp_tombstone = store1.fingerprint(..);
+    assert_until!(store2.fingerprint(..) == fp_tombstone && store3.fingerprint(..) == fp_tombstone);
+
+    // The regression: with NO decommissioning, the tombstone must be collected on all three nodes
+    // (this hung before the fix), and they must converge to the same post-GC fingerprint.
+    assert_until_slow!(store1.fingerprint(..) != fp_tombstone);
+    assert_until_slow!(store2.fingerprint(..) != fp_tombstone);
+    assert_until_slow!(store3.fingerprint(..) != fp_tombstone);
+    let fp_collected = store1.fingerprint(..);
+    assert_until_slow!(
+        store2.fingerprint(..) == fp_collected && store3.fingerprint(..) == fp_collected
+    );
+
+    task1.abort();
+    task2.abort();
+    task3.abort();
+}
+
+/// Companion to the mesh test, in a line topology (A↔B↔C: the middle node relays; A and C never
+/// communicate directly, so each is a member only of B). End-to-end coverage that GC still
+/// converges when propagation is relayed rather than broadcast from a single origin.
+///
+/// Note: the strict regression guard is the *mesh* test above — that is the configuration in
+/// which the pre-fix ack matrix provably never completes (B and C learn the deletion simultaneously
+/// from A and never exchange acks). A relayed line incidentally completes the matrix through the
+/// existing stale-value ack path during each adjacent node's value→tombstone transition, so it
+/// converges even without the periodic-re-ack fix; this test simply confirms the fix does not
+/// regress that path.
+#[tokio::test(flavor = "multi_thread")]
+async fn tombstone_gc_converges_in_3_node_cluster_line() {
+    let port = 8121;
+    let net = "127.0.0.1/8".parse().unwrap();
+    let addr1 = "127.0.0.113".parse().unwrap();
+    let addr2 = "127.0.0.114".parse().unwrap();
+    let addr3 = "127.0.0.115".parse().unwrap();
+
+    let mk = |addr| {
+        Config::default()
+            .with_port(port)
+            .with_listen_addr(addr)
+            .with_net(net)
+            .with_reconcile_interval(Duration::from_millis(100))
+    };
+    // Line: A seeds B; B seeds A and C; C seeds B. Seeds define the intended topology; a stray
+    // discovery probe could only add connectivity, which never prevents GC convergence.
+    let store1 = ReconcileStore::<i32, i32>::new(mk(addr1))
+        .await
+        .expect("bind failed")
+        .with_seed(addr2)
+        .with_tombstone_timeout(Duration::from_millis(200));
+    let store2 = ReconcileStore::<i32, i32>::new(mk(addr2))
+        .await
+        .expect("bind failed")
+        .with_seed(addr1)
+        .with_seed(addr3)
+        .with_tombstone_timeout(Duration::from_millis(200));
+    let store3 = ReconcileStore::<i32, i32>::new(mk(addr3))
+        .await
+        .expect("bind failed")
+        .with_seed(addr2)
+        .with_tombstone_timeout(Duration::from_millis(200));
+
+    let task1 = tokio::spawn(store1.clone().run());
+    let task2 = tokio::spawn(store2.clone().run());
+    let task3 = tokio::spawn(store3.clone().run());
+
+    // Data converges through the middle node B.
+    store1.insert(1, 11);
+    store3.insert(3, 33);
+    assert_until!(store1.get(&3).as_deref() == Some(&33));
+    assert_until!(store3.get(&1).as_deref() == Some(&11));
+    assert_until!(store2.get(&1).as_deref() == Some(&11) && store2.get(&3).as_deref() == Some(&33));
+
+    // Delete key 1 on store1; the tombstone must reach C via B.
+    store1.remove(&1);
+    assert_until!(store2.get(&1).is_none() && store3.get(&1).is_none());
+
+    let fp_tombstone = store1.fingerprint(..);
+    assert_until!(store2.fingerprint(..) == fp_tombstone && store3.fingerprint(..) == fp_tombstone);
+
+    // The tombstone must be GC'd on all three nodes with no decommissioning.
+    assert_until_slow!(store1.fingerprint(..) != fp_tombstone);
+    assert_until_slow!(store2.fingerprint(..) != fp_tombstone);
+    assert_until_slow!(store3.fingerprint(..) != fp_tombstone);
+    let fp_collected = store1.fingerprint(..);
+    assert_until_slow!(
+        store2.fingerprint(..) == fp_collected && store3.fingerprint(..) == fp_collected
+    );
+
+    task1.abort();
+    task2.abort();
+    task3.abort();
 }

--- a/tests/service.rs
+++ b/tests/service.rs
@@ -1127,7 +1127,7 @@ async fn tombstone_gc_converges_in_3_node_cluster_mesh() {
     let addr2 = "127.0.0.111".parse().unwrap();
     let addr3 = "127.0.0.112".parse().unwrap();
 
-    // Short tombstone timeout (quick GC eligibility) and short reconcile interval (re-acks flow
+    // Short tombstone timeout (quick GC eligibility) and short reconcile interval (ack resends flow
     // fast) keep the test brief; GC still cannot fire until causal stability is reached.
     let mk = |addr| {
         Config::default()
@@ -1200,7 +1200,7 @@ async fn tombstone_gc_converges_in_3_node_cluster_mesh() {
 /// which the pre-fix ack matrix provably never completes (B and C learn the deletion simultaneously
 /// from A and never exchange acks). A relayed line incidentally completes the matrix through the
 /// existing stale-value ack path during each adjacent node's value→tombstone transition, so it
-/// converges even without the periodic-re-ack fix; this test simply confirms the fix does not
+/// converges even without the periodic-ack-resend fix; this test simply confirms the fix does not
 /// regress that path.
 #[tokio::test(flavor = "multi_thread")]
 async fn tombstone_gc_converges_in_3_node_cluster_line() {


### PR DESCRIPTION
## Problem (#216)

Causal-stability tombstone GC (invariant 6) removes a tombstone only once **every** member has acknowledged that exact version (`is_tombstone_stable`). In any cluster of **3+ nodes this gate is never reached**, so deletions are never collected — tombstones and their timeout-wheel entries accumulate for the life of the process. 2-node clusters converge fine.

**Root cause:** acks were **pairwise and non-transitive**. They only flowed back to the node a tombstone was *received* from (plus one bounded reciprocal hop). When an originator A deletes a key and broadcasts the tombstone to B and C, both ack A — but **B and C never ack each other**: they each learned the tombstone from A, and once both hold the identical tombstone their range fingerprints match, so the diff protocol never re-surfaces that key. B permanently lacks C's ack and vice-versa, so stability is never reached on the non-originators.

This also kept `has_pending_tombstone_acks` permanently true, disabling the DNS-decommission fast path (#217).

## Fix

**Periodic re-acking of held tombstones, piggybacked on the reconciliation round.** Each round, every node appends an `Ack(key, version)` for the tombstones it currently holds to the same broadcast datagram as the diff. This completes the ack matrix transitively along the reconciliation edges that established membership in the first place, and dissolves the ack-before-tombstone ordering hazard — a re-ack simply lands on the next round once the receiver holds the tombstone (no dropped early acks to re-deliver).

- **Live-tombstone index** (`live_tombstones`) maintained at the single map sink (`map_insert`/`gc_remove`) for O(1) enumeration without scanning the map.
- **`append_tombstone_reacks`** helper emits the acks, bounded by `REACK_BYTE_BUDGET` with a round-advancing window for spillover (sorted keys → deterministic coverage), so the datagram stays bounded. Re-acks ride the broadcast buffer, so they inherit the existing local/remote WAN throttling for free.
- The redundant `already`-guarded **reciprocal-ack path is removed**; the immediate ack on first receipt of a tombstone is kept as the fast path.
- `is_tombstone_stable`, `clear_expired_tombstones`, GC and invariant 6 are **unchanged** — the fix only makes the ack matrix actually complete.

**No wire-format change** (`Message::Ack` already exists; it's just sent more often) and no change to the 8 load-bearing invariants.

### Bounded by design (stacked on #215)
This is stacked on **#215** (`claude/p1-2-bounded-growth`) and relies on its ack-admission gate: a received `Ack` is recorded only for a locally-held tombstone, keeping `tombstone_acks` ⊆ (live local tombstones × members) — #216's acceptance criterion. **Merge after #215.**

## Tests
- `tombstone_gc_converges_in_3_node_cluster_mesh` — the strict regression guard; **hangs before this fix** (mesh broadcast is exactly the case the matrix never completes in), passes after.
- `tombstone_gc_converges_in_3_node_cluster_line` — end-to-end GC convergence in a relay/line topology.
- `reconciliation_round_reacks_held_tombstones` — deterministic, socket-free engine unit test asserting a round re-acks held tombstones and never live values (verified it fails — `got []` — without the fix).

Full suite (`cargo test --all`, `--doc`), `clippy --all-targets -D warnings`, and `cargo build --features metrics-prometheus` (new `reconcile_tombstone_reacks_total` counter) all green.

## Reviewer note
Per #206's working protocol, this touches GC/protocol/invariant 6 and warrants an **adversarial review before merge**. Worth probing specifically: re-ack volume under heavy delete churn (the byte budget + rotating window bound it; the new counter makes it observable) and the `map → live_tombstones → projection` lock order (consistent across all mutation paths; `start_reconciliation` never holds two at once).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KGckuGTXXPaNKfgbE9oijj

---
_Generated by [Claude Code](https://claude.ai/code/session_01KGckuGTXXPaNKfgbE9oijj)_