### PR TITLE
docs(agents): fold the CI/packaging traps from #237 into the merged AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,8 +58,24 @@ Say what the code cannot. Everything else is noise that goes stale.
   `docs/SOTA.md` positions · `docs/GLOSSARY.md` defines. Put a change in exactly one.
 - Prefer a diagram or a table to a paragraph. Mermaid renders on GitHub.
 
+## Traps that are not in the code
+
+- **`./pre-commit` is a repo script, not the Python framework.** There is no
+  `.pre-commit-config.yaml`; `pre-commit run --all-files` does nothing. `.devcontainer/init.sh`
+  links it into `.git/hooks/`. It runs `fmt` and `clippy --all` only, so passing it is weaker than
+  the gate above.
+- **shellcheck and markdownlint are editor aids, not gates.** Both ship in the dev image, neither
+  runs in CI, and the existing docs fail their defaults heavily. Don't "fix" docs to satisfy them.
+  Do keep new shell scripts shellcheck-clean.
+- **Anything new at the top level ships to crates.io unless `Cargo.toml`'s `exclude` says
+  otherwise**, and publishing is irreversible. Check with
+  `cargo package --list --allow-dirty | grep <new-path>`.
+
 ## Conventions
 
+- **Commits**: Conventional Commits with an optional scope, as in the log — `feat(clock):`,
+  `fix(timeout_wheel):`, `refactor(...)`, `perf(...)`, `chore:`, `ci:`. Work lands through a pull
+  request; `main` is not committed to directly.
 - `#![forbid(unsafe_code)]`. MSRV 1.85; raising it is a minor version bump.
 - Ports are `Clock`, `Transport`, `Codec`, `Persistence`, `Discovery`. Which are consumer-wireable,
   and what an implementation owes, is [`docs/CONTRACT.md` §5](docs/CONTRACT.md#5-extending-it).


### PR DESCRIPTION
Rewritten and retargeted onto `claude/p1-7-hygiene`, where `AGENTS.md` now lives after #235.

**What changed and why.** This PR originally wrote its own `AGENTS.md` against `main`, where `internal-testing` is still a Cargo feature. That premise does not hold on the Phase-1 tip: the feature was deliberately replaced with `--cfg reconcile_internal_testing`, so the seam cannot be reached by a downstream consumer of the published crate. Its first two sections — the `--features internal-testing` trap and the CI command list — are therefore not portable, and re-landing them would reintroduce guidance that contradicts `Cargo.toml`.

Four of its findings *are* portable, and none of them were in the merged file:

- **`./pre-commit` is a repo script, not the Python framework.** No `.pre-commit-config.yaml`; `pre-commit run --all-files` does nothing. It runs `fmt` and `clippy --all` only, so passing the hook is a weaker check than CI.
- **shellcheck and markdownlint gate nothing.** Both ship in the dev image, neither runs in CI, and the existing docs fail their defaults heavily — treating them as a gate produces churn.
- **A new top-level file ships to crates.io** unless `Cargo.toml`'s `exclude` says otherwise, and publishing is irreversible. With the `cargo package --list --allow-dirty | grep <path>` check.
- **The commit convention actually practised in the log** — Conventional Commits with an optional scope. The merged file asked for this in spirit but never named the format.

Verified the packaging claim against this tree: `AGENTS.md` and `CLAUDE.md` do not appear in `cargo package --list`.

The `CONTRIBUTING.md` and `README.md` edits from the original are dropped: both files were rewritten in #235, and those edits described the feature-based world that no longer exists here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KGckuGTXXPaNKfgbE9oijj