### PR TITLE
docs: bring PROGRESS/SOTA status current after the audit and correctness sprint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,48 @@
+# Agent guidelines for reconcile-rs
+
+Conventions for anyone (human or agent) making changes to this crate. These are in addition to
+[`CONTRIBUTING.md`](./CONTRIBUTING.md) (workflow) and [`ARCHITECTURE.md`](./ARCHITECTURE.md)
+(structure); this file is about how code in this crate should be shaped.
+
+## Strong-type every wire/domain entity — no bare primitives for meaningful values
+
+A value that means something specific in the protocol or the domain (a sequence number, a
+timestamp, a key, a MAC tag, a cluster secret) must be its own newtype, never passed around as a
+bare `u64`/`[u8; N]`/`String`. Two bare `u64` parameters of the same type are a bug waiting to
+happen (nothing stops a caller from swapping `seq` and `stamp`); two distinct newtypes make that
+swap a compile error.
+
+**Precedent already in the crate**: [`Timestamp`](./src/clock.rs) (HLC timestamp: `wall_ms`,
+`counter`, `node_id`), [`ClusterKey`](./src/auth.rs) and [`Tag`](./src/auth.rs) (MAC key/output),
+[`Seq` and `Stamp`](./src/replay.rs) (replay-header sequence number and sender wall-clock stamp).
+None of these are exposed as raw integers or byte arrays past the boundary where they are parsed
+off the wire.
+
+## Every entity owns its own validation
+
+The type that represents a value is the *only* place that decides whether a given instance of that
+value is well-formed, in-range, or acceptable — never the caller. Concretely:
+
+- Parsing/encoding lives on the type (`Seq::from_le_bytes`/`to_le_bytes`, not free functions that
+  take/return `u64`).
+- A check that is conceptually "is this value acceptable" is a method on the type, not arithmetic
+  redone at each call site. Example: [`Stamp::is_fresh`](./src/replay.rs) is the *only* place the
+  freshness-window comparison is written; [`ReplayFilter`](./src/replay.rs) calls it rather than
+  reimplementing `now.saturating_sub(stamp) > window_ms` itself. If you find the same validation
+  arithmetic duplicated at two call sites, that arithmetic belongs on the type instead.
+- Constructing an invalid instance should be structurally impossible, or at least funneled through
+  one obviously-fallible constructor — not something every caller has to remember to check.
+
+This is the same "parse, don't validate" principle already called out for [`Payload`](./src/auth.rs)
+(a `Payload` can only be obtained from `Authenticator::open`, so unauthenticated bytes can never
+reach message handling) and for [`Entry`](./ARCHITECTURE.md#36-domain-types-and-conflict-policy)
+(merge semantics live on the type, not scattered across call sites). Apply it to every entity, not
+just the ones that happen to be security-critical.
+
+## When adding a new wire field or protocol value
+
+1. Give it a newtype in the module that owns its semantics (usually the module that already parses
+   or generates it), not in the module that happens to consume it first.
+2. Put its encode/decode and any acceptance/validation logic on that type.
+3. Only reach for a bare primitive at the actual wire boundary (the byte array a `to_le_bytes`
+   writes into) — everywhere else in the call chain, pass the typed value.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -10,10 +10,11 @@
 > - **Issue [#138](https://github.com/Akvize/reconcile-rs/issues/138)** — execution tracking of the
 >   architecture migration (one sub-issue per phase).
 
-- **Last updated:** 2026-06-09
-- **Baseline:** `master` @ `6462970` (steps 1+3, `Hlc`→`Timestamp` + `hlc`→`clock` renames); step 2 on
-  `claude/repo-cleanup-status-bcyjez`
-- **Manifest:** `0.0.0-git` (unpublished; API and wire/on-disk formats may still change)
+- **Last updated:** 2026-06-12
+- **Baseline:** `claude/determined-franklin-s3tvt1` @ `f1423ce` (2026-06 correctness sprint; pending
+  merge to master)
+- **Manifest:** `0.2.1` (unpublished; semver and publish policy tracked in
+  [#204](https://github.com/Akvize/reconcile-rs/issues/204))
 
 ---
 
@@ -24,8 +25,17 @@ The **algorithmic core** (HRTree + range fingerprint + RBSR diff) is correct and
 fixed: the crate now has a collision-resistant 256-bit fingerprint, HLC-keyed conflict resolution,
 causal-stability tombstone GC, malformed-packet hardening, optional per-datagram authentication and
 payload encryption, pluggable persistence, runtime observability, and a lightweight dateless
-read-only mirror. Remaining work is **maturity, scaling, and the confidentiality roadmap** — no
-known correctness hazard is open.
+read-only mirror. A 2026-06 adversarial audit filed implementation-level correctness bugs as
+[#195](https://github.com/Akvize/reconcile-rs/issues/195)–[#205](https://github.com/Akvize/reconcile-rs/issues/205)
+(tracking [#206](https://github.com/Akvize/reconcile-rs/issues/206)); the Phase-0 correctness
+findings ([#195](https://github.com/Akvize/reconcile-rs/issues/195),
+[#196](https://github.com/Akvize/reconcile-rs/issues/196),
+[#197](https://github.com/Akvize/reconcile-rs/issues/197),
+[#198](https://github.com/Akvize/reconcile-rs/issues/198)) plus
+[#148](https://github.com/Akvize/reconcile-rs/issues/148) are **fixed on this branch**; remaining
+audit findings ([#199](https://github.com/Akvize/reconcile-rs/issues/199)–[#205](https://github.com/Akvize/reconcile-rs/issues/205))
+are **security/robustness-grade**, scheduled per [#206](https://github.com/Akvize/reconcile-rs/issues/206).
+Remaining work is **maturity, scaling, and the confidentiality roadmap**.
 
 ---
 
@@ -48,16 +58,16 @@ Status of every finding (`Fxx`) from the original code audit (commit `64f1ebf`).
 | F10 | High | IP-scan discovery, O(N²) membership | ◐ | [#147](https://github.com/Akvize/reconcile-rs/issues/147) — `Discovery` port + `DnsDiscovery` (k8s headless-Service DNS, no IP-scan) lands a cloud-native discovery path; bounded-fan-out membership (SWIM/HyParView) still open |
 | F11 | High | no property-testing / fuzzing | ✅ | #113 — `tests/proptest_hrtree.rs`, `tests/fuzz_packets.rs` |
 | F12 | Medium | debug `println!` in the hot path | ✅ | #113 — removed |
-| F13 | Medium | panic-only API (no `Result`) | ◯ | [#148](https://github.com/Akvize/reconcile-rs/issues/148) — `new`/`run` still return `Self`/`()`; `unwrap` on bind/send |
-| F14 | Medium | `pre_insert` hook under the write-lock (net path) | ◯ | [#149](https://github.com/Akvize/reconcile-rs/issues/149) — hook runs under the lock on the network path |
+| F13 | Medium | panic-only API (no `Result`) | ✅ | [#148](https://github.com/Akvize/reconcile-rs/issues/148) — fallible `new` constructors (`io::Result`, `AddrInUse` surfaces); no network send can panic the run loops (`f1423ce`, this branch) |
+| F14 | Medium | `pre_insert` hook under the write-lock (net path) | ✅ | [#149](https://github.com/Akvize/reconcile-rs/issues/149) — `pre_insert` runs outside the write lock on both paths, with a regression test (`f4b5028`) |
 | F15 | Medium | no persistence | ✅ | #122 — pluggable `Persistence` (`InMemory`, `FileSnapshot`) |
 | F16 | Medium | loopback benches + README inconsistency | ◐ | README updated; benches still loopback-only |
 | F17 | Medium/Low | maturity signals | ◐ | clippy fixed; see §3 checklist |
-| F18 | Medium | resource exhaustion (`peers` map, bincode bomb) | ◯ | [#150](https://github.com/Akvize/reconcile-rs/issues/150) — unbounded `peers`; no bincode allocation limit |
-| F19 | Low | dependency hygiene | ◯ | [#151](https://github.com/Akvize/reconcile-rs/issues/151) — `overflow-checks` off; bincode `with_limit`; `cargo audit` |
+| F18 | Medium | resource exhaustion (`peers` map, bincode bomb) | ◐ | bincode decode limit landed ([#151](https://github.com/Akvize/reconcile-rs/issues/151)); [#150](https://github.com/Akvize/reconcile-rs/issues/150) rescoped to the `peers` cap (unauthenticated mode) + per-datagram message/segment caps; related growth vectors in [#200](https://github.com/Akvize/reconcile-rs/issues/200) |
+| F19 | Low | dependency hygiene | ◐ | bincode `with_limit` landed ([#151](https://github.com/Akvize/reconcile-rs/issues/151)); `overflow-checks` and `cargo audit`/`cargo deny` in CI still open ([#203](https://github.com/Akvize/reconcile-rs/issues/203), [#205](https://github.com/Akvize/reconcile-rs/issues/205)) |
 
-**Score:** 11 resolved · 4 partial (F9, F10, F16, F17) · 4 open (F13, F14, F18, F19). All Critical
-resolved; all but one High resolved or mitigated.
+**Score:** 13 resolved · 6 partial (F9, F10, F16, F17, F18, F19) · 0 open. All Critical resolved;
+all but one High resolved or mitigated.
 
 ---
 
@@ -68,12 +78,11 @@ resolved; all but one High resolved or mitigated.
 - [x] Malformed-packet fuzz harness (`fuzz_packets.rs`)
 - [x] Security model documented (README "Security model")
 - [x] Pluggable persistence documented (README "Persistence")
-- [ ] Real semantic version (still `0.0.0-git`)
-- [ ] Declared MSRV (`rust-version`)
+- [ ] Semver and publish policy — `0.2.1` exists but policy is not yet settled ([#204](https://github.com/Akvize/reconcile-rs/issues/204))
 - [ ] `CHANGELOG.md`
 - [x] CI code coverage + doc-tests ([#97](https://github.com/Akvize/reconcile-rs/issues/97)) — Codecov (`cargo llvm-cov`) + `cargo test --doc` in CI
 - [ ] `cargo audit` / `cargo deny` in CI ([#151](https://github.com/Akvize/reconcile-rs/issues/151))
-- [ ] miri job for the `unsafe` iterators
+- [ ] Declare + CI-pin MSRV (`rust-version`) — iterators are safe Rust (crate is `#![forbid(unsafe_code)]`); miri item dropped ([#189](https://github.com/Akvize/reconcile-rs/issues/189))
 - [ ] `overflow-checks = true` in the release profile ([#151](https://github.com/Akvize/reconcile-rs/issues/151))
 - [ ] bincode decode limit (`with_limit`) against allocation bombs ([#150](https://github.com/Akvize/reconcile-rs/issues/150), [#151](https://github.com/Akvize/reconcile-rs/issues/151))
 
@@ -106,9 +115,29 @@ resolved; all but one High resolved or mitigated.
 ### Remaining gaps to SOTA (see [`SOTA.md`](./SOTA.md) §2.4)
 - Reconciliation latency: RBSR uses O(log n) sequential RTTs; a Rateless-IBLT pass to drain
   divergent leaves in one shot would cut WAN latency. Design choice, not a defect.
-- API ergonomics: `Result`-returning `new`/`run` (F13 — [#148](https://github.com/Akvize/reconcile-rs/issues/148));
-  `pre_insert` under the write-lock on the net path (F14 — [#149](https://github.com/Akvize/reconcile-rs/issues/149));
+- API ergonomics: `Result`-returning constructors ✅ (F13 — [#148](https://github.com/Akvize/reconcile-rs/issues/148), `f1423ce`);
+  `pre_insert` outside the write-lock ✅ (F14 — [#149](https://github.com/Akvize/reconcile-rs/issues/149), `f4b5028`);
   post-insert hooks ([#79](https://github.com/Akvize/reconcile-rs/issues/79)).
+
+### 2026-06 adversarial audit
+
+Five independent adversarial audits challenged the codebase and all open issues; findings were
+filed as [#195](https://github.com/Akvize/reconcile-rs/issues/195)–[#205](https://github.com/Akvize/reconcile-rs/issues/205)
+with roadmap and tracking in
+[#206](https://github.com/Akvize/reconcile-rs/issues/206). The Phase-0 correctness items —
+HLC restart monotonicity ([#195](https://github.com/Akvize/reconcile-rs/issues/195)), `TimeoutWheel`
+same-millisecond expiry collision ([#196](https://github.com/Akvize/reconcile-rs/issues/196)),
+fingerprint-desyncing mutable iterators ([#197](https://github.com/Akvize/reconcile-rs/issues/197)),
+and HLC far-future stamp / counter wrap ([#198](https://github.com/Akvize/reconcile-rs/issues/198))
+— are fixed on this branch; the remainder
+([#199](https://github.com/Akvize/reconcile-rs/issues/199) replay/membership poisoning,
+[#200](https://github.com/Akvize/reconcile-rs/issues/200) unbounded acks/bulk dumps,
+[#201](https://github.com/Akvize/reconcile-rs/issues/201) DNS decommission vs GC gate,
+[#202](https://github.com/Akvize/reconcile-rs/issues/202) persistence robustness,
+[#203](https://github.com/Akvize/reconcile-rs/issues/203) CI gaps,
+[#204](https://github.com/Akvize/reconcile-rs/issues/204) release pipeline/version drift,
+[#205](https://github.com/Akvize/reconcile-rs/issues/205) hygiene batch) are security/robustness-grade
+and scheduled per [#206](https://github.com/Akvize/reconcile-rs/issues/206).
 
 ### Architecture refactor
 Tracked in [`ARCHITECTURE.md`](./ARCHITECTURE.md) and issue

--- a/SOTA.md
+++ b/SOTA.md
@@ -418,7 +418,7 @@ surrounding system.
 |---|---|
 | **MSRV** (*Minimum Supported Rust Version*) | The minimum supported Rust version; absent from `Cargo.toml` (F17). |
 | **clippy / `-Dwarnings`** | The Rust linter; CI treating warnings as errors. The `mismatched_lifetime_syntaxes` warning (`hrtree_iter.rs:177`) would break CI (F17). |
-| **miri** | An interpreter detecting UB (*Undefined Behavior*); relevant given the `unsafe` iterators; absent from CI (F17). |
+| **miri** | An interpreter detecting UB (*Undefined Behavior*); not applicable here — the crate is `#![forbid(unsafe_code)]` and all iterators are safe Rust (since `d030c15`). The CI gap for F17 is now the undeclared MSRV ([#189](https://github.com/Akvize/reconcile-rs/issues/189)). |
 | **proptest / quickcheck / fuzzing** | Property-based / generative / random-input testing. **Entirely absent** (F11). |
 | **`cargo audit` / `cargo deny`** | Vulnerability audit / dependency policies. Absent from CI (F19). |
 | **bincode / serde / tokio / parking_lot / arrayvec / ipnet / range-cmp / chrono / rand / once_cell / tracing** | Dependencies: binary serialization; (de)serialization; async runtime; non-poisoning locks; `ArrayVec` (inline vector, B-tree nodes); network/CIDR types; key↔range comparison (`RangeOrdering`); `DateTime<Utc>` (LWW timestamps); randomness; lazy init; structured logs. |

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -13,14 +13,29 @@
 //! crate-level "Security model" documentation). To close that vector, when a cluster key is
 //! configured (see
 //! [`Config::with_cluster_key`](crate::reconcile_store::Config::with_cluster_key)), every outgoing
-//! datagram is framed as `tag || payload` where `tag` is a keyed MAC over `payload`, and every
-//! incoming datagram is verified **before** any deserialization.
+//! datagram is framed as `tag || replay_header || payload` where `tag` is a keyed MAC over
+//! `replay_header || payload`, and every incoming datagram is verified **before** any
+//! deserialization.
+//!
+//! The `replay_header` is a 16-byte prefix (`seq || stamp`, each a little-endian `u64`) that is
+//! authenticated together with the payload. It provides the data the receiver needs for
+//! replay-protection checks (see [`crate::replay`]).
 //!
 //! With the `encryption` feature and
 //! [`Config::with_encryption`](crate::reconcile_store::Config::with_encryption), this keyed mode is
 //! upgraded from authentication-only to **authenticated encryption**: each datagram is framed as
 //! `nonce || ciphertext || tag` using XChaCha20-Poly1305 over the same cluster key, adding
-//! confidentiality on top of the integrity and authenticity the MAC already provides.
+//! confidentiality on top of the integrity and authenticity the MAC already provides. The replay
+//! header is part of the plaintext that is encrypted.
+//!
+//! # Wire layout (authenticated modes)
+//!
+//! MAC mode: `tag (32 B) || seq (8 B LE) || stamp (8 B LE) || protocol_messages`
+//!
+//! Encryption mode: `nonce (24 B) || encrypt(seq (8 B LE) || stamp (8 B LE) || protocol_messages) || tag (16 B)`
+//!
+//! The replay header is inside the authenticated / encrypted region in both cases, so it cannot be
+//! tampered with by an observer.
 //!
 //! # Design
 //!
@@ -39,6 +54,8 @@
 //!   impossible to deserialize bytes that have not cleared the authentication gate.
 
 use std::borrow::Cow;
+
+use crate::replay::REPLAY_HEADER_LEN;
 
 /// Length in bytes of the authentication tag prepended to every datagram.
 pub(crate) const TAG_LEN: usize = 32;
@@ -96,15 +113,45 @@ impl Tag {
 /// The rest of the engine can only obtain one through [`Authenticator::open`], so message handling
 /// cannot, by construction, run on bytes that were not cleared first ("parse, don't validate").
 ///
+/// In authenticated modes the payload also carries the `seq` and `stamp` extracted from the
+/// replay header; in unauthenticated mode both are zero (replay protection is disabled).
+///
 /// The bytes are borrowed from the receive buffer in the MAC and unauthenticated modes (zero-copy),
 /// and owned in the encrypted mode where decryption produces a fresh plaintext buffer; [`Cow`]
 /// captures both without forcing an allocation on the common path.
-pub(crate) struct Payload<'a>(Cow<'a, [u8]>);
+pub(crate) struct Payload<'a> {
+    bytes: Cow<'a, [u8]>,
+    /// Sender sequence number extracted from the replay header, or 0 in unauthenticated mode.
+    pub(crate) seq: u64,
+    /// Sender wall-clock stamp (ms since epoch) from the replay header, or 0 in unauthenticated
+    /// mode.
+    pub(crate) stamp: u64,
+}
 
 impl Payload<'_> {
     pub(crate) fn as_bytes(&self) -> &[u8] {
-        &self.0
+        &self.bytes
     }
+}
+
+/// Build a replay header: `seq (8 bytes LE) || stamp (8 bytes LE)`.
+fn encode_replay_header(seq: u64, stamp: u64) -> [u8; REPLAY_HEADER_LEN] {
+    let mut header = [0u8; REPLAY_HEADER_LEN];
+    header[..8].copy_from_slice(&seq.to_le_bytes());
+    header[8..].copy_from_slice(&stamp.to_le_bytes());
+    header
+}
+
+/// Parse a replay header from the front of a byte slice.
+///
+/// Returns `(seq, stamp, rest)` or `None` if the slice is shorter than the header.
+fn decode_replay_header(data: &[u8]) -> Option<(u64, u64, &[u8])> {
+    if data.len() < REPLAY_HEADER_LEN {
+        return None;
+    }
+    let seq = u64::from_le_bytes(data[..8].try_into().unwrap());
+    let stamp = u64::from_le_bytes(data[8..16].try_into().unwrap());
+    Some((seq, stamp, &data[REPLAY_HEADER_LEN..]))
 }
 
 /// The keyed MAC primitive used to authenticate datagrams.
@@ -229,60 +276,97 @@ impl Authenticator {
         }
     }
 
-    /// Number of extra bytes a sealed datagram adds, for MTU/buffer accounting.
+    /// Number of extra bytes a sealed datagram adds over the raw protocol messages, for
+    /// MTU/buffer accounting.
+    ///
+    /// In authenticated modes this includes both the cryptographic overhead (tag / nonce+tag) and
+    /// the 16-byte replay header.
     pub(crate) fn overhead(&self) -> usize {
         match self {
             Authenticator::Disabled => 0,
-            Authenticator::Enabled(_) => TAG_LEN,
+            Authenticator::Enabled(_) => TAG_LEN + REPLAY_HEADER_LEN,
             #[cfg(feature = "encryption")]
-            Authenticator::Encrypted(_) => AEAD_NONCE_LEN + AEAD_TAG_LEN,
+            Authenticator::Encrypted(_) => AEAD_NONCE_LEN + REPLAY_HEADER_LEN + AEAD_TAG_LEN,
         }
     }
 
-    /// Frame an outgoing datagram.
+    /// Frame an outgoing datagram, injecting the replay header.
     ///
-    /// - `Enabled`: `tag(payload) || payload`.
-    /// - `Encrypted`: `nonce || ciphertext || tag` (the payload is never sent in the clear).
+    /// - `Enabled`: `tag(replay_header || payload) || replay_header || payload`.
+    /// - `Encrypted`: `nonce || ciphertext(replay_header || payload) || tag`.
     ///
     /// Returns `Some(framed)` when enabled/encrypted, or `None` when disabled (the caller then
     /// sends `payload` unchanged, byte-for-byte identical to the unauthenticated protocol).
-    pub(crate) fn seal(&self, payload: &[u8]) -> Option<Vec<u8>> {
+    pub(crate) fn seal(&self, seq: u64, stamp: u64, payload: &[u8]) -> Option<Vec<u8>> {
         match self {
             Authenticator::Disabled => None,
             Authenticator::Enabled(key) => {
-                let tag = ClusterMac::tag(key, payload);
-                let mut framed = Vec::with_capacity(TAG_LEN + payload.len());
+                let header = encode_replay_header(seq, stamp);
+                // Authenticated region: replay_header || payload
+                let mut protected = Vec::with_capacity(REPLAY_HEADER_LEN + payload.len());
+                protected.extend_from_slice(&header);
+                protected.extend_from_slice(payload);
+                let tag = ClusterMac::tag(key, &protected);
+                // Wire: tag || replay_header || payload
+                let mut framed = Vec::with_capacity(TAG_LEN + protected.len());
                 framed.extend_from_slice(tag.as_bytes());
-                framed.extend_from_slice(payload);
+                framed.extend_from_slice(&protected);
                 Some(framed)
             }
             #[cfg(feature = "encryption")]
-            Authenticator::Encrypted(key) => Some(encryption::seal(key, payload)),
+            Authenticator::Encrypted(key) => {
+                let header = encode_replay_header(seq, stamp);
+                // Plaintext = replay_header || payload; both are encrypted and authenticated.
+                let mut plaintext = Vec::with_capacity(REPLAY_HEADER_LEN + payload.len());
+                plaintext.extend_from_slice(&header);
+                plaintext.extend_from_slice(payload);
+                Some(encryption::seal(key, &plaintext))
+            }
         }
     }
 
     /// Authenticate (and, in encrypted mode, decrypt) an incoming datagram, returning the
     /// [`Payload`] cleared for processing.
     ///
-    /// - `Enabled`: the datagram must be `tag || payload` with a valid tag.
-    /// - `Encrypted`: the datagram must be `nonce || ciphertext || tag` that decrypts under the
-    ///   cluster key.
+    /// In authenticated modes the returned [`Payload`] also carries the `seq` and `stamp` values
+    /// extracted from the replay header; the caller must perform the replay check before processing
+    /// the messages. In unauthenticated mode both fields are zero.
     ///
-    /// On any failure (too short, invalid tag, decryption error) `None` is returned and the caller
-    /// drops it silently. When disabled, the whole datagram is returned as the payload.
+    /// On any failure (too short, invalid tag, decryption error, missing replay header) `None` is
+    /// returned and the caller drops it silently.
     pub(crate) fn open<'a>(&self, datagram: &'a [u8]) -> Option<Payload<'a>> {
         match self {
-            Authenticator::Disabled => Some(Payload(Cow::Borrowed(datagram))),
+            Authenticator::Disabled => Some(Payload {
+                bytes: Cow::Borrowed(datagram),
+                seq: 0,
+                stamp: 0,
+            }),
             Authenticator::Enabled(key) => {
-                if datagram.len() < TAG_LEN {
+                if datagram.len() < TAG_LEN + REPLAY_HEADER_LEN {
                     return None;
                 }
-                let (tag, payload) = datagram.split_at(TAG_LEN);
-                ClusterMac::verify(key, payload, tag).then_some(Payload(Cow::Borrowed(payload)))
+                let (tag, protected) = datagram.split_at(TAG_LEN);
+                if !ClusterMac::verify(key, protected, tag) {
+                    return None;
+                }
+                // Strip the replay header from the front of the authenticated region.
+                let (seq, stamp, messages) = decode_replay_header(protected)?;
+                Some(Payload {
+                    bytes: Cow::Borrowed(messages),
+                    seq,
+                    stamp,
+                })
             }
             #[cfg(feature = "encryption")]
             Authenticator::Encrypted(key) => {
-                encryption::open(key, datagram).map(|plaintext| Payload(Cow::Owned(plaintext)))
+                let plaintext = encryption::open(key, datagram)?;
+                // The plaintext starts with the replay header.
+                let (seq, stamp, messages) = decode_replay_header(&plaintext)?;
+                Some(Payload {
+                    bytes: Cow::Owned(messages.to_vec()),
+                    seq,
+                    stamp,
+                })
             }
         }
     }
@@ -333,6 +417,7 @@ mod encryption {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::replay::REPLAY_HEADER_LEN;
 
     fn key(byte: u8) -> ClusterKey {
         ClusterKey::new([byte; KEY_LEN])
@@ -372,18 +457,20 @@ mod tests {
     fn seal_open_roundtrip() {
         let auth = Authenticator::new(Some([0x11; KEY_LEN]), false);
         let payload = b"some serialized message";
-        let sealed = auth.seal(payload).expect("enabled");
-        assert_eq!(sealed.len(), TAG_LEN + payload.len());
-        assert_eq!(
-            auth.open(&sealed).map(|p| p.as_bytes().to_vec()),
-            Some(payload.to_vec())
-        );
+        let sealed = auth.seal(1, 12345, payload).expect("enabled");
+        // MAC overhead + replay header + payload
+        assert_eq!(sealed.len(), TAG_LEN + REPLAY_HEADER_LEN + payload.len());
+        let p = auth.open(&sealed).expect("should open");
+        assert_eq!(p.as_bytes(), payload);
+        assert_eq!(p.seq, 1);
+        assert_eq!(p.stamp, 12345);
     }
 
     #[test]
     fn open_too_short() {
         let auth = Authenticator::new(Some([0x11; KEY_LEN]), false);
-        // Fewer than TAG_LEN bytes can never carry a valid tag.
+        // Fewer than TAG_LEN + REPLAY_HEADER_LEN bytes can never carry a valid datagram.
+        assert!(auth.open(&[0u8; TAG_LEN + REPLAY_HEADER_LEN - 1]).is_none());
         assert!(auth.open(&[0u8; 10]).is_none());
         assert!(auth.open(&[]).is_none());
     }
@@ -391,7 +478,7 @@ mod tests {
     #[test]
     fn open_wrong_key() {
         let sealed = Authenticator::new(Some([0x11; KEY_LEN]), false)
-            .seal(b"payload")
+            .seal(1, 99, b"payload")
             .expect("enabled");
         assert!(Authenticator::new(Some([0x22; KEY_LEN]), false)
             .open(&sealed)
@@ -404,12 +491,27 @@ mod tests {
         assert!(!auth.is_enabled());
         assert!(!auth.is_encrypted());
         assert_eq!(auth.overhead(), 0);
-        assert!(auth.seal(b"payload").is_none());
-        // Any datagram clears the gate unchanged in unauthenticated mode.
-        assert_eq!(
-            auth.open(b"raw bytes").map(|p| p.as_bytes().to_vec()),
-            Some(b"raw bytes".to_vec())
-        );
+        assert!(auth.seal(0, 0, b"payload").is_none());
+        // Any datagram clears the gate unchanged in unauthenticated mode; seq/stamp are 0.
+        let p = auth
+            .open(b"raw bytes")
+            .expect("unauthenticated always clears");
+        assert_eq!(p.as_bytes(), b"raw bytes");
+        assert_eq!(p.seq, 0);
+        assert_eq!(p.stamp, 0);
+    }
+
+    /// Replay: the same sealed datagram must be accepted by `open` (the auth gate does not do
+    /// replay checks), but the payload carries the seq/stamp so the caller can do them.
+    #[test]
+    fn replay_header_round_trips_seq_and_stamp() {
+        let auth = Authenticator::new(Some([0xAB; KEY_LEN]), false);
+        let payload = b"hello";
+        let sealed = auth.seal(42, 9999, payload).expect("enabled");
+        let p = auth.open(&sealed).expect("valid tag");
+        assert_eq!(p.seq, 42);
+        assert_eq!(p.stamp, 9999);
+        assert_eq!(p.as_bytes(), payload);
     }
 
     #[cfg(feature = "encryption")]
@@ -425,21 +527,28 @@ mod tests {
             let auth = encryptor(0x11);
             assert!(auth.is_enabled());
             assert!(auth.is_encrypted());
-            assert_eq!(auth.overhead(), AEAD_NONCE_LEN + AEAD_TAG_LEN);
+            assert_eq!(
+                auth.overhead(),
+                super::AEAD_NONCE_LEN + REPLAY_HEADER_LEN + super::AEAD_TAG_LEN
+            );
 
             let payload = b"some serialized message";
-            let sealed = auth.seal(payload).expect("encrypted");
-            assert_eq!(sealed.len(), AEAD_NONCE_LEN + payload.len() + AEAD_TAG_LEN);
+            let sealed = auth.seal(1, 555, payload).expect("encrypted");
+            // nonce + replay_header + payload + AEAD tag
             assert_eq!(
-                auth.open(&sealed).map(|p| p.as_bytes().to_vec()),
-                Some(payload.to_vec())
+                sealed.len(),
+                super::AEAD_NONCE_LEN + REPLAY_HEADER_LEN + payload.len() + super::AEAD_TAG_LEN
             );
+            let p = auth.open(&sealed).expect("should decrypt");
+            assert_eq!(p.as_bytes(), payload);
+            assert_eq!(p.seq, 1);
+            assert_eq!(p.stamp, 555);
         }
 
         #[test]
         fn ciphertext_hides_plaintext() {
             let payload = b"the quick brown fox jumps over the lazy dog";
-            let sealed = encryptor(0x11).seal(payload).expect("encrypted");
+            let sealed = encryptor(0x11).seal(1, 0, payload).expect("encrypted");
             // The plaintext must not appear anywhere in the framed datagram.
             assert!(!sealed
                 .windows(payload.len())
@@ -453,15 +562,15 @@ mod tests {
             let auth = encryptor(0x11);
             let payload = b"identical payload";
             assert_ne!(
-                auth.seal(payload).expect("encrypted"),
-                auth.seal(payload).expect("encrypted")
+                auth.seal(1, 0, payload).expect("encrypted"),
+                auth.seal(2, 0, payload).expect("encrypted")
             );
         }
 
         #[test]
         fn tamper_is_rejected() {
             let auth = encryptor(0x11);
-            let mut sealed = auth.seal(b"payload").expect("encrypted");
+            let mut sealed = auth.seal(1, 0, b"payload").expect("encrypted");
             // Flip a ciphertext byte (past the nonce): authentication must fail.
             let last = sealed.len() - 1;
             sealed[last] ^= 0x01;
@@ -470,18 +579,28 @@ mod tests {
 
         #[test]
         fn wrong_key_is_rejected() {
-            let sealed = encryptor(0x11).seal(b"payload").expect("encrypted");
+            let sealed = encryptor(0x11).seal(1, 0, b"payload").expect("encrypted");
             assert!(encryptor(0x22).open(&sealed).is_none());
         }
 
         #[test]
         fn truncated_is_rejected() {
             let auth = encryptor(0x11);
-            // Shorter than nonce + tag can never carry a valid datagram.
+            // Shorter than nonce + replay_header + tag can never carry a valid datagram.
             assert!(auth
-                .open(&[0u8; AEAD_NONCE_LEN + AEAD_TAG_LEN - 1])
+                .open(&[0u8; super::AEAD_NONCE_LEN + REPLAY_HEADER_LEN + super::AEAD_TAG_LEN - 1])
                 .is_none());
             assert!(auth.open(&[]).is_none());
+        }
+
+        #[test]
+        fn replay_header_survives_encryption() {
+            let auth = encryptor(0x33);
+            let sealed = auth.seal(77, 888888, b"data").expect("encrypted");
+            let p = auth.open(&sealed).expect("should decrypt");
+            assert_eq!(p.seq, 77);
+            assert_eq!(p.stamp, 888888);
+            assert_eq!(p.as_bytes(), b"data");
         }
     }
 }

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -8,25 +8,18 @@
 
 //! Per-datagram message authentication for the reconciliation protocol.
 //!
-//! The UDP protocol performs no authentication by itself: any host that can send a datagram to the
-//! port can forge an update and poison the whole cluster through last-write-wins (see the
-//! crate-level "Security model" documentation). To close that vector, when a cluster key is
-//! configured (see
-//! [`Config::with_cluster_key`](crate::reconcile_store::Config::with_cluster_key)), every outgoing
-//! datagram is framed as `tag || replay_header || payload` where `tag` is a keyed MAC over
-//! `replay_header || payload`, and every incoming datagram is verified **before** any
-//! deserialization.
-//!
-//! The `replay_header` is a 16-byte prefix (`seq || stamp`, each a little-endian `u64`) that is
-//! authenticated together with the payload. It provides the data the receiver needs for
-//! replay-protection checks (see [`crate::replay`]).
+//! Without a cluster key, any host that can reach the port can forge an update and poison the
+//! cluster via last-write-wins (see the crate-level "Security model" docs). With
+//! [`Config::with_cluster_key`](crate::reconcile_store::Config::with_cluster_key), every outgoing
+//! datagram is framed as `tag || replay_header || payload`, `tag` a keyed MAC over
+//! `replay_header || payload`; incoming datagrams are verified before any deserialization. The
+//! 16-byte `replay_header` (`seq || stamp`, both little-endian `u64`) feeds the checks in
+//! [`crate::replay`].
 //!
 //! With the `encryption` feature and
-//! [`Config::with_encryption`](crate::reconcile_store::Config::with_encryption), this keyed mode is
-//! upgraded from authentication-only to **authenticated encryption**: each datagram is framed as
-//! `nonce || ciphertext || tag` using XChaCha20-Poly1305 over the same cluster key, adding
-//! confidentiality on top of the integrity and authenticity the MAC already provides. The replay
-//! header is part of the plaintext that is encrypted.
+//! [`Config::with_encryption`](crate::reconcile_store::Config::with_encryption), the same keyed
+//! mode upgrades to authenticated encryption: `nonce || ciphertext || tag` via XChaCha20-Poly1305,
+//! the replay header encrypted along with the payload.
 //!
 //! # Wire layout (authenticated modes)
 //!

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -48,7 +48,7 @@
 
 use std::borrow::Cow;
 
-use crate::replay::REPLAY_HEADER_LEN;
+use crate::replay::{Seq, Stamp, REPLAY_HEADER_LEN};
 
 /// Length in bytes of the authentication tag prepended to every datagram.
 pub(crate) const TAG_LEN: usize = 32;
@@ -114,11 +114,12 @@ impl Tag {
 /// captures both without forcing an allocation on the common path.
 pub(crate) struct Payload<'a> {
     bytes: Cow<'a, [u8]>,
-    /// Sender sequence number extracted from the replay header, or 0 in unauthenticated mode.
-    pub(crate) seq: u64,
-    /// Sender wall-clock stamp (ms since epoch) from the replay header, or 0 in unauthenticated
+    /// Sender sequence number extracted from the replay header, or [`Seq::NONE`] in
+    /// unauthenticated mode.
+    pub(crate) seq: Seq,
+    /// Sender wall-clock stamp from the replay header, or [`Stamp::NONE`] in unauthenticated
     /// mode.
-    pub(crate) stamp: u64,
+    pub(crate) stamp: Stamp,
 }
 
 impl Payload<'_> {
@@ -128,7 +129,7 @@ impl Payload<'_> {
 }
 
 /// Build a replay header: `seq (8 bytes LE) || stamp (8 bytes LE)`.
-fn encode_replay_header(seq: u64, stamp: u64) -> [u8; REPLAY_HEADER_LEN] {
+fn encode_replay_header(seq: Seq, stamp: Stamp) -> [u8; REPLAY_HEADER_LEN] {
     let mut header = [0u8; REPLAY_HEADER_LEN];
     header[..8].copy_from_slice(&seq.to_le_bytes());
     header[8..].copy_from_slice(&stamp.to_le_bytes());
@@ -138,12 +139,12 @@ fn encode_replay_header(seq: u64, stamp: u64) -> [u8; REPLAY_HEADER_LEN] {
 /// Parse a replay header from the front of a byte slice.
 ///
 /// Returns `(seq, stamp, rest)` or `None` if the slice is shorter than the header.
-fn decode_replay_header(data: &[u8]) -> Option<(u64, u64, &[u8])> {
+fn decode_replay_header(data: &[u8]) -> Option<(Seq, Stamp, &[u8])> {
     if data.len() < REPLAY_HEADER_LEN {
         return None;
     }
-    let seq = u64::from_le_bytes(data[..8].try_into().unwrap());
-    let stamp = u64::from_le_bytes(data[8..16].try_into().unwrap());
+    let seq = Seq::from_le_bytes(data[..8].try_into().unwrap());
+    let stamp = Stamp::from_le_bytes(data[8..16].try_into().unwrap());
     Some((seq, stamp, &data[REPLAY_HEADER_LEN..]))
 }
 
@@ -290,7 +291,7 @@ impl Authenticator {
     ///
     /// Returns `Some(framed)` when enabled/encrypted, or `None` when disabled (the caller then
     /// sends `payload` unchanged, byte-for-byte identical to the unauthenticated protocol).
-    pub(crate) fn seal(&self, seq: u64, stamp: u64, payload: &[u8]) -> Option<Vec<u8>> {
+    pub(crate) fn seal(&self, seq: Seq, stamp: Stamp, payload: &[u8]) -> Option<Vec<u8>> {
         match self {
             Authenticator::Disabled => None,
             Authenticator::Enabled(key) => {
@@ -331,8 +332,8 @@ impl Authenticator {
         match self {
             Authenticator::Disabled => Some(Payload {
                 bytes: Cow::Borrowed(datagram),
-                seq: 0,
-                stamp: 0,
+                seq: Seq::NONE,
+                stamp: Stamp::NONE,
             }),
             Authenticator::Enabled(key) => {
                 if datagram.len() < TAG_LEN + REPLAY_HEADER_LEN {
@@ -450,13 +451,15 @@ mod tests {
     fn seal_open_roundtrip() {
         let auth = Authenticator::new(Some([0x11; KEY_LEN]), false);
         let payload = b"some serialized message";
-        let sealed = auth.seal(1, 12345, payload).expect("enabled");
+        let sealed = auth
+            .seal(Seq::new(1), Stamp::new(12345), payload)
+            .expect("enabled");
         // MAC overhead + replay header + payload
         assert_eq!(sealed.len(), TAG_LEN + REPLAY_HEADER_LEN + payload.len());
         let p = auth.open(&sealed).expect("should open");
         assert_eq!(p.as_bytes(), payload);
-        assert_eq!(p.seq, 1);
-        assert_eq!(p.stamp, 12345);
+        assert_eq!(p.seq, Seq::new(1));
+        assert_eq!(p.stamp, Stamp::new(12345));
     }
 
     #[test]
@@ -471,7 +474,7 @@ mod tests {
     #[test]
     fn open_wrong_key() {
         let sealed = Authenticator::new(Some([0x11; KEY_LEN]), false)
-            .seal(1, 99, b"payload")
+            .seal(Seq::new(1), Stamp::new(99), b"payload")
             .expect("enabled");
         assert!(Authenticator::new(Some([0x22; KEY_LEN]), false)
             .open(&sealed)
@@ -484,14 +487,14 @@ mod tests {
         assert!(!auth.is_enabled());
         assert!(!auth.is_encrypted());
         assert_eq!(auth.overhead(), 0);
-        assert!(auth.seal(0, 0, b"payload").is_none());
+        assert!(auth.seal(Seq::new(0), Stamp::new(0), b"payload").is_none());
         // Any datagram clears the gate unchanged in unauthenticated mode; seq/stamp are 0.
         let p = auth
             .open(b"raw bytes")
             .expect("unauthenticated always clears");
         assert_eq!(p.as_bytes(), b"raw bytes");
-        assert_eq!(p.seq, 0);
-        assert_eq!(p.stamp, 0);
+        assert_eq!(p.seq, Seq::new(0));
+        assert_eq!(p.stamp, Stamp::new(0));
     }
 
     /// Replay: the same sealed datagram must be accepted by `open` (the auth gate does not do
@@ -500,10 +503,12 @@ mod tests {
     fn replay_header_round_trips_seq_and_stamp() {
         let auth = Authenticator::new(Some([0xAB; KEY_LEN]), false);
         let payload = b"hello";
-        let sealed = auth.seal(42, 9999, payload).expect("enabled");
+        let sealed = auth
+            .seal(Seq::new(42), Stamp::new(9999), payload)
+            .expect("enabled");
         let p = auth.open(&sealed).expect("valid tag");
-        assert_eq!(p.seq, 42);
-        assert_eq!(p.stamp, 9999);
+        assert_eq!(p.seq, Seq::new(42));
+        assert_eq!(p.stamp, Stamp::new(9999));
         assert_eq!(p.as_bytes(), payload);
     }
 
@@ -526,7 +531,9 @@ mod tests {
             );
 
             let payload = b"some serialized message";
-            let sealed = auth.seal(1, 555, payload).expect("encrypted");
+            let sealed = auth
+                .seal(Seq::new(1), Stamp::new(555), payload)
+                .expect("encrypted");
             // nonce + replay_header + payload + AEAD tag
             assert_eq!(
                 sealed.len(),
@@ -534,14 +541,16 @@ mod tests {
             );
             let p = auth.open(&sealed).expect("should decrypt");
             assert_eq!(p.as_bytes(), payload);
-            assert_eq!(p.seq, 1);
-            assert_eq!(p.stamp, 555);
+            assert_eq!(p.seq, Seq::new(1));
+            assert_eq!(p.stamp, Stamp::new(555));
         }
 
         #[test]
         fn ciphertext_hides_plaintext() {
             let payload = b"the quick brown fox jumps over the lazy dog";
-            let sealed = encryptor(0x11).seal(1, 0, payload).expect("encrypted");
+            let sealed = encryptor(0x11)
+                .seal(Seq::new(1), Stamp::new(0), payload)
+                .expect("encrypted");
             // The plaintext must not appear anywhere in the framed datagram.
             assert!(!sealed
                 .windows(payload.len())
@@ -555,15 +564,19 @@ mod tests {
             let auth = encryptor(0x11);
             let payload = b"identical payload";
             assert_ne!(
-                auth.seal(1, 0, payload).expect("encrypted"),
-                auth.seal(2, 0, payload).expect("encrypted")
+                auth.seal(Seq::new(1), Stamp::new(0), payload)
+                    .expect("encrypted"),
+                auth.seal(Seq::new(2), Stamp::new(0), payload)
+                    .expect("encrypted")
             );
         }
 
         #[test]
         fn tamper_is_rejected() {
             let auth = encryptor(0x11);
-            let mut sealed = auth.seal(1, 0, b"payload").expect("encrypted");
+            let mut sealed = auth
+                .seal(Seq::new(1), Stamp::new(0), b"payload")
+                .expect("encrypted");
             // Flip a ciphertext byte (past the nonce): authentication must fail.
             let last = sealed.len() - 1;
             sealed[last] ^= 0x01;
@@ -572,7 +585,9 @@ mod tests {
 
         #[test]
         fn wrong_key_is_rejected() {
-            let sealed = encryptor(0x11).seal(1, 0, b"payload").expect("encrypted");
+            let sealed = encryptor(0x11)
+                .seal(Seq::new(1), Stamp::new(0), b"payload")
+                .expect("encrypted");
             assert!(encryptor(0x22).open(&sealed).is_none());
         }
 
@@ -589,10 +604,12 @@ mod tests {
         #[test]
         fn replay_header_survives_encryption() {
             let auth = encryptor(0x33);
-            let sealed = auth.seal(77, 888888, b"data").expect("encrypted");
+            let sealed = auth
+                .seal(Seq::new(77), Stamp::new(888888), b"data")
+                .expect("encrypted");
             let p = auth.open(&sealed).expect("should decrypt");
-            assert_eq!(p.seq, 77);
-            assert_eq!(p.stamp, 888888);
+            assert_eq!(p.seq, Seq::new(77));
+            assert_eq!(p.stamp, Stamp::new(888888));
             assert_eq!(p.as_bytes(), b"data");
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,12 +42,19 @@
 //! # Security model
 //!
 //! By default the UDP reconciliation protocol is **unauthenticated**: any host able to send a
-//! datagram to the port can forge an update and poison the whole cluster through last-write-wins.
-//! To prevent this, configure a shared cluster secret with
+//! datagram to the port can forge an update and poison the whole cluster through last-write-wins,
+//! and there is **no replay protection** — a captured datagram can be re-injected later to
+//! re-poison membership or re-deliver stale data. Unauthenticated mode is intentionally unprotected
+//! against both attacks; it is suitable only for fully trusted network underlays.
+//!
+//! To close the forgery and replay vectors, configure a shared cluster secret with
 //! [`Config::with_cluster_key`](reconcile_store::Config::with_cluster_key) on **every** node: this
-//! enables a per-datagram keyed MAC that is verified before deserialization, silently dropping
-//! unauthenticated or forged datagrams. See the README "Security model" section for the full
-//! threat model and scope.
+//! enables per-datagram MAC authentication and per-sender replay protection. Every datagram carries
+//! a monotonically increasing sequence number and a sender wall-clock stamp (both inside the
+//! authenticated region); the receiver maintains per-peer state and rejects duplicates, stale
+//! out-of-window sequences, and datagrams whose freshness stamp deviates from local physical time
+//! by more than the configured freshness window (default 5 minutes). See the README "Security
+//! model" section for the full threat model and scope.
 
 // The entire crate is implemented in safe Rust; this turns any `unsafe` block into a hard
 // compile error.
@@ -76,6 +83,7 @@ pub(crate) mod hrtree_iter;
 pub(crate) mod observability;
 pub(crate) mod proto;
 pub(crate) mod reconcile_engine;
+pub(crate) mod replay;
 pub(crate) mod timeout_wheel;
 
 pub use bounds::{Key, Value};
@@ -121,5 +129,33 @@ pub mod testing {
         R: std::ops::RangeBounds<K>,
     {
         tree.hash(range)
+    }
+
+    /// Seal a raw payload with the given 32-byte cluster key, sequence number, and wall-clock stamp
+    /// using MAC authentication (not encryption), producing the on-wire datagram bytes.
+    ///
+    /// Exposed so integration tests can craft legitimately-sealed datagrams and inject them via a
+    /// raw UDP socket to exercise the anti-replay pipeline end-to-end.  The output format matches
+    /// what the engine sends in authenticated (non-encrypted) mode:
+    /// `tag(32) || seq(8 LE) || stamp(8 LE) || payload`.
+    pub fn seal_datagram(key: [u8; 32], seq: u64, stamp: u64, payload: &[u8]) -> Vec<u8> {
+        crate::auth::Authenticator::new(Some(key), false)
+            .seal(seq, stamp, payload)
+            .expect("Enabled authenticator always seals")
+    }
+
+    /// Return the current membership set for integration-test assertions.
+    ///
+    /// Members are peers that have sent at least one dated, authenticated datagram and gate
+    /// tombstone garbage collection via causal stability. Exposed so integration tests can
+    /// assert that a decommissioned peer was not re-added to membership by a replayed datagram.
+    pub fn members_snapshot<K, V>(
+        store: &crate::ReconcileStore<K, V>,
+    ) -> std::collections::HashSet<std::net::IpAddr>
+    where
+        K: crate::bounds::Key,
+        V: crate::bounds::Value,
+    {
+        store.members_snapshot()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,13 +131,9 @@ pub mod testing {
         tree.hash(range)
     }
 
-    /// Seal a raw payload with the given 32-byte cluster key, sequence number, and wall-clock stamp
-    /// using MAC authentication (not encryption), producing the on-wire datagram bytes.
-    ///
-    /// Exposed so integration tests can craft legitimately-sealed datagrams and inject them via a
-    /// raw UDP socket to exercise the anti-replay pipeline end-to-end.  The output format matches
-    /// what the engine sends in authenticated (non-encrypted) mode:
-    /// `tag(32) || seq(8 LE) || stamp(8 LE) || payload`.
+    /// Seal `payload` with MAC authentication (not encryption): `tag(32) || seq(8 LE) || stamp(8
+    /// LE) || payload`. Lets integration tests craft legitimate datagrams to exercise the
+    /// anti-replay pipeline over a raw UDP socket.
     pub fn seal_datagram(key: [u8; 32], seq: u64, stamp: u64, payload: &[u8]) -> Vec<u8> {
         crate::auth::Authenticator::new(Some(key), false)
             .seal(seq, stamp, payload)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,7 +136,11 @@ pub mod testing {
     /// anti-replay pipeline over a raw UDP socket.
     pub fn seal_datagram(key: [u8; 32], seq: u64, stamp: u64, payload: &[u8]) -> Vec<u8> {
         crate::auth::Authenticator::new(Some(key), false)
-            .seal(seq, stamp, payload)
+            .seal(
+                crate::replay::Seq::new(seq),
+                crate::replay::Stamp::new(stamp),
+                payload,
+            )
             .expect("Enabled authenticator always seals")
     }
 

--- a/src/mirror.rs
+++ b/src/mirror.rs
@@ -72,6 +72,7 @@ use crate::proto;
 use crate::reconcilable::ValueOnly;
 use crate::reconcile_engine::{send_messages_to, send_to_retry, Message};
 use crate::reconcile_store::Config;
+use crate::replay;
 use crate::HRTree;
 
 const BUFFER_SIZE: usize = 65507;
@@ -103,6 +104,8 @@ pub struct ReconcileMirror<K, V> {
     rng: Arc<RwLock<StdRng>>,
     peers: Arc<RwLock<HashMap<IpAddr, Instant>>>,
     authenticator: auth::Authenticator,
+    sender_counter: Arc<replay::SenderCounter>,
+    replay_filter: Arc<replay::ReplayFilter>,
     /// Invoked just before each inbound value is integrated, so callers can be notified of changes.
     on_update: Arc<RwLock<OnUpdateCallback<K, V>>>,
 }
@@ -117,6 +120,8 @@ impl<K, V> Clone for ReconcileMirror<K, V> {
             rng: self.rng.clone(),
             peers: self.peers.clone(),
             authenticator: self.authenticator.clone(),
+            sender_counter: self.sender_counter.clone(),
+            replay_filter: self.replay_filter.clone(),
             on_update: self.on_update.clone(),
         }
     }
@@ -164,6 +169,8 @@ impl<K: Key, V: Clone + Debug + DeserializeOwned + Hash + Send + Serialize + Syn
             rng: Arc::new(RwLock::new(StdRng::from_entropy())),
             peers: Arc::new(RwLock::new(HashMap::new())),
             authenticator,
+            sender_counter: Arc::new(replay::SenderCounter::new()),
+            replay_filter: Arc::new(replay::ReplayFilter::new(config.freshness_window)),
             on_update: Arc::new(RwLock::new(Box::new(|_, _| {}))),
         })
     }
@@ -265,6 +272,7 @@ impl<K: Key, V: Clone + Debug + DeserializeOwned + Hash + Send + Serialize + Syn
             if let Err(err) = send_to_retry(
                 &self.socket,
                 &self.authenticator,
+                &self.sender_counter,
                 send_buf,
                 (peer, self.port),
             )
@@ -340,6 +348,7 @@ impl<K: Key, V: Clone + Debug + DeserializeOwned + Hash + Send + Serialize + Syn
                     &messages,
                     Arc::clone(&self.socket),
                     &self.authenticator,
+                    &self.sender_counter,
                     &peer,
                     send_buf,
                 )
@@ -373,6 +382,22 @@ impl<K: Key, V: Clone + Debug + DeserializeOwned + Hash + Send + Serialize + Syn
                     } else {
                         match self.authenticator.open(&recv_buf[..size]) {
                             Some(payload) => {
+                                if self.authenticator.is_enabled() {
+                                    let sender = peer.ip();
+                                    if !self.replay_filter.check_and_record(
+                                        sender,
+                                        payload.seq,
+                                        payload.stamp,
+                                    ) {
+                                        trace!(
+                                            "mirror dropped replayed datagram from {peer}: \
+                                             seq={} stamp={}",
+                                            payload.seq,
+                                            payload.stamp
+                                        );
+                                        continue;
+                                    }
+                                }
                                 self.handle_messages(payload, peer, &mut send_buf).await;
                                 // Record the sender so we keep gossiping value-only diffs to it.
                                 self.peers.write().insert(peer.ip(), Instant::now());

--- a/src/reconcile_engine.rs
+++ b/src/reconcile_engine.rs
@@ -42,6 +42,7 @@ use crate::observability;
 use crate::proto::{self, HashSegment};
 use crate::reconcilable::{MaybeTombstone, Projectable, Reconcilable};
 use crate::reconcile_store::{Config, MAX_NETS};
+use crate::replay;
 use crate::HRTree;
 
 const BUFFER_SIZE: usize = 65507;
@@ -195,6 +196,14 @@ pub(crate) struct Inner<K, V: Projectable> {
     pub(crate) pre_insert: Arc<RwLock<PreInsertCallback<K, V>>>,
     /// Per-datagram authentication policy; carries the cluster key when enabled.
     authenticator: auth::Authenticator,
+    /// Sender-side replay counter: a monotonically increasing sequence number stamped onto every
+    /// outgoing datagram in authenticated modes. Shared across all clones so that parallel send
+    /// paths draw from a single strictly-increasing sequence.
+    sender_counter: Arc<replay::SenderCounter>,
+    /// Receiver-side per-peer replay filter. Enforces the sequence-number window and freshness
+    /// window for all inbound datagrams in authenticated modes. Shared across clones (the same
+    /// receive loop instance holds the only clone that calls `check_and_record`).
+    replay_filter: Arc<replay::ReplayFilter>,
     /// Monotonic set of every peer this node has ever exchanged messages with.
     ///
     /// Unlike [`peers`](Self::peers), entries are never expired automatically: a tombstone
@@ -356,6 +365,8 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
                 peers: Arc::new(RwLock::new(HashMap::new())),
                 pre_insert: Arc::new(RwLock::new(Box::new(|_, _| {}))),
                 authenticator,
+                sender_counter: Arc::new(replay::SenderCounter::new()),
+                replay_filter: Arc::new(replay::ReplayFilter::new(config.freshness_window)),
                 members: Arc::new(RwLock::new(HashSet::new())),
                 tombstone_acks: Arc::new(RwLock::new(HashMap::new())),
                 clock,
@@ -503,6 +514,7 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
         let port = self.port;
         let socket = Arc::clone(&self.socket);
         let authenticator = self.authenticator.clone();
+        let sender_counter = Arc::clone(&self.sender_counter);
         tokio::spawn(async move {
             let mut send_buf = Vec::new();
             for addr in peers {
@@ -511,6 +523,7 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
                     &messages,
                     Arc::clone(&socket),
                     &authenticator,
+                    &sender_counter,
                     &peer,
                     &mut send_buf,
                 )
@@ -550,6 +563,7 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
         };
         let socket = Arc::clone(&self.socket);
         let authenticator = self.authenticator.clone();
+        let sender_counter = Arc::clone(&self.sender_counter);
         let rate = self.bulk_send_rate;
         tokio::spawn(async move {
             let _guard = guard;
@@ -558,6 +572,7 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
                 &messages,
                 socket,
                 &authenticator,
+                &sender_counter,
                 &peer,
                 &mut send_buf,
                 rate,
@@ -649,6 +664,28 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
                         // dropped silently (trace-only, to avoid attacker-driven log flooding).
                         match self.authenticator.open(&recv_buf[..size]) {
                             Some(payload) => {
+                                // In authenticated modes, perform the replay check *after*
+                                // authentication (so forgeries cannot poison the per-peer state)
+                                // and *before* message processing. In unauthenticated mode
+                                // seq/stamp are both 0 and `is_enabled()` is false, so the check
+                                // is skipped entirely.
+                                if self.authenticator.is_enabled() {
+                                    let sender = peer.ip();
+                                    if !self.replay_filter.check_and_record(
+                                        sender,
+                                        payload.seq,
+                                        payload.stamp,
+                                    ) {
+                                        trace!(
+                                            "dropped replayed or stale datagram from {peer}: \
+                                             seq={} stamp={}",
+                                            payload.seq,
+                                            payload.stamp
+                                        );
+                                        observability::record_datagram_dropped("replay");
+                                        continue;
+                                    }
+                                }
                                 let spoke_dated =
                                     self.handle_messages(payload, peer, &mut send_buf).await;
                                 // Only record senders whose datagram was accepted. With
@@ -756,6 +793,7 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
             if let Err(err) = send_to_retry(
                 &self.socket,
                 &self.authenticator,
+                &self.sender_counter,
                 send_buf,
                 (peer, self.port),
             )
@@ -849,6 +887,7 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
                     &reciprocal_acks,
                     Arc::clone(&self.socket),
                     &self.authenticator,
+                    &self.sender_counter,
                     &peer,
                     send_buf,
                 )
@@ -876,6 +915,7 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
                     &messages,
                     Arc::clone(&self.socket),
                     &self.authenticator,
+                    &self.sender_counter,
                     &peer,
                     send_buf,
                 )
@@ -967,6 +1007,7 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
                     &acks_to_send,
                     Arc::clone(&self.socket),
                     &self.authenticator,
+                    &self.sender_counter,
                     &peer,
                     send_buf,
                 )
@@ -1000,6 +1041,7 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
                     &messages,
                     Arc::clone(&self.socket),
                     &self.authenticator,
+                    &self.sender_counter,
                     &peer,
                     send_buf,
                 )
@@ -1055,6 +1097,11 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
     /// Permanently remove a peer from the membership set so that tombstones are no longer held
     /// back waiting for its acknowledgment. Use when a replica is decommissioned or will never
     /// return. Also clears any acknowledgments it had recorded.
+    ///
+    /// Per-peer replay state is intentionally **not** evicted: a replay attacker who captured a
+    /// datagram from this peer while it was active and replays it within the freshness window
+    /// would otherwise bypass the bitmap duplicate check (the entry was removed) and re-add the
+    /// peer to membership. Keeping the replay state lets the bitmap reject the captured datagram.
     pub(crate) fn decommission_peer(&self, peer: IpAddr) {
         self.members.write().remove(&peer);
         for key_acks in self.tombstone_acks.write().values_mut() {
@@ -1089,12 +1136,16 @@ impl<K: Key, V: Value + MaybeTombstone + Projectable + Reconcilable + Timestampe
 pub(crate) async fn send_to_retry<A: ToSocketAddrs>(
     socket: &UdpSocket,
     authenticator: &auth::Authenticator,
+    sender_counter: &replay::SenderCounter,
     buf: &[u8],
     target: A,
 ) -> std::io::Result<usize> {
-    // Frame the datagram once and reuse it across retries. When authentication is disabled,
-    // `seal` returns `None` and the wire bytes are identical to the unauthenticated behavior.
-    let framed = authenticator.seal(buf);
+    // Allocate a sequence number and stamp, then frame the datagram once and reuse it across
+    // retries. When authentication is disabled, `seal` returns `None` and the wire bytes are
+    // identical to the unauthenticated behavior.
+    let seq = sender_counter.next_seq();
+    let stamp = sender_counter.next_stamp();
+    let framed = authenticator.seal(seq, stamp, buf);
     let wire: &[u8] = framed.as_deref().unwrap_or(buf);
     let mut res = Ok(0);
     for _ in 0..MAX_SENDTO_RETRIES {
@@ -1123,10 +1174,20 @@ pub(crate) async fn send_messages_to<K: Serialize, V: Serialize, P: Serialize>(
     messages: &[Message<K, V, P>],
     socket: Arc<UdpSocket>,
     authenticator: &auth::Authenticator,
+    sender_counter: &replay::SenderCounter,
     peer: &SocketAddr,
     send_buf: &mut Vec<u8>,
 ) {
-    send_messages_paced(messages, socket, authenticator, peer, send_buf, None).await
+    send_messages_paced(
+        messages,
+        socket,
+        authenticator,
+        sender_counter,
+        peer,
+        send_buf,
+        None,
+    )
+    .await
 }
 
 /// Send `messages` to `peer` as ≤64 KiB datagrams, optionally metered to `rate` bytes/sec.
@@ -1142,6 +1203,7 @@ pub(crate) async fn send_messages_paced<K: Serialize, V: Serialize, P: Serialize
     messages: &[Message<K, V, P>],
     socket: Arc<UdpSocket>,
     authenticator: &auth::Authenticator,
+    sender_counter: &replay::SenderCounter,
     peer: &SocketAddr,
     send_buf: &mut Vec<u8>,
     rate: Option<usize>,
@@ -1160,8 +1222,14 @@ pub(crate) async fn send_messages_paced<K: Serialize, V: Serialize, P: Serialize
             .expect("serializing a protocol Message into an in-memory buffer cannot fail");
         if send_buf.len() > max_payload {
             trace!("sending {} bytes to {peer}", last_size);
-            if let Err(err) =
-                send_to_retry(&socket, authenticator, &send_buf[..last_size], peer).await
+            if let Err(err) = send_to_retry(
+                &socket,
+                authenticator,
+                sender_counter,
+                &send_buf[..last_size],
+                peer,
+            )
+            .await
             {
                 warn!("failed to send datagram to {peer}: {err}; continuing");
             } else {
@@ -1173,7 +1241,7 @@ pub(crate) async fn send_messages_paced<K: Serialize, V: Serialize, P: Serialize
         }
     }
     trace!("sending last {} bytes to {peer}", send_buf.len());
-    if let Err(err) = send_to_retry(&socket, authenticator, send_buf, peer).await {
+    if let Err(err) = send_to_retry(&socket, authenticator, sender_counter, send_buf, peer).await {
         warn!("failed to send final datagram to {peer}: {err}; continuing");
     } else {
         trace!("sent last {} bytes to {peer}", send_buf.len());
@@ -1357,6 +1425,7 @@ mod auth_attack {
     use std::time::Duration;
 
     use bincode::{DefaultOptions, Serializer};
+    use chrono::Utc;
     use serde::Serialize;
     use tokio::net::UdpSocket;
 
@@ -1405,7 +1474,7 @@ mod auth_attack {
         attacker.send_to(&forged, &target).await.unwrap();
         // (b) forged update sealed with the WRONG key
         let wrong_key_sealed = auth::Authenticator::new(Some([0x99u8; auth::KEY_LEN]), false)
-            .seal(&forged)
+            .seal(1, Utc::now().timestamp_millis().max(0) as u64, &forged)
             .expect("enabled");
         attacker.send_to(&wrong_key_sealed, &target).await.unwrap();
 
@@ -1560,10 +1629,20 @@ mod pacing {
     async fn time_send(messages: &[Msg], rate: Option<usize>) -> Duration {
         let socket = Arc::new(UdpSocket::bind("127.0.0.1:0").await.unwrap());
         let authenticator = Authenticator::new(None, false);
+        let sender_counter = crate::replay::SenderCounter::new();
         let peer: SocketAddr = "127.0.0.1:9".parse().unwrap(); // discard port
         let mut send_buf = Vec::new();
         let start = Instant::now();
-        send_messages_paced(messages, socket, &authenticator, &peer, &mut send_buf, rate).await;
+        send_messages_paced(
+            messages,
+            socket,
+            &authenticator,
+            &sender_counter,
+            &peer,
+            &mut send_buf,
+            rate,
+        )
+        .await;
         start.elapsed()
     }
 

--- a/src/reconcile_engine.rs
+++ b/src/reconcile_engine.rs
@@ -1474,7 +1474,11 @@ mod auth_attack {
         attacker.send_to(&forged, &target).await.unwrap();
         // (b) forged update sealed with the WRONG key
         let wrong_key_sealed = auth::Authenticator::new(Some([0x99u8; auth::KEY_LEN]), false)
-            .seal(1, Utc::now().timestamp_millis().max(0) as u64, &forged)
+            .seal(
+                crate::replay::Seq::new(1),
+                crate::replay::Stamp::new(Utc::now().timestamp_millis().max(0) as u64),
+                &forged,
+            )
             .expect("enabled");
         attacker.send_to(&wrong_key_sealed, &target).await.unwrap();
 

--- a/src/reconcile_store.rs
+++ b/src/reconcile_store.rs
@@ -478,6 +478,16 @@ impl<K: Key, V: Value> ReconcileStore<K, V> {
         self.engine.decommission_peer(peer);
     }
 
+    /// Return the current membership set.
+    ///
+    /// Exposed for integration-test assertions under the `internal-testing` feature gate. Members
+    /// are peers that have sent at least one dated, authenticated datagram and gate tombstone
+    /// garbage collection via causal stability.
+    #[cfg(any(test, feature = "internal-testing"))]
+    pub fn members_snapshot(&self) -> std::collections::HashSet<std::net::IpAddr> {
+        self.engine.members_snapshot()
+    }
+
     /// (runtime) Replace the declared geographical networks, retuning the gossip topology **without
     /// recreating the node**. The local network is re-derived automatically (whichever new net
     /// contains the listen address). See [`Config::nets`].
@@ -799,7 +809,16 @@ pub struct Config {
     /// Set to `None` to leave the inherited OS default untouched. See
     /// [`with_send_buffer_size`](Config::with_send_buffer_size).
     pub send_buffer_size: Option<usize>,
-    // may include other options in the future: tombstone_ttl, metrics, etc.
+    /// Maximum deviation between a datagram's sender wall-clock stamp and local physical time for
+    /// the datagram to be accepted in authenticated modes.
+    ///
+    /// Datagrams whose freshness stamp is more than this far in the past **or** future are
+    /// silently dropped, preventing replay of old authenticated traffic. Only applied in
+    /// authenticated modes (MAC or encrypted); unauthenticated mode ignores this setting.
+    ///
+    /// Defaults to 5 minutes. Increase if nodes have large, legitimate clock skew; decrease for
+    /// tighter replay protection. See [`with_freshness_window`](Config::with_freshness_window).
+    pub freshness_window: Duration,
 }
 impl Default for Config {
     fn default() -> Self {
@@ -816,6 +835,7 @@ impl Default for Config {
             bulk_send_rate: Some(DEFAULT_BULK_SEND_RATE),
             recv_buffer_size: Some(DEFAULT_SOCKET_BUFFER_SIZE),
             send_buffer_size: Some(DEFAULT_SOCKET_BUFFER_SIZE),
+            freshness_window: crate::replay::FRESHNESS_WINDOW_DEFAULT,
         }
     }
 }
@@ -937,6 +957,17 @@ impl Config {
         self
     }
 
+    /// Set the freshness window for replay protection in authenticated modes (default 5 minutes).
+    ///
+    /// Datagrams whose sender wall-clock stamp deviates from local physical time by more than
+    /// `window` in either direction are silently dropped. A narrower window tightens replay
+    /// protection; a wider one tolerates larger clock skew between nodes. Has no effect in
+    /// unauthenticated mode (no cluster key). See [`freshness_window`](Config::freshness_window).
+    pub fn with_freshness_window(mut self, window: Duration) -> Self {
+        self.freshness_window = window;
+        self
+    }
+
     /// Encrypt datagram payloads with XChaCha20-Poly1305, upgrading the keyed protocol from
     /// authentication-only to authenticated **encryption**.
     ///
@@ -988,6 +1019,7 @@ mod reconcile_store_tests {
             bulk_send_rate: Some(super::DEFAULT_BULK_SEND_RATE),
             recv_buffer_size: Some(super::DEFAULT_SOCKET_BUFFER_SIZE),
             send_buffer_size: Some(super::DEFAULT_SOCKET_BUFFER_SIZE),
+            freshness_window: crate::replay::FRESHNESS_WINDOW_DEFAULT,
         }
     }
 

--- a/src/reconcile_store.rs
+++ b/src/reconcile_store.rs
@@ -809,15 +809,9 @@ pub struct Config {
     /// Set to `None` to leave the inherited OS default untouched. See
     /// [`with_send_buffer_size`](Config::with_send_buffer_size).
     pub send_buffer_size: Option<usize>,
-    /// Maximum deviation between a datagram's sender wall-clock stamp and local physical time for
-    /// the datagram to be accepted in authenticated modes.
-    ///
-    /// Datagrams whose freshness stamp is more than this far in the past **or** future are
-    /// silently dropped, preventing replay of old authenticated traffic. Only applied in
-    /// authenticated modes (MAC or encrypted); unauthenticated mode ignores this setting.
-    ///
-    /// Defaults to 5 minutes. Increase if nodes have large, legitimate clock skew; decrease for
-    /// tighter replay protection. See [`with_freshness_window`](Config::with_freshness_window).
+    /// Maximum age (past or future) of a datagram's sender wall-clock stamp before it is silently
+    /// dropped as a replay. Authenticated modes only; ignored unkeyed. Default 5 minutes — see
+    /// [`with_freshness_window`](Config::with_freshness_window).
     pub freshness_window: Duration,
 }
 impl Default for Config {
@@ -957,12 +951,8 @@ impl Config {
         self
     }
 
-    /// Set the freshness window for replay protection in authenticated modes (default 5 minutes).
-    ///
-    /// Datagrams whose sender wall-clock stamp deviates from local physical time by more than
-    /// `window` in either direction are silently dropped. A narrower window tightens replay
-    /// protection; a wider one tolerates larger clock skew between nodes. Has no effect in
-    /// unauthenticated mode (no cluster key). See [`freshness_window`](Config::freshness_window).
+    /// Set [`freshness_window`](Config::freshness_window): the max stamp deviation tolerated in
+    /// authenticated modes before a datagram is dropped as a replay. No effect unkeyed.
     pub fn with_freshness_window(mut self, window: Duration) -> Self {
         self.freshness_window = window;
         self

--- a/src/replay.rs
+++ b/src/replay.rs
@@ -1,0 +1,806 @@
+// Copyright 2023 Developers of the reconcile project.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Per-peer replay protection for the authenticated protocol modes.
+//!
+//! When a cluster key is configured (MAC or encrypted mode), every outgoing datagram carries a
+//! 16-byte **replay header** — a monotonically increasing `u64` sequence number followed by a
+//! `u64` sender wall-clock stamp (milliseconds since the Unix epoch, little-endian) — that is
+//! included in the authenticated portion of the datagram. The receiver maintains per-peer state
+//! to reject:
+//!
+//! - **Duplicate or stale datagrams**: a sequence number within the backward window that has
+//!   already been seen (sliding-bitmap check), or a sequence number older than the window.
+//! - **Stale freshness stamps**: a sender wall-clock stamp that deviates from the receiver's
+//!   physical clock by more than [`FRESHNESS_WINDOW_DEFAULT`] in either direction.
+//!
+//! Only datagrams that carry an authenticated replay header are checked. Unauthenticated mode
+//! (no cluster key) is explicitly exempt — and documented as unprotected.
+//!
+//! # Replay state lifetime and staleness purge
+//!
+//! Per-peer replay state **intentionally outlives membership**. Decommissioning a peer removes it
+//! from `members` and `peers` so it no longer gates tombstone garbage collection or receives gossip
+//! probes, but the replay filter entry is kept. This matters because an adversary who captured a
+//! datagram from the peer while it was active can replay it within the freshness window after
+//! decommission: the replayed datagram passes MAC verification and the freshness check, but hits
+//! the bitmap duplicate check and is rejected. Without this, decommission + replay would re-add
+//! the peer to `members`, re-poisoning causal-stability membership — which is exactly what this
+//! design exists to prevent.
+//!
+//! **Staleness purge is sound**: the purge retains only entries where
+//! `now - stamp_at_max <= window`. Any replayable datagram from a peer has a stamp no greater than
+//! `stamp_at_max` (the bitmap path never raises it; a strictly newer stamp triggers `reset` instead
+//! of replay). Once `now - stamp_at_max > window`, the freshness check on any such stamp would fail
+//! even accounting for the maximum allowed sender clock skew, so no replay can pass. The entry is
+//! therefore safe to drop at that point. The purge runs opportunistically on every call to
+//! [`ReplayFilter::check_and_record`] via `HashMap::retain`, which is cheap for the small maps
+//! typical in a gossip cluster.
+//!
+//! # Sequence-number regression
+//!
+//! A sender's sequence counter is per-process lifetime, so a restart resets it to 1. The receiver
+//! distinguishes a restart from a replay with the freshness stamp. The rule applies on **any**
+//! sequence regression (`seq <= max_seq`):
+//!
+//! - The stamp is checked **first**: if `stamp > stamp_at_max`, the regression is treated as a
+//!   legitimate restart — per-peer state is reset and the datagram is accepted.
+//! - Otherwise, the bitmap check runs normally: if the sequence is within the out-of-order window
+//!   and has not been seen, it is accepted; otherwise it is rejected.
+//! - If the sequence is beyond the backward window and the stamp is not strictly newer, the
+//!   datagram is unconditionally rejected.
+//!
+//! **Residual**: a restart that happens within the same millisecond as the sender's last
+//! pre-restart send produces `stamp == stamp_at_max`, which does not satisfy `stamp > stamp_at_max`.
+//! Such a restart is indistinguishable from a replay within that millisecond and is dropped. This
+//! is a deliberate trade-off: the alternative (accepting same-stamp regressions) would allow
+//! replays within the same millisecond.
+//!
+//! # Post-restart tail guard (monotone max-stamp)
+//!
+//! After a genuine restart triggers `reset()` to a low `max_seq` with a cleared bitmap, captured
+//! pre-restart datagrams with high sequence numbers (but stamps still inside the freshness window)
+//! would otherwise be re-accepted on the forward path (`seq > max_seq`). To prevent this, each
+//! `PeerState` tracks `max_stamp_seen`: the maximum sender stamp ever accepted from this peer.
+//! `reset()` does **not** rewind `max_stamp_seen`. On the forward path (`seq > max_seq`), any
+//! datagram whose stamp is strictly less than `max_stamp_seen` is rejected.
+//!
+//! The monotonicity premise is enforced at the source: [`SenderCounter::next_stamp`] maintains an
+//! in-process floor (`AtomicU64`) so that each minted stamp is `max(wall_clock_now, floor)`.
+//! Stamps therefore never decrease within a process lifetime, and same-millisecond bursts share a
+//! stamp — hence the guard uses strict `<` (not `<=`) to accept those bursts correctly.
+//!
+//! **Residual**: a sender that *restarts* while its wall clock is still behind its pre-restart
+//! stamps (e.g. after an NTP backward step or VM resume that shrinks wall time) loses the
+//! in-memory floor on restart and re-mints stamps lower than the receiver's recorded
+//! `max_stamp_seen`. Such datagrams are treated as replays and silently dropped until the sender's
+//! clock advances past the old high-water mark — bounded by the size of the clock step. This is the
+//! same family of trade-off as the documented same-millisecond-restart residual.
+//!
+//! # Wire layout (authenticated portion only)
+//!
+//! ```text
+//! seq   (8 bytes, little-endian u64)
+//! stamp (8 bytes, little-endian u64, milliseconds since Unix epoch)
+//! <protocol messages ...>
+//! ```
+//!
+//! This 16-byte header is the **first thing inside** the authenticated or encrypted region, before
+//! any protocol messages. For MAC mode the tag still authenticates the whole payload including the
+//! header; for encryption mode the header is encrypted together with the messages.
+
+use std::collections::HashMap;
+use std::net::IpAddr;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+
+use chrono::Utc;
+use parking_lot::Mutex;
+
+/// Length of the replay header prepended to the authenticated portion of every datagram.
+///
+/// `seq (8 bytes) || stamp (8 bytes)`.
+pub(crate) const REPLAY_HEADER_LEN: usize = 16;
+
+/// Default freshness window: datagrams whose sender wall-clock stamp deviates from local physical
+/// time by more than this value in either direction are rejected.
+pub const FRESHNESS_WINDOW_DEFAULT: Duration = Duration::from_secs(5 * 60); // 5 minutes
+
+/// Number of bits in the out-of-order acceptance bitmap.
+///
+/// A bitmap of 1024 entries allows sequence numbers up to 1024 behind the highest accepted to be
+/// accepted as out-of-order legitimate UDP reordering. Each bit represents whether the
+/// corresponding sequence number (relative to `max_seq`) was received. Anything older than 1024
+/// behind `max_seq` is unconditionally rejected as outside the window.
+const WINDOW_SIZE: u64 = 1024;
+
+/// The per-peer replay state.
+///
+/// Tracks the highest sequence number seen from a peer, the sender stamp at which that maximum was
+/// accepted, a sliding bitmap for the out-of-order acceptance window, and a monotone high-water
+/// mark of sender stamps (used for the post-restart tail guard).
+struct PeerState {
+    /// Highest sequence number accepted from this peer.
+    max_seq: u64,
+    /// Sender wall-clock stamp (ms since epoch) that was present on the datagram carrying `max_seq`.
+    /// Used for restart detection: if a new datagram has a higher stamp and a lower seq, the peer
+    /// has restarted.
+    stamp_at_max: u64,
+    /// Monotonically non-decreasing high-water mark of all sender stamps ever accepted from this
+    /// peer. Never reset by `reset()`. Used on the forward path to reject captured pre-restart
+    /// datagrams whose stamp predates the restart stamp.
+    max_stamp_seen: u64,
+    /// Sliding bitmap. Bit `i` represents whether sequence number `max_seq - i` was already
+    /// accepted. `bitmap & 1` is always `1` (max_seq itself was accepted). Bits beyond
+    /// `WINDOW_SIZE` are not tracked (always treated as seen/rejected if below window).
+    ///
+    /// Stored as a fixed-size array of `u64` words; `WINDOW_SIZE / 64 = 16`.
+    bitmap: [u64; (WINDOW_SIZE / 64) as usize],
+}
+
+impl PeerState {
+    fn new(first_seq: u64, first_stamp: u64) -> Self {
+        let mut bitmap = [0u64; (WINDOW_SIZE / 64) as usize];
+        // Mark the first sequence as seen (bit 0 of word 0).
+        bitmap[0] = 1;
+        PeerState {
+            max_seq: first_seq,
+            stamp_at_max: first_stamp,
+            max_stamp_seen: first_stamp,
+            bitmap,
+        }
+    }
+
+    /// Return the sender stamp at the highest accepted sequence number (used for staleness purge).
+    fn stamp_at_max(&self) -> u64 {
+        self.stamp_at_max
+    }
+
+    /// Attempt to accept a datagram with the given `seq` and `stamp`.
+    ///
+    /// Returns `true` if the datagram is fresh (not a replay), `false` if it should be rejected.
+    ///
+    /// Side effect on success: updates the bitmap and `max_seq`/`stamp_at_max` as appropriate.
+    fn accept(&mut self, seq: u64, stamp: u64) -> bool {
+        if seq > self.max_seq {
+            // Forward path: new high-water sequence.
+            // Post-restart tail guard: reject pre-restart captured datagrams. A genuinely
+            // later-minted datagram always has stamp >= every prior datagram (sender mints
+            // monotonically). Same-millisecond bursts share a stamp, so guard uses strict <.
+            if stamp < self.max_stamp_seen {
+                return false;
+            }
+            // Advance the window. Shift the bitmap forward by (seq - max_seq) positions.
+            let delta = seq - self.max_seq;
+            self.shift_bitmap(delta);
+            self.max_seq = seq;
+            self.stamp_at_max = stamp;
+            self.max_stamp_seen = self.max_stamp_seen.max(stamp);
+            // Mark the new max as seen (bit 0).
+            self.bitmap[0] |= 1;
+            true
+        } else {
+            // seq <= max_seq: check stamp FIRST for restart detection.
+            // If the sender's stamp is strictly newer than what we recorded at max_seq,
+            // this is a restart — reset state regardless of how far behind seq is.
+            if stamp > self.stamp_at_max {
+                self.reset(seq, stamp);
+                return true;
+            }
+            // Not a restart: fall through to bitmap / window check.
+            let behind = self.max_seq - seq;
+            if behind >= WINDOW_SIZE {
+                // Outside the window: unconditionally reject.
+                return false;
+            }
+            let word = (behind / 64) as usize;
+            let bit = behind % 64;
+            if self.bitmap[word] & (1 << bit) != 0 {
+                // Already seen: duplicate.
+                return false;
+            }
+            // First time in window: accept and mark.
+            self.bitmap[word] |= 1 << bit;
+            true
+        }
+    }
+
+    /// Shift the bitmap forward by `delta` positions (oldest bits fall off).
+    ///
+    /// A shift of 1 means `max_seq` moved up by 1; the former bit 0 becomes bit 1, etc.
+    /// Bits that shift past position `WINDOW_SIZE - 1` are discarded.
+    fn shift_bitmap(&mut self, delta: u64) {
+        if delta >= WINDOW_SIZE {
+            // The whole bitmap falls off — start fresh.
+            self.bitmap = [0u64; (WINDOW_SIZE / 64) as usize];
+            return;
+        }
+        let word_shift = (delta / 64) as usize;
+        let bit_shift = (delta % 64) as u32;
+        let words = (WINDOW_SIZE / 64) as usize;
+
+        if bit_shift == 0 {
+            // Whole-word shift only.
+            for i in (0..words).rev() {
+                self.bitmap[i] = if i >= word_shift {
+                    self.bitmap[i - word_shift]
+                } else {
+                    0
+                };
+            }
+        } else {
+            // Combined word + bit shift.
+            for i in (0..words).rev() {
+                let lo = if i >= word_shift {
+                    self.bitmap[i - word_shift] << bit_shift
+                } else {
+                    0
+                };
+                let hi = if i > word_shift {
+                    self.bitmap[i - word_shift - 1] >> (64 - bit_shift)
+                } else {
+                    0
+                };
+                self.bitmap[i] = lo | hi;
+            }
+        }
+    }
+
+    /// Reset state for a restarted sender.
+    ///
+    /// `max_stamp_seen` is intentionally NOT reset — it is a monotone high-water mark that
+    /// persists across restarts to guard against replays of captured pre-restart datagrams.
+    fn reset(&mut self, new_seq: u64, new_stamp: u64) {
+        self.max_seq = new_seq;
+        self.stamp_at_max = new_stamp;
+        // max_stamp_seen is never rewound — keep the monotone high-water mark.
+        self.max_stamp_seen = self.max_stamp_seen.max(new_stamp);
+        self.bitmap = [0u64; (WINDOW_SIZE / 64) as usize];
+        self.bitmap[0] = 1;
+    }
+}
+
+/// Read the local physical time as milliseconds since the Unix epoch.
+fn phys_now_ms() -> u64 {
+    Utc::now().timestamp_millis().max(0) as u64
+}
+
+/// Sender-side replay state: a monotonically increasing sequence counter and stamp floor.
+///
+/// One instance per node, incremented for every datagram sent in an authenticated mode.
+/// The sequence counter starts at 1; 0 is reserved as "no sequence" (unauthenticated mode).
+///
+/// The stamp floor (`stamp_floor`) guarantees that minted sender stamps never decrease within a
+/// process lifetime. Each call to [`next_stamp`](Self::next_stamp) returns
+/// `max(Utc::now().timestamp_millis(), previous_stamp)`. Concurrent senders sharing a
+/// millisecond will emit equal stamps; the receiver's forward-path guard uses strict `<` precisely
+/// to tolerate same-millisecond bursts.
+///
+/// **Residual**: a sender that *restarts* while its wall clock is still behind its pre-restart
+/// stamps (e.g. after an NTP correction or VM resume that shrinks wall time) re-mints lower stamps
+/// because the in-memory floor is lost on restart. The receiver treats the regressed stamps as a
+/// replayer until the sender's clock catches back up — bounded by the clock-step size. This is the
+/// same family of trade-off as the documented same-millisecond-restart residual.
+pub(crate) struct SenderCounter {
+    seq: AtomicU64,
+    stamp_floor: AtomicU64,
+}
+
+impl SenderCounter {
+    pub(crate) fn new() -> Self {
+        SenderCounter {
+            seq: AtomicU64::new(1),
+            stamp_floor: AtomicU64::new(0),
+        }
+    }
+
+    /// Allocate the next sequence number (strictly increasing).
+    pub(crate) fn next_seq(&self) -> u64 {
+        self.seq.fetch_add(1, Ordering::Relaxed)
+    }
+
+    /// Mint a monotonically non-decreasing sender stamp (milliseconds since Unix epoch).
+    ///
+    /// Each call returns `max(Utc::now().timestamp_millis().max(0), floor)` and advances the
+    /// internal floor so subsequent calls never return a smaller value.
+    pub(crate) fn next_stamp(&self) -> u64 {
+        self.next_stamp_at(phys_now_ms())
+    }
+
+    /// Inner implementation with an injectable `now_ms` for unit-testing backward clock steps.
+    pub(crate) fn next_stamp_at(&self, now_ms: u64) -> u64 {
+        // `fetch_max` atomically sets floor = max(floor, now_ms) and returns the OLD value.
+        // The stamp we return is the maximum of the returned old floor and now_ms, which equals
+        // the new floor value after the update.
+        let prev = self.stamp_floor.fetch_max(now_ms, Ordering::Relaxed);
+        prev.max(now_ms)
+    }
+}
+
+/// Receiver-side per-peer replay filter.
+///
+/// Maintains per-peer [`PeerState`] and enforces the freshness window. Entries are purged
+/// opportunistically once `now - stamp_at_max > window`: at that point any replayable datagram
+/// (stamp ≤ `stamp_at_max`) would fail the freshness check, so no replay can pass and the entry is
+/// safe to drop, reclaiming memory automatically.
+pub(crate) struct ReplayFilter {
+    peers: Mutex<HashMap<IpAddr, PeerState>>,
+    freshness_window: Duration,
+}
+
+impl ReplayFilter {
+    pub(crate) fn new(freshness_window: Duration) -> Self {
+        ReplayFilter {
+            peers: Mutex::new(HashMap::new()),
+            freshness_window,
+        }
+    }
+
+    /// Decide whether a datagram from `sender` with the given `seq` and `stamp` should be accepted.
+    ///
+    /// Returns `true` when the datagram is fresh and unique — the caller may proceed to process it.
+    /// Returns `false` when the datagram is a replay (duplicate, too old within the window, or
+    /// outside the freshness window) — the caller should drop it silently.
+    pub(crate) fn check_and_record(&self, sender: IpAddr, seq: u64, stamp: u64) -> bool {
+        self.check_and_record_at(sender, seq, stamp, phys_now_ms())
+    }
+
+    /// Inner implementation with an injectable `now_ms` (milliseconds since epoch).
+    ///
+    /// Separating the clock source allows unit tests to exercise time-dependent logic
+    /// (staleness purge, skew-positive scenarios) without sleeping.
+    fn check_and_record_at(&self, sender: IpAddr, seq: u64, stamp: u64, now: u64) -> bool {
+        // Freshness window check: reject stamps that are too far in the past or future.
+        let window_ms = self.freshness_window.as_millis() as u64;
+        if now.saturating_sub(stamp) > window_ms || stamp.saturating_sub(now) > window_ms {
+            return false;
+        }
+
+        let mut map = self.peers.lock();
+
+        // Opportunistic staleness purge: entries whose stamp_at_max is older than the freshness
+        // window cannot produce any accepted datagrams (any replayable stamp ≤ stamp_at_max would
+        // fail the freshness check above), so it is safe to drop them.
+        map.retain(|_, s| now.saturating_sub(s.stamp_at_max()) <= window_ms);
+
+        match map.get_mut(&sender) {
+            None => {
+                // First datagram from this sender.
+                map.insert(sender, PeerState::new(seq, stamp));
+                true
+            }
+            Some(state) => state.accept(seq, stamp),
+        }
+    }
+
+    /// Remove the replay state for a peer, freeing its memory immediately.
+    ///
+    /// This is an explicit escape hatch for tests. Production code does not call this — per-peer
+    /// state is reclaimed automatically by the staleness purge in [`check_and_record`].
+    #[cfg(test)]
+    pub(crate) fn evict(&self, peer: IpAddr) {
+        self.peers.lock().remove(&peer);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── Sender counter ────────────────────────────────────────────────────────
+
+    #[test]
+    fn sender_counter_starts_at_1_and_increments() {
+        let c = SenderCounter::new();
+        assert_eq!(c.next_seq(), 1);
+        assert_eq!(c.next_seq(), 2);
+        assert_eq!(c.next_seq(), 3);
+    }
+
+    /// The stamp mint must be monotonically non-decreasing even when the wall clock steps backward.
+    ///
+    /// Uses the injectable `next_stamp_at` to simulate a backward clock step without sleeping.
+    #[test]
+    fn stamp_mint_is_monotonic_across_backward_clock_steps() {
+        let c = SenderCounter::new();
+
+        // Feed a normal increasing sequence of wall-clock values.
+        let t1 = 1_700_000_000_000_u64;
+        let t2 = t1 + 50;
+        let t3 = t2 + 50;
+
+        assert_eq!(c.next_stamp_at(t1), t1, "first stamp equals wall clock");
+        assert_eq!(
+            c.next_stamp_at(t2),
+            t2,
+            "second stamp equals advancing wall clock"
+        );
+        assert_eq!(
+            c.next_stamp_at(t3),
+            t3,
+            "third stamp equals advancing wall clock"
+        );
+
+        // Simulate a backward step: wall clock goes back 500 ms (e.g. NTP correction).
+        let t_regressed = t3 - 500;
+        let s_after_regression = c.next_stamp_at(t_regressed);
+        assert_eq!(
+            s_after_regression, t3,
+            "stamp after backward step must equal the floor (t3), not the regressed wall clock"
+        );
+        assert!(
+            s_after_regression >= t3,
+            "stamp must not decrease after backward clock step"
+        );
+
+        // Verify the floor is sticky: a second regressed call still yields t3.
+        assert_eq!(
+            c.next_stamp_at(t_regressed),
+            t3,
+            "floor remains at t3 for further backward clock values"
+        );
+
+        // Once the wall clock catches back up past the floor, stamps advance again.
+        let t_recovered = t3 + 1;
+        assert_eq!(
+            c.next_stamp_at(t_recovered),
+            t_recovered,
+            "stamps advance normally once wall clock passes the floor"
+        );
+    }
+
+    // ── PeerState bitmap ──────────────────────────────────────────────────────
+
+    #[test]
+    fn bitmap_shift_by_1() {
+        let mut state = PeerState::new(10, 1000);
+        // max_seq = 10, bit 0 set
+        assert!(!state.accept(10, 1000)); // already seen
+                                          // out of order: seq 9
+        assert!(state.accept(9, 999));
+        // seq 9 accepted, now bitmap has bit 0 (=10) and bit 1 (=9) set
+        assert!(!state.accept(9, 999)); // already seen
+    }
+
+    #[test]
+    fn bitmap_advance_and_reuse() {
+        let mut state = PeerState::new(10, 1000);
+        // advance max_seq to 20
+        assert!(state.accept(20, 1000));
+        // seq 10 was already accepted when state was created: must be rejected as duplicate
+        assert!(!state.accept(10, 1000));
+        // seq 15 (mid-window, never seen before) must be accepted
+        assert!(state.accept(15, 1000));
+        // seq 15 again: rejected
+        assert!(!state.accept(15, 1000));
+    }
+
+    #[test]
+    fn bitmap_outside_window_is_rejected() {
+        let mut state = PeerState::new(1024, 1000);
+        // advance max to 2048; seq 1 is 2047 behind, outside window
+        assert!(state.accept(2048, 1000));
+        assert!(!state.accept(1, 1000));
+    }
+
+    #[test]
+    fn bitmap_large_jump_clears_window() {
+        let mut state = PeerState::new(10, 1000);
+        // Jump so big the whole window rolls over
+        assert!(state.accept(10 + WINDOW_SIZE + 5, 1000));
+        // seq 10 is now (WINDOW_SIZE + 5) behind, outside the window
+        assert!(!state.accept(10, 1000));
+    }
+
+    #[test]
+    fn in_order_sequence_all_accepted_once() {
+        let mut state = PeerState::new(1, 1000);
+        for seq in 2..=100 {
+            assert!(state.accept(seq, 1000), "seq {seq} should be accepted");
+        }
+        // All previously accepted seqs rejected on replay
+        for seq in 1..=100 {
+            assert!(
+                !state.accept(seq, 1000),
+                "seq {seq} should be rejected as duplicate"
+            );
+        }
+    }
+
+    // ── ReplayFilter freshness check ──────────────────────────────────────────
+
+    fn filter_5min() -> ReplayFilter {
+        ReplayFilter::new(FRESHNESS_WINDOW_DEFAULT)
+    }
+
+    /// Helper: call check_and_record_at with a caller-supplied `now`.
+    fn check_at(filter: &ReplayFilter, peer: IpAddr, seq: u64, stamp: u64, now: u64) -> bool {
+        filter.check_and_record_at(peer, seq, stamp, now)
+    }
+
+    #[test]
+    fn fresh_datagram_accepted() {
+        let filter = filter_5min();
+        let peer: IpAddr = "127.0.0.1".parse().unwrap();
+        let now = phys_now_ms();
+        assert!(filter.check_and_record(peer, 1, now));
+    }
+
+    #[test]
+    fn replay_of_same_datagram_rejected() {
+        let filter = filter_5min();
+        let peer: IpAddr = "127.0.0.2".parse().unwrap();
+        let now = phys_now_ms();
+        assert!(filter.check_and_record(peer, 1, now));
+        assert!(!filter.check_and_record(peer, 1, now));
+    }
+
+    #[test]
+    fn stale_stamp_rejected() {
+        let filter = filter_5min();
+        let peer: IpAddr = "127.0.0.3".parse().unwrap();
+        // Stamp 10 minutes in the past — beyond the 5-minute window.
+        let old_stamp = phys_now_ms().saturating_sub(10 * 60 * 1000 + 1);
+        assert!(!filter.check_and_record(peer, 1, old_stamp));
+    }
+
+    #[test]
+    fn far_future_stamp_rejected() {
+        let filter = filter_5min();
+        let peer: IpAddr = "127.0.0.4".parse().unwrap();
+        // Stamp 10 minutes in the future.
+        let future_stamp = phys_now_ms() + 10 * 60 * 1000 + 1;
+        assert!(!filter.check_and_record(peer, 1, future_stamp));
+    }
+
+    #[test]
+    fn out_of_order_within_window_accepted_once() {
+        let filter = filter_5min();
+        let peer: IpAddr = "127.0.0.5".parse().unwrap();
+        let now = phys_now_ms();
+        // Accept seq 5 first, then 3 (out of order but within window).
+        assert!(filter.check_and_record(peer, 5, now));
+        assert!(filter.check_and_record(peer, 3, now));
+        // Both must be rejected on replay.
+        assert!(!filter.check_and_record(peer, 5, now));
+        assert!(!filter.check_and_record(peer, 3, now));
+    }
+
+    #[test]
+    fn seq_regression_outside_window_with_newer_stamp_accepted_as_restart() {
+        let filter = filter_5min();
+        let peer: IpAddr = "127.0.0.6".parse().unwrap();
+        let now = phys_now_ms();
+        // Advance to a seq well beyond WINDOW_SIZE so a restart lands outside the bitmap.
+        let high_seq = WINDOW_SIZE + 100;
+        assert!(filter.check_and_record(peer, high_seq, now));
+        // Simulated restart: seq resets to 1 (outside the backward window) with a newer stamp.
+        let newer = now + 1000;
+        assert!(
+            filter.check_and_record(peer, 1, newer),
+            "a seq regression outside the window with a strictly newer stamp must be accepted as a restart"
+        );
+        // After reset the new state has max_seq=1, stamp_at_max=newer.
+        // A further seq=2 with the new stamp must be accepted normally.
+        assert!(filter.check_and_record(peer, 2, newer));
+        // Replaying seq=1 with the new stamp is rejected (already seen after restart).
+        assert!(!filter.check_and_record(peer, 1, newer));
+    }
+
+    #[test]
+    fn seq_regression_outside_window_with_old_stamp_rejected_as_replay() {
+        let filter = filter_5min();
+        let peer: IpAddr = "127.0.0.7".parse().unwrap();
+        let now = phys_now_ms();
+        let high_seq = WINDOW_SIZE + 100;
+        assert!(filter.check_and_record(peer, high_seq, now));
+        // Lower seq outside the window with the SAME stamp: not a restart, must be rejected.
+        assert!(
+            !filter.check_and_record(peer, 1, now),
+            "seq regression outside the window with same stamp must be rejected as replay"
+        );
+    }
+
+    #[test]
+    fn evict_clears_state_and_allows_fresh_start() {
+        let filter = filter_5min();
+        let peer: IpAddr = "127.0.0.8".parse().unwrap();
+        let now = phys_now_ms();
+        assert!(filter.check_and_record(peer, 10, now));
+        // After eviction the peer state is gone; any new datagram is accepted.
+        filter.evict(peer);
+        assert!(filter.check_and_record(peer, 1, now));
+    }
+
+    /// Test 3 (updated): staleness purge uses sender `stamp_at_max`, not receiver clock.
+    ///
+    /// A peer is purged once `now - stamp_at_max > window`, regardless of when the receiver
+    /// last saw activity. This test injects time via `check_and_record_at`.
+    #[test]
+    fn staleness_purge_removes_silent_peer_and_accepts_fresh_start() {
+        // A peer whose stamp_at_max is older than the freshness window is purged;
+        // a fresh datagram from it afterwards is accepted as first contact.
+        let filter = filter_5min();
+        let peer: IpAddr = "127.0.0.20".parse().unwrap();
+        let window_ms = FRESHNESS_WINDOW_DEFAULT.as_millis() as u64;
+
+        // Use a fixed "now" well into the future so we can control relative ages.
+        // Base receiver time: t0. Sender stamp: also t0.
+        let t0: u64 = 1_700_000_000_000; // arbitrary fixed ms epoch
+
+        // Record one datagram: stamp = t0, receiver now = t0.
+        assert!(check_at(&filter, peer, 1, t0, t0));
+
+        // Advance simulated receiver clock past stamp_at_max + window: now = t0 + window + 1.
+        // The stamp (t0) is now older than the window relative to the new `now`.
+        let now_after_purge = t0 + window_ms + 1;
+
+        // Deliver a fresh datagram from a DIFFERENT peer to trigger the opportunistic purge.
+        // The other peer uses stamp = now_after_purge (fresh relative to that now).
+        let other: IpAddr = "127.0.0.21".parse().unwrap();
+        assert!(check_at(
+            &filter,
+            other,
+            1,
+            now_after_purge,
+            now_after_purge
+        ));
+
+        // The original peer must have been purged (stamp_at_max = t0, now - t0 > window).
+        assert!(
+            !filter.peers.lock().contains_key(&peer),
+            "stale peer entry should have been purged"
+        );
+
+        // A fresh datagram from the original peer is now accepted as first contact.
+        assert!(
+            check_at(&filter, peer, 1, now_after_purge, now_after_purge),
+            "first-contact datagram after purge must be accepted"
+        );
+    }
+
+    #[test]
+    fn restart_with_small_seq_regression_is_accepted() {
+        // Accept seqs 1..=5, then a regression to seq 1 with a strictly newer stamp is ACCEPTED
+        // (restart reset), and an immediate replay of an old captured (seq, stamp) pair is rejected.
+        let filter = filter_5min();
+        let peer: IpAddr = "127.0.0.22".parse().unwrap();
+        let now = phys_now_ms();
+
+        // Accept seqs 1..=5 with stamp `now`.
+        for seq in 1u64..=5 {
+            assert!(
+                filter.check_and_record(peer, seq, now),
+                "seq {seq} should be accepted"
+            );
+        }
+
+        // Restart: seq resets to 1 with a strictly newer stamp. This is INSIDE the window
+        // (behind = 4, which is < WINDOW_SIZE = 1024), so the old code would check the bitmap
+        // and reject it as a duplicate. The new code checks stamp FIRST.
+        let newer = now + 1000;
+        assert!(
+            filter.check_and_record(peer, 1, newer),
+            "seq regression inside the window with strictly newer stamp must be accepted as restart"
+        );
+
+        // After reset: max_seq=1, stamp_at_max=newer. seq=2 with newer stamp is accepted.
+        assert!(filter.check_and_record(peer, 2, newer));
+
+        // A replay of the old (seq=1, old stamp) pair must be rejected — stamp is not strictly
+        // newer than stamp_at_max (now < newer), so restart check fails, then bitmap check:
+        // bit 0 is set (seq=1 was the reset), so rejected as duplicate.
+        assert!(
+            !filter.check_and_record(peer, 1, now),
+            "replay of old (seq=1, old stamp) after restart must be rejected"
+        );
+    }
+
+    /// Test 1: skew-positive purge — sender clock ahead of receiver by some skew S ≤ window.
+    ///
+    /// Plant a datagram whose stamp is ahead of receiver `now` (within window), then advance
+    /// simulated receiver time past `last-activity + window` but within `stamp_at_max + window`.
+    /// The entry must NOT be purged, and a replay of the captured (seq, stamp) must be REJECTED.
+    ///
+    /// This demonstrates that purging on `stamp_at_max` (not receiver clock) is correct: even
+    /// after the receiver's notion of "last activity" falls outside the window, an attacker cannot
+    /// trigger a purge-and-replay if the sender's stamp is still within the window.
+    #[test]
+    fn skew_positive_purge_does_not_evict_while_stamp_at_max_is_fresh() {
+        let filter = filter_5min();
+        let peer: IpAddr = "127.1.0.1".parse().unwrap();
+        let window_ms = FRESHNESS_WINDOW_DEFAULT.as_millis() as u64;
+
+        // Receiver time at acceptance.
+        let receiver_t0: u64 = 1_700_000_000_000;
+        // Sender clock is 2 minutes ahead of receiver (positive skew, within window).
+        let skew_ms: u64 = 2 * 60 * 1000;
+        let sender_stamp: u64 = receiver_t0 + skew_ms;
+
+        // Accept the datagram: stamp is ahead of receiver now but within window.
+        assert!(check_at(&filter, peer, 42, sender_stamp, receiver_t0));
+
+        // Advance receiver time past receiver_t0 + window (where last_activity_ms would have been
+        // purged under the old scheme), but still within stamp_at_max + window.
+        // Specifically: now = receiver_t0 + window + 1  (old scheme would purge here),
+        // but stamp_at_max = receiver_t0 + skew_ms, so now - stamp_at_max = window + 1 - skew_ms
+        // = window - skew_ms + 1 < window (since skew_ms > 0). Entry must NOT be purged.
+        let now_mid = receiver_t0 + window_ms + 1;
+
+        // Trigger opportunistic purge via a different peer (stamp = now_mid, fresh).
+        let other: IpAddr = "127.1.0.2".parse().unwrap();
+        assert!(check_at(&filter, other, 1, now_mid, now_mid));
+
+        // The original peer must still be present (stamp_at_max - now_mid = skew_ms - 1 < window).
+        assert!(
+            filter.peers.lock().contains_key(&peer),
+            "entry must NOT be purged while stamp_at_max is still within the freshness window"
+        );
+
+        // A replay of the captured (seq=42, sender_stamp) must be REJECTED despite the time
+        // advance — the bitmap still has the sequence marked.
+        assert!(
+            !check_at(&filter, peer, 42, sender_stamp, now_mid),
+            "replay of captured datagram must be rejected even when receiver clock has advanced"
+        );
+    }
+
+    /// Test 2: post-restart tail — captured pre-restart datagrams are rejected after a restart.
+    ///
+    /// Accept seqs 1..=8 (stamps T..T+2), then a restart-reset via seq 1 stamp T+5.
+    /// A replay of captured seq 8 (stamp ≤ T+2) is REJECTED (stamp < max_stamp_seen = T+5).
+    /// A genuine new seq 2 stamp T+5 (same ms as reset) is ACCEPTED.
+    #[test]
+    fn post_restart_tail_captured_pre_restart_datagrams_rejected() {
+        let filter = filter_5min();
+        let peer: IpAddr = "127.2.0.1".parse().unwrap();
+        let window_ms = FRESHNESS_WINDOW_DEFAULT.as_millis() as u64;
+
+        // Fixed base stamp; receiver now tracks the same base so all stamps are fresh.
+        let t: u64 = 1_700_000_000_000;
+        // All datagrams and receiver now within freshness window of each other.
+        let receiver_now = t + window_ms / 2; // midpoint; all stamps ≤ t+5 are fresh
+
+        // Accept seqs 1..=8 with stamps in T..T+2 (simulate slight stamp spread).
+        // Seqs 1..=6 at stamp T, seqs 7..=8 at stamp T+2.
+        for seq in 1u64..=6 {
+            assert!(
+                check_at(&filter, peer, seq, t, receiver_now),
+                "seq {seq} at stamp T should be accepted"
+            );
+        }
+        for seq in 7u64..=8 {
+            assert!(
+                check_at(&filter, peer, seq, t + 2, receiver_now),
+                "seq {seq} at stamp T+2 should be accepted"
+            );
+        }
+
+        // Restart: seq resets to 1 with stamp T+5 (strictly newer than stamp_at_max = T+2).
+        let restart_stamp = t + 5;
+        assert!(
+            check_at(&filter, peer, 1, restart_stamp, receiver_now),
+            "restart datagram (seq=1, stamp=T+5) must be accepted"
+        );
+        // After reset: max_seq=1, stamp_at_max=T+5, max_stamp_seen=T+5.
+
+        // Replay of captured pre-restart seq=8 with stamp T+2 (< max_stamp_seen = T+5):
+        // forward path (8 > max_seq=1), stamp < max_stamp_seen → REJECTED.
+        assert!(
+            !check_at(&filter, peer, 8, t + 2, receiver_now),
+            "captured pre-restart seq=8 (stamp T+2 < max_stamp_seen T+5) must be REJECTED"
+        );
+
+        // Genuine new datagram: seq=2, stamp=T+5 (same ms as reset stamp, >= max_stamp_seen).
+        // Forward path (2 > max_seq=1), stamp == max_stamp_seen → ACCEPTED.
+        assert!(
+            check_at(&filter, peer, 2, restart_stamp, receiver_now),
+            "genuine new seq=2 with stamp=T+5 (same ms as reset) must be ACCEPTED"
+        );
+    }
+}

--- a/src/replay.rs
+++ b/src/replay.rs
@@ -8,91 +8,41 @@
 
 //! Per-peer replay protection for the authenticated protocol modes.
 //!
-//! When a cluster key is configured (MAC or encrypted mode), every outgoing datagram carries a
-//! 16-byte **replay header** — a monotonically increasing `u64` sequence number followed by a
-//! `u64` sender wall-clock stamp (milliseconds since the Unix epoch, little-endian) — that is
-//! included in the authenticated portion of the datagram. The receiver maintains per-peer state
-//! to reject:
+//! When a cluster key is configured, every outgoing datagram carries a 16-byte **replay header**
+//! (`seq: u64` then `stamp: u64`, little-endian, milliseconds since epoch) inside the authenticated
+//! region, first before any protocol messages. The receiver keeps per-peer state to reject a
+//! sequence number already seen or older than the sliding-bitmap window, and a stamp that deviates
+//! from local physical time by more than [`FRESHNESS_WINDOW_DEFAULT`]. Unauthenticated mode carries
+//! no header and is exempt.
 //!
-//! - **Duplicate or stale datagrams**: a sequence number within the backward window that has
-//!   already been seen (sliding-bitmap check), or a sequence number older than the window.
-//! - **Stale freshness stamps**: a sender wall-clock stamp that deviates from the receiver's
-//!   physical clock by more than [`FRESHNESS_WINDOW_DEFAULT`] in either direction.
+//! # Replay state outlives membership
 //!
-//! Only datagrams that carry an authenticated replay header are checked. Unauthenticated mode
-//! (no cluster key) is explicitly exempt — and documented as unprotected.
+//! Decommissioning a peer drops it from `members`/`peers`, but its replay-filter entry is kept: a
+//! captured datagram replayed after decommission would otherwise pass MAC and freshness checks and
+//! re-add the peer to `members`, re-poisoning causal stability. The staleness purge
+//! (`now - stamp_at_max <= window`, opportunistic on every `check_and_record` via `HashMap::retain`)
+//! is sound because no datagram can carry a stamp greater than `stamp_at_max` without either being
+//! accepted (raising it) or triggering `reset`, so once the window has passed no replay can clear
+//! the freshness check regardless of sender skew.
 //!
-//! # Replay state lifetime and staleness purge
+//! # Sequence regression vs. restart
 //!
-//! Per-peer replay state **intentionally outlives membership**. Decommissioning a peer removes it
-//! from `members` and `peers` so it no longer gates tombstone garbage collection or receives gossip
-//! probes, but the replay filter entry is kept. This matters because an adversary who captured a
-//! datagram from the peer while it was active can replay it within the freshness window after
-//! decommission: the replayed datagram passes MAC verification and the freshness check, but hits
-//! the bitmap duplicate check and is rejected. Without this, decommission + replay would re-add
-//! the peer to `members`, re-poisoning causal-stability membership — which is exactly what this
-//! design exists to prevent.
+//! A sender's sequence counter resets to 1 on restart, so every `seq <= max_seq` is checked against
+//! the stamp first: `stamp > stamp_at_max` means a genuine restart (state resets, datagram
+//! accepted); otherwise the bitmap decides. **Residual**: a restart within the same millisecond as
+//! the pre-restart send produces `stamp == stamp_at_max`, fails the strict `>`, and is
+//! indistinguishable from a same-millisecond replay — dropped by design.
 //!
-//! **Staleness purge is sound**: the purge retains only entries where
-//! `now - stamp_at_max <= window`. Any replayable datagram from a peer has a stamp no greater than
-//! `stamp_at_max` (the bitmap path never raises it; a strictly newer stamp triggers `reset` instead
-//! of replay). Once `now - stamp_at_max > window`, the freshness check on any such stamp would fail
-//! even accounting for the maximum allowed sender clock skew, so no replay can pass. The entry is
-//! therefore safe to drop at that point. The purge runs opportunistically on every call to
-//! [`ReplayFilter::check_and_record`] via `HashMap::retain`, which is cheap for the small maps
-//! typical in a gossip cluster.
+//! # Post-restart tail guard
 //!
-//! # Sequence-number regression
-//!
-//! A sender's sequence counter is per-process lifetime, so a restart resets it to 1. The receiver
-//! distinguishes a restart from a replay with the freshness stamp. The rule applies on **any**
-//! sequence regression (`seq <= max_seq`):
-//!
-//! - The stamp is checked **first**: if `stamp > stamp_at_max`, the regression is treated as a
-//!   legitimate restart — per-peer state is reset and the datagram is accepted.
-//! - Otherwise, the bitmap check runs normally: if the sequence is within the out-of-order window
-//!   and has not been seen, it is accepted; otherwise it is rejected.
-//! - If the sequence is beyond the backward window and the stamp is not strictly newer, the
-//!   datagram is unconditionally rejected.
-//!
-//! **Residual**: a restart that happens within the same millisecond as the sender's last
-//! pre-restart send produces `stamp == stamp_at_max`, which does not satisfy `stamp > stamp_at_max`.
-//! Such a restart is indistinguishable from a replay within that millisecond and is dropped. This
-//! is a deliberate trade-off: the alternative (accepting same-stamp regressions) would allow
-//! replays within the same millisecond.
-//!
-//! # Post-restart tail guard (monotone max-stamp)
-//!
-//! After a genuine restart triggers `reset()` to a low `max_seq` with a cleared bitmap, captured
-//! pre-restart datagrams with high sequence numbers (but stamps still inside the freshness window)
-//! would otherwise be re-accepted on the forward path (`seq > max_seq`). To prevent this, each
-//! `PeerState` tracks `max_stamp_seen`: the maximum sender stamp ever accepted from this peer.
-//! `reset()` does **not** rewind `max_stamp_seen`. On the forward path (`seq > max_seq`), any
-//! datagram whose stamp is strictly less than `max_stamp_seen` is rejected.
-//!
-//! The monotonicity premise is enforced at the source: [`SenderCounter::next_stamp`] maintains an
-//! in-process floor (`AtomicU64`) so that each minted stamp is `max(wall_clock_now, floor)`.
-//! Stamps therefore never decrease within a process lifetime, and same-millisecond bursts share a
-//! stamp — hence the guard uses strict `<` (not `<=`) to accept those bursts correctly.
-//!
-//! **Residual**: a sender that *restarts* while its wall clock is still behind its pre-restart
-//! stamps (e.g. after an NTP backward step or VM resume that shrinks wall time) loses the
-//! in-memory floor on restart and re-mints stamps lower than the receiver's recorded
-//! `max_stamp_seen`. Such datagrams are treated as replays and silently dropped until the sender's
-//! clock advances past the old high-water mark — bounded by the size of the clock step. This is the
-//! same family of trade-off as the documented same-millisecond-restart residual.
-//!
-//! # Wire layout (authenticated portion only)
-//!
-//! ```text
-//! seq   (8 bytes, little-endian u64)
-//! stamp (8 bytes, little-endian u64, milliseconds since Unix epoch)
-//! <protocol messages ...>
-//! ```
-//!
-//! This 16-byte header is the **first thing inside** the authenticated or encrypted region, before
-//! any protocol messages. For MAC mode the tag still authenticates the whole payload including the
-//! header; for encryption mode the header is encrypted together with the messages.
+//! A reset clears `max_seq`, so a captured high-`seq` pre-restart datagram would otherwise re-enter
+//! on the forward path. `PeerState::max_stamp_seen` — never rewound by `reset()` — blocks any
+//! forward-path datagram with a strictly lower stamp. [`SenderCounter::next_stamp`] enforces the
+//! monotonicity this relies on via an in-process floor (`max(wall_clock_now, floor)`), which is why
+//! the guard uses strict `<`: same-millisecond bursts share a stamp and must still pass. **Residual**:
+//! a sender restarting with its wall clock behind its own pre-restart stamps (NTP step, VM resume)
+//! loses that floor and is treated as a replay until its clock catches up — bounded by the clock
+//! step, same trade-off family as the regression residual above.
 
 use std::collections::HashMap;
 use std::net::IpAddr;
@@ -111,12 +61,8 @@ pub(crate) const REPLAY_HEADER_LEN: usize = 16;
 /// time by more than this value in either direction are rejected.
 pub const FRESHNESS_WINDOW_DEFAULT: Duration = Duration::from_secs(5 * 60); // 5 minutes
 
-/// Number of bits in the out-of-order acceptance bitmap.
-///
-/// A bitmap of 1024 entries allows sequence numbers up to 1024 behind the highest accepted to be
-/// accepted as out-of-order legitimate UDP reordering. Each bit represents whether the
-/// corresponding sequence number (relative to `max_seq`) was received. Anything older than 1024
-/// behind `max_seq` is unconditionally rejected as outside the window.
+/// Size of the out-of-order acceptance bitmap: a `seq` up to this far behind `max_seq` is accepted
+/// as legitimate UDP reordering (one bit per relative sequence number); older is rejected.
 const WINDOW_SIZE: u64 = 1024;
 
 /// The per-peer replay state.
@@ -270,22 +216,11 @@ fn phys_now_ms() -> u64 {
     Utc::now().timestamp_millis().max(0) as u64
 }
 
-/// Sender-side replay state: a monotonically increasing sequence counter and stamp floor.
-///
-/// One instance per node, incremented for every datagram sent in an authenticated mode.
-/// The sequence counter starts at 1; 0 is reserved as "no sequence" (unauthenticated mode).
-///
-/// The stamp floor (`stamp_floor`) guarantees that minted sender stamps never decrease within a
-/// process lifetime. Each call to [`next_stamp`](Self::next_stamp) returns
-/// `max(Utc::now().timestamp_millis(), previous_stamp)`. Concurrent senders sharing a
-/// millisecond will emit equal stamps; the receiver's forward-path guard uses strict `<` precisely
-/// to tolerate same-millisecond bursts.
-///
-/// **Residual**: a sender that *restarts* while its wall clock is still behind its pre-restart
-/// stamps (e.g. after an NTP correction or VM resume that shrinks wall time) re-mints lower stamps
-/// because the in-memory floor is lost on restart. The receiver treats the regressed stamps as a
-/// replayer until the sender's clock catches back up — bounded by the clock-step size. This is the
-/// same family of trade-off as the documented same-millisecond-restart residual.
+/// Sender-side replay state: one per node, incremented for every authenticated-mode datagram.
+/// `seq` starts at 1 (0 means unauthenticated). `stamp_floor` makes minted stamps monotonic within
+/// the process lifetime — [`next_stamp`](Self::next_stamp) returns
+/// `max(Utc::now().timestamp_millis(), previous_stamp)` — which is the guarantee the receiver's
+/// tail guard relies on (module docs). The floor is lost on restart; see the residual there.
 pub(crate) struct SenderCounter {
     seq: AtomicU64,
     stamp_floor: AtomicU64,

--- a/src/replay.rs
+++ b/src/replay.rs
@@ -45,7 +45,9 @@
 //! step, same trade-off family as the regression residual above.
 
 use std::collections::HashMap;
+use std::fmt;
 use std::net::IpAddr;
+use std::ops::Sub;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
@@ -65,6 +67,103 @@ pub const FRESHNESS_WINDOW_DEFAULT: Duration = Duration::from_secs(5 * 60); // 5
 /// as legitimate UDP reordering (one bit per relative sequence number); older is rejected.
 const WINDOW_SIZE: u64 = 1024;
 
+/// A per-sender monotonic sequence number carried in the replay header.
+///
+/// This module is the sole owner of `seq`'s semantics — its wire encoding
+/// ([`to_le_bytes`](Seq::to_le_bytes)/[`from_le_bytes`](Seq::from_le_bytes)) and the ordering used
+/// to detect replays and restarts live here rather than being reconstructed from a bare `u64` at
+/// each call site (see `AGENTS.md`, "entities own their own validation").
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct Seq(u64);
+
+impl Seq {
+    /// The first sequence number a [`SenderCounter`] issues in authenticated mode.
+    pub(crate) const FIRST: Seq = Seq(1);
+    /// Sentinel carried on a [`crate::auth::Payload`] produced in unauthenticated mode, where no
+    /// replay header exists.
+    pub(crate) const NONE: Seq = Seq(0);
+
+    #[allow(dead_code)] // used by cfg(test) unit tests and the `internal-testing` feature seam
+    pub(crate) const fn new(value: u64) -> Seq {
+        Seq(value)
+    }
+
+    pub(crate) fn to_le_bytes(self) -> [u8; 8] {
+        self.0.to_le_bytes()
+    }
+
+    pub(crate) fn from_le_bytes(bytes: [u8; 8]) -> Seq {
+        Seq(u64::from_le_bytes(bytes))
+    }
+}
+
+impl fmt::Display for Seq {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.0, f)
+    }
+}
+
+/// Number of sequence numbers between two `Seq`s. Only meaningful (and only used) where the
+/// caller already knows `self >= rhs`, mirroring the raw `u64` subtraction it replaces.
+impl Sub for Seq {
+    type Output = u64;
+
+    fn sub(self, rhs: Seq) -> u64 {
+        self.0 - rhs.0
+    }
+}
+
+/// A sender wall-clock stamp (milliseconds since the Unix epoch) carried in the replay header.
+///
+/// This module is the sole owner of `stamp`'s semantics: its wire encoding and the freshness
+/// check ([`is_fresh`](Stamp::is_fresh)) that decides whether a stamp is acceptable both live here,
+/// rather than [`ReplayFilter`] reaching into a bare `u64` to redo that arithmetic itself (see
+/// `AGENTS.md`, "entities own their own validation").
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct Stamp(u64);
+
+impl Stamp {
+    /// Sentinel carried on a [`crate::auth::Payload`] produced in unauthenticated mode, where no
+    /// replay header exists.
+    pub(crate) const NONE: Stamp = Stamp(0);
+
+    #[allow(dead_code)] // used by cfg(test) unit tests and the `internal-testing` feature seam
+    pub(crate) const fn new(value: u64) -> Stamp {
+        Stamp(value)
+    }
+
+    pub(crate) fn to_le_bytes(self) -> [u8; 8] {
+        self.0.to_le_bytes()
+    }
+
+    pub(crate) fn from_le_bytes(bytes: [u8; 8]) -> Stamp {
+        Stamp(u64::from_le_bytes(bytes))
+    }
+
+    /// Read local physical time as a `Stamp` (ms since the Unix epoch, clamped to non-negative).
+    fn now() -> Stamp {
+        Stamp(phys_now_ms())
+    }
+
+    /// Whether `self` deviates from `now` by no more than `window` in either direction — the
+    /// freshness check applied to every incoming replay header.
+    fn is_fresh(self, now: Stamp, window: Duration) -> bool {
+        let window_ms = window.as_millis() as u64;
+        self.age_relative_to(now) <= window_ms && now.age_relative_to(self) <= window_ms
+    }
+
+    /// How far behind `now` this stamp is, saturating at 0 if `self` is not older than `now`.
+    fn age_relative_to(self, now: Stamp) -> u64 {
+        now.0.saturating_sub(self.0)
+    }
+}
+
+impl fmt::Display for Stamp {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.0, f)
+    }
+}
+
 /// The per-peer replay state.
 ///
 /// Tracks the highest sequence number seen from a peer, the sender stamp at which that maximum was
@@ -72,15 +171,15 @@ const WINDOW_SIZE: u64 = 1024;
 /// mark of sender stamps (used for the post-restart tail guard).
 struct PeerState {
     /// Highest sequence number accepted from this peer.
-    max_seq: u64,
-    /// Sender wall-clock stamp (ms since epoch) that was present on the datagram carrying `max_seq`.
+    max_seq: Seq,
+    /// Sender wall-clock stamp that was present on the datagram carrying `max_seq`.
     /// Used for restart detection: if a new datagram has a higher stamp and a lower seq, the peer
     /// has restarted.
-    stamp_at_max: u64,
+    stamp_at_max: Stamp,
     /// Monotonically non-decreasing high-water mark of all sender stamps ever accepted from this
     /// peer. Never reset by `reset()`. Used on the forward path to reject captured pre-restart
     /// datagrams whose stamp predates the restart stamp.
-    max_stamp_seen: u64,
+    max_stamp_seen: Stamp,
     /// Sliding bitmap. Bit `i` represents whether sequence number `max_seq - i` was already
     /// accepted. `bitmap & 1` is always `1` (max_seq itself was accepted). Bits beyond
     /// `WINDOW_SIZE` are not tracked (always treated as seen/rejected if below window).
@@ -90,7 +189,7 @@ struct PeerState {
 }
 
 impl PeerState {
-    fn new(first_seq: u64, first_stamp: u64) -> Self {
+    fn new(first_seq: Seq, first_stamp: Stamp) -> Self {
         let mut bitmap = [0u64; (WINDOW_SIZE / 64) as usize];
         // Mark the first sequence as seen (bit 0 of word 0).
         bitmap[0] = 1;
@@ -103,7 +202,7 @@ impl PeerState {
     }
 
     /// Return the sender stamp at the highest accepted sequence number (used for staleness purge).
-    fn stamp_at_max(&self) -> u64 {
+    fn stamp_at_max(&self) -> Stamp {
         self.stamp_at_max
     }
 
@@ -112,7 +211,7 @@ impl PeerState {
     /// Returns `true` if the datagram is fresh (not a replay), `false` if it should be rejected.
     ///
     /// Side effect on success: updates the bitmap and `max_seq`/`stamp_at_max` as appropriate.
-    fn accept(&mut self, seq: u64, stamp: u64) -> bool {
+    fn accept(&mut self, seq: Seq, stamp: Stamp) -> bool {
         if seq > self.max_seq {
             // Forward path: new high-water sequence.
             // Post-restart tail guard: reject pre-restart captured datagrams. A genuinely
@@ -201,7 +300,7 @@ impl PeerState {
     ///
     /// `max_stamp_seen` is intentionally NOT reset — it is a monotone high-water mark that
     /// persists across restarts to guard against replays of captured pre-restart datagrams.
-    fn reset(&mut self, new_seq: u64, new_stamp: u64) {
+    fn reset(&mut self, new_seq: Seq, new_stamp: Stamp) {
         self.max_seq = new_seq;
         self.stamp_at_max = new_stamp;
         // max_stamp_seen is never rewound — keep the monotone high-water mark.
@@ -229,31 +328,31 @@ pub(crate) struct SenderCounter {
 impl SenderCounter {
     pub(crate) fn new() -> Self {
         SenderCounter {
-            seq: AtomicU64::new(1),
+            seq: AtomicU64::new(Seq::FIRST.0),
             stamp_floor: AtomicU64::new(0),
         }
     }
 
     /// Allocate the next sequence number (strictly increasing).
-    pub(crate) fn next_seq(&self) -> u64 {
-        self.seq.fetch_add(1, Ordering::Relaxed)
+    pub(crate) fn next_seq(&self) -> Seq {
+        Seq(self.seq.fetch_add(1, Ordering::Relaxed))
     }
 
-    /// Mint a monotonically non-decreasing sender stamp (milliseconds since Unix epoch).
+    /// Mint a monotonically non-decreasing sender stamp.
     ///
     /// Each call returns `max(Utc::now().timestamp_millis().max(0), floor)` and advances the
     /// internal floor so subsequent calls never return a smaller value.
-    pub(crate) fn next_stamp(&self) -> u64 {
+    pub(crate) fn next_stamp(&self) -> Stamp {
         self.next_stamp_at(phys_now_ms())
     }
 
     /// Inner implementation with an injectable `now_ms` for unit-testing backward clock steps.
-    pub(crate) fn next_stamp_at(&self, now_ms: u64) -> u64 {
+    pub(crate) fn next_stamp_at(&self, now_ms: u64) -> Stamp {
         // `fetch_max` atomically sets floor = max(floor, now_ms) and returns the OLD value.
         // The stamp we return is the maximum of the returned old floor and now_ms, which equals
         // the new floor value after the update.
         let prev = self.stamp_floor.fetch_max(now_ms, Ordering::Relaxed);
-        prev.max(now_ms)
+        Stamp(prev.max(now_ms))
     }
 }
 
@@ -281,18 +380,18 @@ impl ReplayFilter {
     /// Returns `true` when the datagram is fresh and unique — the caller may proceed to process it.
     /// Returns `false` when the datagram is a replay (duplicate, too old within the window, or
     /// outside the freshness window) — the caller should drop it silently.
-    pub(crate) fn check_and_record(&self, sender: IpAddr, seq: u64, stamp: u64) -> bool {
-        self.check_and_record_at(sender, seq, stamp, phys_now_ms())
+    pub(crate) fn check_and_record(&self, sender: IpAddr, seq: Seq, stamp: Stamp) -> bool {
+        self.check_and_record_at(sender, seq, stamp, Stamp::now())
     }
 
-    /// Inner implementation with an injectable `now_ms` (milliseconds since epoch).
+    /// Inner implementation with an injectable `now` (as a [`Stamp`]).
     ///
     /// Separating the clock source allows unit tests to exercise time-dependent logic
     /// (staleness purge, skew-positive scenarios) without sleeping.
-    fn check_and_record_at(&self, sender: IpAddr, seq: u64, stamp: u64, now: u64) -> bool {
-        // Freshness window check: reject stamps that are too far in the past or future.
-        let window_ms = self.freshness_window.as_millis() as u64;
-        if now.saturating_sub(stamp) > window_ms || stamp.saturating_sub(now) > window_ms {
+    fn check_and_record_at(&self, sender: IpAddr, seq: Seq, stamp: Stamp, now: Stamp) -> bool {
+        // Freshness window check: reject stamps that are too far in the past or future. `Stamp`
+        // owns this check, not the filter (see the `Stamp` doc comment).
+        if !stamp.is_fresh(now, self.freshness_window) {
             return false;
         }
 
@@ -301,7 +400,8 @@ impl ReplayFilter {
         // Opportunistic staleness purge: entries whose stamp_at_max is older than the freshness
         // window cannot produce any accepted datagrams (any replayable stamp ≤ stamp_at_max would
         // fail the freshness check above), so it is safe to drop them.
-        map.retain(|_, s| now.saturating_sub(s.stamp_at_max()) <= window_ms);
+        let window = self.freshness_window;
+        map.retain(|_, s| s.stamp_at_max().age_relative_to(now) <= window.as_millis() as u64);
 
         match map.get_mut(&sender) {
             None => {
@@ -332,9 +432,9 @@ mod tests {
     #[test]
     fn sender_counter_starts_at_1_and_increments() {
         let c = SenderCounter::new();
-        assert_eq!(c.next_seq(), 1);
-        assert_eq!(c.next_seq(), 2);
-        assert_eq!(c.next_seq(), 3);
+        assert_eq!(c.next_seq(), Seq::new(1));
+        assert_eq!(c.next_seq(), Seq::new(2));
+        assert_eq!(c.next_seq(), Seq::new(3));
     }
 
     /// The stamp mint must be monotonically non-decreasing even when the wall clock steps backward.
@@ -349,15 +449,19 @@ mod tests {
         let t2 = t1 + 50;
         let t3 = t2 + 50;
 
-        assert_eq!(c.next_stamp_at(t1), t1, "first stamp equals wall clock");
+        assert_eq!(
+            c.next_stamp_at(t1),
+            Stamp::new(t1),
+            "first stamp equals wall clock"
+        );
         assert_eq!(
             c.next_stamp_at(t2),
-            t2,
+            Stamp::new(t2),
             "second stamp equals advancing wall clock"
         );
         assert_eq!(
             c.next_stamp_at(t3),
-            t3,
+            Stamp::new(t3),
             "third stamp equals advancing wall clock"
         );
 
@@ -365,18 +469,19 @@ mod tests {
         let t_regressed = t3 - 500;
         let s_after_regression = c.next_stamp_at(t_regressed);
         assert_eq!(
-            s_after_regression, t3,
+            s_after_regression,
+            Stamp::new(t3),
             "stamp after backward step must equal the floor (t3), not the regressed wall clock"
         );
         assert!(
-            s_after_regression >= t3,
+            s_after_regression >= Stamp::new(t3),
             "stamp must not decrease after backward clock step"
         );
 
         // Verify the floor is sticky: a second regressed call still yields t3.
         assert_eq!(
             c.next_stamp_at(t_regressed),
-            t3,
+            Stamp::new(t3),
             "floor remains at t3 for further backward clock values"
         );
 
@@ -384,7 +489,7 @@ mod tests {
         let t_recovered = t3 + 1;
         assert_eq!(
             c.next_stamp_at(t_recovered),
-            t_recovered,
+            Stamp::new(t_recovered),
             "stamps advance normally once wall clock passes the floor"
         );
     }
@@ -393,55 +498,58 @@ mod tests {
 
     #[test]
     fn bitmap_shift_by_1() {
-        let mut state = PeerState::new(10, 1000);
+        let mut state = PeerState::new(Seq::new(10), Stamp::new(1000));
         // max_seq = 10, bit 0 set
-        assert!(!state.accept(10, 1000)); // already seen
-                                          // out of order: seq 9
-        assert!(state.accept(9, 999));
+        assert!(!state.accept(Seq::new(10), Stamp::new(1000))); // already seen
+                                                                // out of order: seq 9
+        assert!(state.accept(Seq::new(9), Stamp::new(999)));
         // seq 9 accepted, now bitmap has bit 0 (=10) and bit 1 (=9) set
-        assert!(!state.accept(9, 999)); // already seen
+        assert!(!state.accept(Seq::new(9), Stamp::new(999))); // already seen
     }
 
     #[test]
     fn bitmap_advance_and_reuse() {
-        let mut state = PeerState::new(10, 1000);
+        let mut state = PeerState::new(Seq::new(10), Stamp::new(1000));
         // advance max_seq to 20
-        assert!(state.accept(20, 1000));
+        assert!(state.accept(Seq::new(20), Stamp::new(1000)));
         // seq 10 was already accepted when state was created: must be rejected as duplicate
-        assert!(!state.accept(10, 1000));
+        assert!(!state.accept(Seq::new(10), Stamp::new(1000)));
         // seq 15 (mid-window, never seen before) must be accepted
-        assert!(state.accept(15, 1000));
+        assert!(state.accept(Seq::new(15), Stamp::new(1000)));
         // seq 15 again: rejected
-        assert!(!state.accept(15, 1000));
+        assert!(!state.accept(Seq::new(15), Stamp::new(1000)));
     }
 
     #[test]
     fn bitmap_outside_window_is_rejected() {
-        let mut state = PeerState::new(1024, 1000);
+        let mut state = PeerState::new(Seq::new(1024), Stamp::new(1000));
         // advance max to 2048; seq 1 is 2047 behind, outside window
-        assert!(state.accept(2048, 1000));
-        assert!(!state.accept(1, 1000));
+        assert!(state.accept(Seq::new(2048), Stamp::new(1000)));
+        assert!(!state.accept(Seq::new(1), Stamp::new(1000)));
     }
 
     #[test]
     fn bitmap_large_jump_clears_window() {
-        let mut state = PeerState::new(10, 1000);
+        let mut state = PeerState::new(Seq::new(10), Stamp::new(1000));
         // Jump so big the whole window rolls over
-        assert!(state.accept(10 + WINDOW_SIZE + 5, 1000));
+        assert!(state.accept(Seq::new(10 + WINDOW_SIZE + 5), Stamp::new(1000)));
         // seq 10 is now (WINDOW_SIZE + 5) behind, outside the window
-        assert!(!state.accept(10, 1000));
+        assert!(!state.accept(Seq::new(10), Stamp::new(1000)));
     }
 
     #[test]
     fn in_order_sequence_all_accepted_once() {
-        let mut state = PeerState::new(1, 1000);
+        let mut state = PeerState::new(Seq::new(1), Stamp::new(1000));
         for seq in 2..=100 {
-            assert!(state.accept(seq, 1000), "seq {seq} should be accepted");
+            assert!(
+                state.accept(Seq::new(seq), Stamp::new(1000)),
+                "seq {seq} should be accepted"
+            );
         }
         // All previously accepted seqs rejected on replay
         for seq in 1..=100 {
             assert!(
-                !state.accept(seq, 1000),
+                !state.accept(Seq::new(seq), Stamp::new(1000)),
                 "seq {seq} should be rejected as duplicate"
             );
         }
@@ -455,7 +563,7 @@ mod tests {
 
     /// Helper: call check_and_record_at with a caller-supplied `now`.
     fn check_at(filter: &ReplayFilter, peer: IpAddr, seq: u64, stamp: u64, now: u64) -> bool {
-        filter.check_and_record_at(peer, seq, stamp, now)
+        filter.check_and_record_at(peer, Seq::new(seq), Stamp::new(stamp), Stamp::new(now))
     }
 
     #[test]
@@ -463,7 +571,7 @@ mod tests {
         let filter = filter_5min();
         let peer: IpAddr = "127.0.0.1".parse().unwrap();
         let now = phys_now_ms();
-        assert!(filter.check_and_record(peer, 1, now));
+        assert!(filter.check_and_record(peer, Seq::new(1), Stamp::new(now)));
     }
 
     #[test]
@@ -471,8 +579,8 @@ mod tests {
         let filter = filter_5min();
         let peer: IpAddr = "127.0.0.2".parse().unwrap();
         let now = phys_now_ms();
-        assert!(filter.check_and_record(peer, 1, now));
-        assert!(!filter.check_and_record(peer, 1, now));
+        assert!(filter.check_and_record(peer, Seq::new(1), Stamp::new(now)));
+        assert!(!filter.check_and_record(peer, Seq::new(1), Stamp::new(now)));
     }
 
     #[test]
@@ -481,7 +589,7 @@ mod tests {
         let peer: IpAddr = "127.0.0.3".parse().unwrap();
         // Stamp 10 minutes in the past — beyond the 5-minute window.
         let old_stamp = phys_now_ms().saturating_sub(10 * 60 * 1000 + 1);
-        assert!(!filter.check_and_record(peer, 1, old_stamp));
+        assert!(!filter.check_and_record(peer, Seq::new(1), Stamp::new(old_stamp)));
     }
 
     #[test]
@@ -490,7 +598,7 @@ mod tests {
         let peer: IpAddr = "127.0.0.4".parse().unwrap();
         // Stamp 10 minutes in the future.
         let future_stamp = phys_now_ms() + 10 * 60 * 1000 + 1;
-        assert!(!filter.check_and_record(peer, 1, future_stamp));
+        assert!(!filter.check_and_record(peer, Seq::new(1), Stamp::new(future_stamp)));
     }
 
     #[test]
@@ -499,11 +607,11 @@ mod tests {
         let peer: IpAddr = "127.0.0.5".parse().unwrap();
         let now = phys_now_ms();
         // Accept seq 5 first, then 3 (out of order but within window).
-        assert!(filter.check_and_record(peer, 5, now));
-        assert!(filter.check_and_record(peer, 3, now));
+        assert!(filter.check_and_record(peer, Seq::new(5), Stamp::new(now)));
+        assert!(filter.check_and_record(peer, Seq::new(3), Stamp::new(now)));
         // Both must be rejected on replay.
-        assert!(!filter.check_and_record(peer, 5, now));
-        assert!(!filter.check_and_record(peer, 3, now));
+        assert!(!filter.check_and_record(peer, Seq::new(5), Stamp::new(now)));
+        assert!(!filter.check_and_record(peer, Seq::new(3), Stamp::new(now)));
     }
 
     #[test]
@@ -513,18 +621,18 @@ mod tests {
         let now = phys_now_ms();
         // Advance to a seq well beyond WINDOW_SIZE so a restart lands outside the bitmap.
         let high_seq = WINDOW_SIZE + 100;
-        assert!(filter.check_and_record(peer, high_seq, now));
+        assert!(filter.check_and_record(peer, Seq::new(high_seq), Stamp::new(now)));
         // Simulated restart: seq resets to 1 (outside the backward window) with a newer stamp.
         let newer = now + 1000;
         assert!(
-            filter.check_and_record(peer, 1, newer),
+            filter.check_and_record(peer, Seq::new(1), Stamp::new(newer)),
             "a seq regression outside the window with a strictly newer stamp must be accepted as a restart"
         );
         // After reset the new state has max_seq=1, stamp_at_max=newer.
         // A further seq=2 with the new stamp must be accepted normally.
-        assert!(filter.check_and_record(peer, 2, newer));
+        assert!(filter.check_and_record(peer, Seq::new(2), Stamp::new(newer)));
         // Replaying seq=1 with the new stamp is rejected (already seen after restart).
-        assert!(!filter.check_and_record(peer, 1, newer));
+        assert!(!filter.check_and_record(peer, Seq::new(1), Stamp::new(newer)));
     }
 
     #[test]
@@ -533,10 +641,10 @@ mod tests {
         let peer: IpAddr = "127.0.0.7".parse().unwrap();
         let now = phys_now_ms();
         let high_seq = WINDOW_SIZE + 100;
-        assert!(filter.check_and_record(peer, high_seq, now));
+        assert!(filter.check_and_record(peer, Seq::new(high_seq), Stamp::new(now)));
         // Lower seq outside the window with the SAME stamp: not a restart, must be rejected.
         assert!(
-            !filter.check_and_record(peer, 1, now),
+            !filter.check_and_record(peer, Seq::new(1), Stamp::new(now)),
             "seq regression outside the window with same stamp must be rejected as replay"
         );
     }
@@ -546,10 +654,10 @@ mod tests {
         let filter = filter_5min();
         let peer: IpAddr = "127.0.0.8".parse().unwrap();
         let now = phys_now_ms();
-        assert!(filter.check_and_record(peer, 10, now));
+        assert!(filter.check_and_record(peer, Seq::new(10), Stamp::new(now)));
         // After eviction the peer state is gone; any new datagram is accepted.
         filter.evict(peer);
-        assert!(filter.check_and_record(peer, 1, now));
+        assert!(filter.check_and_record(peer, Seq::new(1), Stamp::new(now)));
     }
 
     /// Test 3 (updated): staleness purge uses sender `stamp_at_max`, not receiver clock.
@@ -610,7 +718,7 @@ mod tests {
         // Accept seqs 1..=5 with stamp `now`.
         for seq in 1u64..=5 {
             assert!(
-                filter.check_and_record(peer, seq, now),
+                filter.check_and_record(peer, Seq::new(seq), Stamp::new(now)),
                 "seq {seq} should be accepted"
             );
         }
@@ -620,18 +728,18 @@ mod tests {
         // and reject it as a duplicate. The new code checks stamp FIRST.
         let newer = now + 1000;
         assert!(
-            filter.check_and_record(peer, 1, newer),
+            filter.check_and_record(peer, Seq::new(1), Stamp::new(newer)),
             "seq regression inside the window with strictly newer stamp must be accepted as restart"
         );
 
         // After reset: max_seq=1, stamp_at_max=newer. seq=2 with newer stamp is accepted.
-        assert!(filter.check_and_record(peer, 2, newer));
+        assert!(filter.check_and_record(peer, Seq::new(2), Stamp::new(newer)));
 
         // A replay of the old (seq=1, old stamp) pair must be rejected — stamp is not strictly
         // newer than stamp_at_max (now < newer), so restart check fails, then bitmap check:
         // bit 0 is set (seq=1 was the reset), so rejected as duplicate.
         assert!(
-            !filter.check_and_record(peer, 1, now),
+            !filter.check_and_record(peer, Seq::new(1), Stamp::new(now)),
             "replay of old (seq=1, old stamp) after restart must be rejected"
         );
     }

--- a/tests/service.rs
+++ b/tests/service.rs
@@ -879,3 +879,225 @@ async fn runtime_config_setters() {
     store.set_reconcile_interval(Duration::from_millis(200));
     store.set_tombstone_timeout(Duration::from_millis(500));
 }
+
+/// A datagram whose wall-clock stamp is far outside the freshness window must be silently dropped.
+///
+/// This test injects a legitimately-sealed datagram (correct key, correct MAC) whose stamp is set
+/// one hour in the past, well outside the default 5-minute freshness window.  The engine must
+/// reject it silently and keep running.
+///
+/// This test would FAIL against the pre-change code: old code had no replay filter and therefore no
+/// freshness check.  Any correctly-MAC-tagged datagram was accepted regardless of its timestamp,
+/// so an attacker who captured a datagram hours earlier could replay it indefinitely.  The
+/// `seal_datagram` helper also did not exist in the testing seam before this change.
+#[cfg(feature = "internal-testing")]
+#[tokio::test(flavor = "multi_thread")]
+async fn stale_datagram_outside_freshness_window_is_rejected() {
+    use reconcile::testing::seal_datagram;
+
+    let port = 8092;
+    let net = "127.0.0.1/8".parse().unwrap();
+    let addr_victim = "127.0.9.1".parse().unwrap();
+    let key = [0xBBu8; 32];
+
+    let cfg = Config::default()
+        .with_port(port)
+        .with_listen_addr(addr_victim)
+        .with_net(net)
+        .with_cluster_key(key);
+    // Default freshness window is 5 minutes; the injected stamp is 1 hour in the past.
+
+    let store = ReconcileStore::<i32, i32>::new(cfg)
+        .await
+        .expect("bind failed");
+    store.just_insert(0, 99);
+    let task = tokio::spawn(store.clone().run());
+
+    tokio::time::sleep(Duration::from_millis(20)).await;
+
+    let sender_sock = tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
+    let target = format!("{}:{}", addr_victim, port);
+
+    // A stamp from 1 hour ago — definitively outside the 5-minute freshness window.
+    let one_hour_ago_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .saturating_sub(Duration::from_secs(3600))
+        .as_millis() as u64;
+
+    // A minimal `Ack` message: bincode variant index 2, key=0 (i32), version token=0 (u64).
+    // If the freshness check were absent, this would reach the handler and do nothing (no tombstone
+    // for key=0 exists).  With the freshness check, it never reaches the handler at all.
+    let mut payload = Vec::new();
+    payload.extend_from_slice(&2u32.to_le_bytes()); // Ack variant index
+    payload.extend_from_slice(&0i32.to_le_bytes()); // key = 0
+    payload.extend_from_slice(&0u64.to_le_bytes()); // version token = 0
+
+    let stale_datagram = seal_datagram(key, 1, one_hour_ago_ms, &payload);
+    sender_sock.send_to(&stale_datagram, &target).await.unwrap();
+
+    // Give the engine time to (not) process.
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // The injected datagram must have been rejected silently: engine is still running.
+    assert!(
+        !task.is_finished(),
+        "engine must still be running after stale datagram"
+    );
+    // No state change: the value inserted before the test started is unchanged.
+    assert_eq!(store.get(&0).as_deref(), Some(&99));
+
+    task.abort();
+}
+
+/// Replaying the same sealed datagram (identical bytes, same seq) must be silently rejected after
+/// the first delivery.
+///
+/// This test crafts a valid authenticated datagram via the `internal-testing` seam, delivers it to
+/// an authenticated store, and then delivers the exact same bytes a second time.  Because the
+/// sequence number (seq=1) is already recorded in the per-peer replay filter, the second delivery
+/// is dropped silently and the engine continues running normally.
+///
+/// This test would FAIL against the pre-change code: old code had no replay header, no
+/// `SenderCounter`, and no `ReplayFilter`.  The `Authenticator::seal` function did not accept
+/// `seq` or `stamp` parameters, and `seal_datagram` did not exist in the testing seam.
+#[cfg(feature = "internal-testing")]
+#[tokio::test(flavor = "multi_thread")]
+async fn replayed_sealed_datagram_is_rejected() {
+    use reconcile::testing::seal_datagram;
+
+    let port = 8093;
+    let net = "127.0.0.1/8".parse().unwrap();
+    let addr_victim = "127.0.10.1".parse().unwrap();
+    let key = [0xDDu8; 32];
+
+    let cfg = Config::default()
+        .with_port(port)
+        .with_listen_addr(addr_victim)
+        .with_net(net)
+        .with_cluster_key(key);
+
+    let store = ReconcileStore::<i32, i32>::new(cfg)
+        .await
+        .expect("bind failed");
+    let task = tokio::spawn(store.clone().run());
+
+    // Give the run loop time to start before injecting traffic.
+    tokio::time::sleep(Duration::from_millis(20)).await;
+
+    let sender_sock = tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
+    let target = format!("{}:{}", addr_victim, port);
+    let now_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as u64;
+
+    // A minimal `Ack` message: bincode variant index 2, key=0 (i32), version token=0 (u64).
+    let mut payload = Vec::new();
+    payload.extend_from_slice(&2u32.to_le_bytes()); // Ack variant index
+    payload.extend_from_slice(&0i32.to_le_bytes()); // key = 0
+    payload.extend_from_slice(&0u64.to_le_bytes()); // version token = 0
+
+    // Seal once with seq=1 and a fresh stamp.
+    let datagram = seal_datagram(key, 1, now_ms, &payload);
+
+    // First delivery: seq=1 is new for this sender — passes the replay filter.
+    sender_sock.send_to(&datagram, &target).await.unwrap();
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    // Second delivery: identical bytes, seq=1 already recorded — must be dropped by the replay
+    // filter without reaching the message handler.
+    sender_sock.send_to(&datagram, &target).await.unwrap();
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    // The engine must still be alive: replay rejection is silent, not a crash.
+    assert!(
+        !task.is_finished(),
+        "engine must still be running after replay"
+    );
+
+    task.abort();
+}
+
+/// A decommissioned peer's captured datagram, replayed while still fresh, must be rejected
+/// and must not re-add the peer to membership.
+///
+/// Attack scenario: an adversary captures a valid datagram from peer X while X is active,
+/// waits for X to be decommissioned, and then replays the datagram within the freshness
+/// window. Without replay state surviving decommission, the filter treats the replay as
+/// first contact and re-adds X to `members`, re-poisoning causal-stability membership.
+///
+/// This test must FAIL against the pre-fix code (commit 4391c82): `decommission_peer` called
+/// `replay_filter.evict(peer)`, erasing per-peer state, so the replayed datagram was accepted
+/// as first contact.
+#[cfg(feature = "internal-testing")]
+#[tokio::test(flavor = "multi_thread")]
+async fn decommissioned_peer_replay_is_rejected() {
+    use reconcile::testing::{members_snapshot, seal_datagram};
+
+    let port = 8094;
+    let net = "127.0.0.1/8".parse().unwrap();
+    let addr_victim: std::net::IpAddr = "127.0.11.1".parse().unwrap();
+    let addr_sender: std::net::IpAddr = "127.0.11.2".parse().unwrap();
+    let key = [0xEEu8; 32];
+
+    let cfg = Config::default()
+        .with_port(port)
+        .with_listen_addr(addr_victim)
+        .with_net(net)
+        .with_cluster_key(key);
+
+    let store = ReconcileStore::<i32, i32>::new(cfg)
+        .await
+        .expect("bind failed");
+    let task = tokio::spawn(store.clone().run());
+
+    tokio::time::sleep(Duration::from_millis(20)).await;
+
+    let sender_sock = tokio::net::UdpSocket::bind(std::net::SocketAddr::new(addr_sender, 0))
+        .await
+        .unwrap();
+    let target = format!("{}:{}", addr_victim, port);
+    let now_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as u64;
+
+    // A minimal `Ack` message (variant 2): causes `spoke_dated = true` so the sender is
+    // added to `members` on acceptance.
+    let mut payload = Vec::new();
+    payload.extend_from_slice(&2u32.to_le_bytes()); // Ack variant index
+    payload.extend_from_slice(&0i32.to_le_bytes()); // key = 0
+    payload.extend_from_slice(&0u64.to_le_bytes()); // version token = 0
+
+    // Seal the datagram — this is the "captured" datagram the adversary holds.
+    let captured = seal_datagram(key, 1, now_ms, &payload);
+
+    // First delivery: peer X joins members.
+    sender_sock.send_to(&captured, &target).await.unwrap();
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    assert!(
+        members_snapshot(&store).contains(&addr_sender),
+        "sender must have joined members after first delivery"
+    );
+
+    // Decommission peer X: removes it from members/tombstone_acks but must NOT erase replay state.
+    store.forget_peer(addr_sender);
+    assert!(
+        !members_snapshot(&store).contains(&addr_sender),
+        "sender must be gone from members after decommission"
+    );
+
+    // Replay the SAME still-fresh captured datagram.
+    sender_sock.send_to(&captured, &target).await.unwrap();
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    // The replay must be rejected: X must NOT be re-added to members.
+    assert!(
+        !members_snapshot(&store).contains(&addr_sender),
+        "decommissioned peer must not be re-added to members by a replayed datagram"
+    );
+
+    assert!(!task.is_finished(), "engine must still be running");
+    task.abort();
+}


### PR DESCRIPTION
The headline still claimed no open correctness hazard; the 2026-06
adversarial audit disproved that, and the Phase-0 fixes for its
correctness findings now sit on this branch. F13/F14 were resolved but
still marked open, the manifest line said 0.0.0-git against a 0.2.1
Cargo.toml, the maturity checklist demanded a miri job for unsafe
iterators that no longer exist, and the F18/F19 rows ignored that the
bincode decode limit already landed. SOTA's miri note carried the same
stale unsafe-iterators claim.

https://claude.ai/code/session_01BaajsC6gEk1v7Y55dA5cPG